### PR TITLE
Updated note saving to save on editor change

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -223,6 +223,10 @@ export class FullApp extends Component {
         });
     }
 
+    setDocumentTextWithCallback = (documentText, callback) => {
+        this.setFullAppStateWithCallback({ documentText }, callback);
+    }
+
     openReferencedNote = (item, arrayIndex = -1) => {
         if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2])) {
             this.setState({
@@ -307,6 +311,7 @@ export class FullApp extends Component {
                             possibleClinicalEvents={this.possibleClinicalEvents}
                             searchSelectedItem={this.state.searchSelectedItem}
                             setDocumentText={this.setDocumentText}
+                            setDocumentTextWithCallback={this.setDocumentTextWithCallback}
                             setNoteClosed={this.setNoteClosed}
                             setNoteViewerEditable={this.setNoteViewerEditable}
                             setNoteViewerVisible={this.setNoteViewerVisible}

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -195,6 +195,7 @@ export default class ClinicianDashboard extends Component {
                         patient={this.props.appState.patient}
                         searchSelectedItem={this.props.searchSelectedItem}
                         setDocumentText={this.props.setDocumentText}
+                        setDocumentTextWithCallback={this.props.setDocumentTextWithCallback}
                         setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                         setLayout={this.props.setLayout}
                         setNoteClosed={this.props.setNoteClosed}
@@ -227,6 +228,7 @@ ClinicianDashboard.proptypes = {
     onContextUpdate: PropTypes.func.isRequired,
     possibleClinicalEvents: PropTypes.array.isRequired,
     searchSelectedItem: PropTypes.object,
+    setDocumentTextWithCallback: PropTypes.func.isRequired,
     setForceRefresh: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,
     setLayout: PropTypes.func.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -405,10 +405,13 @@ class FluxNotesEditor extends React.Component {
         };
         const docText = this.structuredFieldPlugin.convertToText(state, entireNote);
 
-        this.props.setFullAppState('documentText', docText);
+        this.props.setFullAppStateWithCallback({
+            documentText: docText,
+        }, () => {
+            // save note after documentText gets set
+            this.props.saveNoteUponKeypress();
+        });
 
-        // save
-        this.props.saveNoteUponKeypress();
         this.setState({
             state: state
         });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -183,8 +183,6 @@ class FluxNotesEditor extends React.Component {
             isPortalOpen: false,
             portalOptions: null,
         };
-
-        // this.props.setFullAppState('isNoteViewerEditable', true);
     }
 
     // Reset editor state and clear context
@@ -403,18 +401,14 @@ class FluxNotesEditor extends React.Component {
             endKey: endOfNoteKey,
             endOffset: endOfNoteOffset
         };
-        const docText = this.structuredFieldPlugin.convertToText(state, entireNote);
+        const documentText = this.structuredFieldPlugin.convertToText(state, entireNote);
 
-        this.props.setFullAppStateWithCallback({
-            documentText: docText,
-        }, () => {
+        this.props.setDocumentTextWithCallback(documentText, () => {
             // save note after documentText gets set
             this.props.saveNoteOnChange();
         });
 
-        this.setState({
-            state: state
-        });
+        this.setState({ state });
     }
 
     onFocus = () => {
@@ -1228,6 +1222,7 @@ FluxNotesEditor.proptypes = {
     patient: PropTypes.object.isRequired,
     saveNoteOnChange: PropTypes.func.isRequired,
     selectedNote: PropTypes.object,
+    setDocumentTextWithCallback: PropTypes.func,
     setFullAppState: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,
     setLayout: PropTypes.func.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -409,7 +409,7 @@ class FluxNotesEditor extends React.Component {
             documentText: docText,
         }, () => {
             // save note after documentText gets set
-            this.props.saveNoteUponKeypress();
+            this.props.saveNoteOnChange();
         });
 
         this.setState({
@@ -1226,7 +1226,7 @@ FluxNotesEditor.proptypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     noteAssistantMode: PropTypes.string.isRequired,
     patient: PropTypes.object.isRequired,
-    saveNoteUponKeypress: PropTypes.func.isRequired,
+    saveNoteOnChange: PropTypes.func.isRequired,
     selectedNote: PropTypes.object,
     setFullAppState: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -397,17 +397,15 @@ class FluxNotesEditor extends React.Component {
         // 'copy' the text every time into the note
         // Need to artificially set selection to the whole document
         // state.selection only has a getter for these values so create a new object
-        let entireNote = {
+        const entireNote = {
             startKey: "0",
             startOffset: 0,
             endKey: endOfNoteKey,
             endOffset: endOfNoteOffset
         };
-        let docText = this.structuredFieldPlugin.convertToText(state, entireNote); 
-        
-        this.props.setFullAppStateWithCallback(function(prevState, props){
-            return {documentText: docText};
-        });
+        const docText = this.structuredFieldPlugin.convertToText(state, entireNote);
+
+        this.props.setFullAppState('documentText', docText);
 
         // save
         this.props.saveNoteUponKeypress();

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -386,10 +386,10 @@ class FluxNotesEditor extends React.Component {
         let endOfNoteKey = state.toJSON().document.nodes[indexOfLastNode].key;
         let endOfNoteOffset = 0;
         // If the editor has no structured phrases, use the number of characters in the first 'node'
-        if(Lang.isEqual(indexOfLastNode, 0) && !Lang.isUndefined(state.toJSON().document.nodes["0"].nodes["0"].characters)){
+        if (Lang.isEqual(indexOfLastNode, 0) && !Lang.isUndefined(state.toJSON().document.nodes["0"].nodes["0"].characters)) {
             endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
-        } else{
-            if(!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)){
+        } else {
+            if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)) {
                 endOfNoteOffset = this.props.documentText.length;
             }
         }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -196,12 +196,8 @@ export default class NoteAssistant extends Component {
     // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
         // Don't start saving until there is content in the editor
-        if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)) {
-            if (Lang.isEqual(this.props.currentlyEditingEntryId, -1)) {
-                this.saveEditorContentsToNewNote();
-            } else {
-                this.updateExistingNote();
-            }
+        if (this.props.currentlyEditingEntryId !== -1) {
+            this.updateExistingNote();
         }
     }
 

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -195,7 +195,7 @@ export default class NoteAssistant extends Component {
 
     // save the note after every keypress. Invoked by FluxNotesEditor.
     saveNoteOnKeypress = () => {
-        // Don't start saving until there is content in the editor
+        // Only save if note is currently open
         if (this.props.currentlyEditingEntryId !== -1) {
             this.updateExistingNote();
         }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -56,7 +56,7 @@ export default class NoteAssistant extends Component {
 
     componentDidMount() {
         // set callback so the editor can signal a change and this class can save the note
-        this.props.saveNote(this.saveNoteOnKeypress);
+        this.props.saveNote(this.saveNoteOnChange);
         this.props.closeNote(this.closeNote);
     }
 
@@ -148,25 +148,6 @@ export default class NoteAssistant extends Component {
         }
     }
 
-    saveEditorContentsToNewNote = () => {
-        // Create info to be set for new note
-        let date = new moment().format("D MMM YYYY");
-        let subject = "New Note";
-        let hospital = "Dana Farber";
-        let clinician = this.props.loginUser;
-        let signed = false;
-
-        // Add new unsigned note to patient record
-        var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, this.props.documentText, signed);
-        this.props.updateCurrentlyEditingEntryId(currentlyEditingEntryId);
-
-        var found = this.props.patient.getNotes().find(function (element) {
-            return Lang.isEqual(element.entryInfo.entryId, currentlyEditingEntryId);
-        });
-
-        this.props.updateSelectedNote(found);
-    }
-
     // creates blank new note and puts it on the screen
     createBlankNewNote = () => {
         this.props.setNoteClosed(false);
@@ -193,8 +174,8 @@ export default class NoteAssistant extends Component {
         this.toggleView("context-tray");
     }
 
-    // save the note after every keypress. Invoked by FluxNotesEditor.
-    saveNoteOnKeypress = () => {
+    // save the note after every editor change. Invoked by FluxNotesEditor.
+    saveNoteOnChange = () => {
         // Only save if note is currently open
         if (this.props.currentlyEditingEntryId !== -1) {
             this.updateExistingNote();
@@ -312,7 +293,7 @@ export default class NoteAssistant extends Component {
                                 newCurrentShortcut={this.props.newCurrentShortcut}
                                 noteAssistantMode={this.props.noteAssistantMode}
                                 patient={this.props.patient}
-                                saveNoteUponKeypress={this.props.saveNoteUponKeypress}
+                                saveNoteOnChange={this.props.saveNoteOnChange}
                                 selectedNote={this.props.selectedNote}
                                 setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                                 setNoteViewerEditable={this.props.setNoteViewerEditable}
@@ -614,7 +595,7 @@ NoteAssistant.propTypes = {
     noteClosed: PropTypes.bool.isRequired,
     patient: PropTypes.object.isRequired,
     saveNote: PropTypes.func.isRequired,
-    saveNoteUponKeypress: PropTypes.func.isRequired,
+    saveNoteOnChange: PropTypes.func.isRequired,
     searchSelectedItem: PropTypes.object,
     selectedNote: PropTypes.object,
     setFullAppStateWithCallback: PropTypes.func.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -253,6 +253,7 @@ export default class NotesPanel extends Component {
                     patient={this.props.patient}
                     saveNoteOnChange={this.saveNoteOnChange}
                     selectedNote={this.state.selectedNote}
+                    setDocumentTextWithCallback={this.props.setDocumentTextWithCallback}
                     setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
                     setLayout={this.setLayout}
@@ -347,6 +348,7 @@ NotesPanel.propTypes = {
     patient: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
     setDocumentText: PropTypes.func.isRequired,
+    setDocumentTextWithCallback: PropTypes.func.isRequired,
     setNoteClosed: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -27,11 +27,11 @@ export default class NotesPanel extends Component {
     }
 
     componentWillReceiveProps = (nextProps) => {
-        if (Lang.isNull(nextProps.openClinicalNote) && !Lang.isNull(this.props.openClinicalNote) && !this.props.openClinicalNote.signed && nextProps.documentText !== this.props.documentText) {
-            this.props.openClinicalNote.content = nextProps.documentText;
-        }
-
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
+            if (this.props.openClinicalNote !== null && this.props.openClinicalNote.signed === false) {
+                this.props.openClinicalNote.content = this.props.documentText;
+            }
+            
             const note = nextProps.openClinicalNote;
             this.handleUpdateEditorWithNote(note);
         }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -27,6 +27,7 @@ export default class NotesPanel extends Component {
     }
 
     componentWillReceiveProps = (nextProps) => {
+        // Logic to handle switching notes
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
             this.handleUpdateEditorWithNote(nextProps.openClinicalNote);
         }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -28,12 +28,7 @@ export default class NotesPanel extends Component {
 
     componentWillReceiveProps = (nextProps) => {
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
-            if (this.props.openClinicalNote !== null && this.props.openClinicalNote.signed === false) {
-                this.props.openClinicalNote.content = this.props.documentText;
-            }
-            
-            const note = nextProps.openClinicalNote;
-            this.handleUpdateEditorWithNote(note);
+            this.handleUpdateEditorWithNote(nextProps.openClinicalNote);
         }
     }
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -113,8 +113,8 @@ export default class NotesPanel extends Component {
         this.setState({arrayOfPickLists: array})
     }
 
-    // Save the note after every keypress. This function invokes the note saving logic in NoteAssistant
-    saveNoteUponKeypress = () => {
+    // Save the note after every editor change. This function invokes the note saving logic in NoteAssistant
+    saveNoteOnChange = () => {
         this.saveNoteChild();
     }
 
@@ -251,7 +251,7 @@ export default class NotesPanel extends Component {
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     noteAssistantMode={this.state.noteAssistantMode}
                     patient={this.props.patient}
-                    saveNoteUponKeypress={this.saveNoteUponKeypress}
+                    saveNoteOnChange={this.saveNoteOnChange}
                     selectedNote={this.state.selectedNote}
                     setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
@@ -295,7 +295,7 @@ export default class NotesPanel extends Component {
                     noteClosed={this.props.noteClosed}
                     patient={this.props.patient}
                     saveNote={click => this.saveNoteChild = click}
-                    saveNoteUponKeypress={this.saveNoteUponKeypress}
+                    saveNoteOnChange={this.saveNoteOnChange}
                     searchSelectedItem={this.props.searchSelectedItem}
                     selectedNote={this.state.selectedNote}
                     setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -274,6 +274,7 @@ describe('FluxNotesEditor', function() {
             loginUser={''}
             noteClosed={false}
             setDocumentText={jest.fn()}
+            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA-1112.

- Added callback in notes editor to save note after documentText is set by FullApp.
- Any change to editor causes a note save.
- Added setDocumentTextWithCallback helper function in FullApp to help set documentText prop.
- Changed saveNoteUponKeypress -> saveNoteOnChange.
- Cleaned up and removed code that is no longer needed for note saving logic.


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
