### PR TITLE
Added ucum resolution to package.json to fix CQL Execution IE bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "testcafe": "0.17.1"
   },
   "resolutions": {
-    "moment": "2.22.0"
+    "moment": "2.22.0",
+    "ucum": "cmoesel/ucum.js#es5-friendly"
   },
   "scripts": {
     "build-css": "node-sass-chokidar src/ -o src/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7515,9 +7515,9 @@ ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
-ucum@0.0.7:
+ucum@0.0.7, ucum@cmoesel/ucum.js#es5-friendly:
   version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ucum/-/ucum-0.0.7.tgz#cd07efe5599a17ef7fb327778bf838e832dfd1a4"
+  resolved "https://codeload.github.com/cmoesel/ucum.js/tar.gz/40f10d8f7913a49b5f4cf73588251db25c562d40"
 
 uglify-js@1.2.6:
   version "1.2.6"


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Chris Moesel's [forked repo](https://github.com/cmoesel/ucum.js/tree/es5-friendly) fixes the ucum issues on IE11.  He has a [pull request](https://github.com/Ventrom/ucum.js/pull/5) up hoping to get the fix published on NPM.  For now, we will add a resolution to `package.json` to pull from Chris' repo.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

-  4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
-  Code is commented

**Tests**

-  Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
