### PR TITLE
Actions in narrative view

### DIFF
--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -1,6 +1,3 @@
-//import { ListItemIcon, ListItemText } from 'material-ui/List';
-//import Menu, { MenuItem } from 'material-ui/Menu';
-//import FontAwesome from 'react-fontawesome';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Lang from 'lodash';

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -5,6 +5,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Lang from 'lodash';
 import './NarrativeNameValuePairsVisualizer.css';
+import VisualizerMenu from './VisualizerMenu.jsx';
 
 /*
  A narrative view of one or more data summary items.
@@ -212,15 +213,17 @@ class NarrativeNameValuePairsVisualizer extends Component {
     // renders Menu for snippet and associated actions as Menu items
     // Will check whether an action should be rendered as a Menu item based on criteria of each action
     renderedMenu = (snippet, snippetId, snippetText, arrayIndex) => {
-        const {
-            snippetDisplayingMenu,
-            positionLeft,
-            positionTop,
-        } = this.state;
-        
+        // const {
+        //     snippetDisplayingMenu,
+        //     positionLeft,
+        //     positionTop,
+        // } = this.state;
+
         const onMenuItemClicked = (fn, element) => {
+            console.log("On Menu Item Clicked");
             const callback = () => {
                 // convert element to format action is expecting
+                console.log("On Menu Item Clicked Callback");
                 const transformedElement = {
                     shortcut: element.shortcut,
                     value: [
@@ -237,9 +240,22 @@ class NarrativeNameValuePairsVisualizer extends Component {
         let isSigned = true;
         const checkSnippetUnsigned = Lang.isUndefined(snippet.unsigned) ? isSigned : !snippet.unsigned;
         isSigned = Lang.isArray(snippet.value) ? !snippet.value[1] : checkSnippetUnsigned;
-     
-        return this.props.filterAndDisplayActions(this.props.actions, isSigned, arrayIndex, snippetId, snippet, snippetText, 
-                                                 this.closeInsertionMenu, onMenuItemClicked,  snippetDisplayingMenu, positionLeft, positionTop);
+    
+       return( 
+         <VisualizerMenu
+            allowItemClick={this.props.allowItemClick}
+            arrayIndex={arrayIndex}
+            closeInsertionMenu={this.closeInsertionMenu}
+            element={snippet}
+            elementDisplayingMenu={this.state.snippetDisplayingMenu}
+            elementId={snippetId}
+            elementText={snippetText}
+            isSigned={isSigned}
+            onMenuItemClicked={onMenuItemClicked}
+            positionLeft={this.state.positionLeft}
+            positionTop={this.state.positionTop}
+            unfilteredActions={this.props.actions}
+       /> );
     }
 
     // Opens the insertion menu for the given snippet id, based on cursor location
@@ -311,7 +327,6 @@ NarrativeNameValuePairsVisualizer.propTypes = {
     condition: PropTypes.object,
     conditionSection: PropTypes.object,
     isWide: PropTypes.bool,
-    filterAndDisplayActions: PropTypes.func.isRequired,
     allowItemClick: PropTypes.bool,
     actions: PropTypes.array
 };

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -1,6 +1,6 @@
-import { ListItemIcon, ListItemText } from 'material-ui/List';
-import Menu, { MenuItem } from 'material-ui/Menu';
-import FontAwesome from 'react-fontawesome';
+//import { ListItemIcon, ListItemText } from 'material-ui/List';
+//import Menu, { MenuItem } from 'material-ui/Menu';
+//import FontAwesome from 'react-fontawesome';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Lang from 'lodash';
@@ -211,12 +211,13 @@ class NarrativeNameValuePairsVisualizer extends Component {
 
     // renders Menu for snippet and associated actions as Menu items
     // Will check whether an action should be rendered as a Menu item based on criteria of each action
-    renderedMenu = (snippet, snippetId, snippetText) => {
+    renderedMenu = (snippet, snippetId, snippetText, arrayIndex) => {
         const {
             snippetDisplayingMenu,
             positionLeft,
             positionTop,
         } = this.state;
+        
         const onMenuItemClicked = (fn, element) => {
             const callback = () => {
                 // convert element to format action is expecting
@@ -232,48 +233,13 @@ class NarrativeNameValuePairsVisualizer extends Component {
             }
             this.closeInsertionMenu(callback);
         }
-
+        
         let isSigned = true;
         const checkSnippetUnsigned = Lang.isUndefined(snippet.unsigned) ? isSigned : !snippet.unsigned;
         isSigned = Lang.isArray(snippet.value) ? !snippet.value[1] : checkSnippetUnsigned;
-        // Filter actions by whenToDisplay property on action
-        const filteredActions = this.props.actions.filter((a) => {
-            if (a.whenToDisplay.valueExists && Lang.isNull(snippet)) return false;
-            if (a.whenToDisplay.existingValueSigned !== "either" && a.whenToDisplay.existingValueSigned !== isSigned) return false;
-            return a.whenToDisplay.editableNoteOpen === "either" || String(a.whenToDisplay.editableNoteOpen) === String(this.props.allowItemClick);
-        });
-        if (filteredActions.length === 0) return null;
-        return (
-            <Menu
-                open={snippetDisplayingMenu === snippetId}
-                anchorReference="anchorPosition"
-                anchorPosition={{ top: positionTop, left: positionLeft }}
-                onClose={(event) => this.closeInsertionMenu()}
-                className="narrative-inserter-tooltip"
-            >
-                {
-                    // map filterActions to MenuItems
-                    filteredActions.map((a, index) => {
-                        const icon = a.icon ? (
-                            <ListItemIcon>
-                                <FontAwesome name={a.icon} />
-                            </ListItemIcon>
-                        ) : null;
-                        const text = a.text.replace("{elementText}", snippetText);
-                        return (
-                            <MenuItem
-                                key={`${snippetId}-${index}`}
-                                onClick={() => onMenuItemClicked(a.handler, snippet)}
-                                className="narrative-inserter-box"
-                            >
-                                {icon}
-                                <ListItemText className='narrative-inserter-menu-item' inset primary={text} />
-                            </MenuItem>
-                        )
-                    })
-                }
-            </Menu>
-        );
+     
+        return this.props.filterAndDisplayActions(this.props.actions, isSigned, arrayIndex, snippetId, snippet, snippetText, 
+                                                 this.closeInsertionMenu, onMenuItemClicked,  snippetDisplayingMenu, positionLeft, positionTop);
     }
 
     // Opens the insertion menu for the given snippet id, based on cursor location
@@ -321,7 +287,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
                         >
                             {snippet.text}
                         </span>
-                        {this.renderedMenu(snippet.item, snippetId, snippet.text)}
+                        {this.renderedMenu(snippet.item, snippetId, snippet.text, index)}
                     </span>
                 );
             } else if (snippet.type !== 'plain') {
@@ -345,6 +311,7 @@ NarrativeNameValuePairsVisualizer.propTypes = {
     condition: PropTypes.object,
     conditionSection: PropTypes.object,
     isWide: PropTypes.bool,
+    filterAndDisplayActions: PropTypes.func.isRequired,
     allowItemClick: PropTypes.bool,
     actions: PropTypes.array
 };

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -213,17 +213,10 @@ class NarrativeNameValuePairsVisualizer extends Component {
     // renders Menu for snippet and associated actions as Menu items
     // Will check whether an action should be rendered as a Menu item based on criteria of each action
     renderedMenu = (snippet, snippetId, snippetText, arrayIndex) => {
-        // const {
-        //     snippetDisplayingMenu,
-        //     positionLeft,
-        //     positionTop,
-        // } = this.state;
 
         const onMenuItemClicked = (fn, element) => {
-            console.log("On Menu Item Clicked");
             const callback = () => {
                 // convert element to format action is expecting
-                console.log("On Menu Item Clicked Callback");
                 const transformedElement = {
                     shortcut: element.shortcut,
                     value: [

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -211,7 +211,6 @@ class NarrativeNameValuePairsVisualizer extends Component {
     }
 
     // renders Menu for snippet and associated actions as Menu items
-    // Will check whether an action should be rendered as a Menu item based on criteria of each action
     renderedMenu = (snippet, snippetId, snippetText, arrayIndex) => {
 
         const onMenuItemClicked = (fn, element) => {

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Lang from 'lodash';
 import { TableCell, TableRow } from 'material-ui/Table';
 import Tooltip from 'rc-tooltip';
-
 import TabularListVisualizerTable from './TabularListVisualizerTable';
 import './TabularListVisualizer.css';
 import VisualizerMenu from './VisualizerMenu.jsx';

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -230,7 +230,6 @@ export default class TabularListVisualizer extends Component {
     renderedPostTableList(itemsFunction, subsectionName, subsectionActions, arrayIndex) {
         const {patient, condition} = this.props;
         if (patient == null || condition == null || Lang.isUndefined(itemsFunction)) return [];
-
         const list = itemsFunction(patient, condition);
         return list.map((element, index) => {
             const elementId = `post-item-${index}`;
@@ -390,7 +389,6 @@ export default class TabularListVisualizer extends Component {
             this.closeInsertionMenu(callback);
         }
 
-        //console.log(this.props.actions.concat(subsectionActions));
         let isSigned = true;
         if (Lang.isArray(element.value)) isSigned = !element.value[1];
         return (

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -2,10 +2,7 @@ import React, { Component } from 'react';
 import { Row, Col } from 'react-flexbox-grid';
 import PropTypes from 'prop-types';
 import Lang from 'lodash';
-//import { ListItemIcon, ListItemText } from 'material-ui/List';
-//import Menu, { MenuItem } from 'material-ui/Menu';
 import { TableCell, TableRow } from 'material-ui/Table';
-//import FontAwesome from 'react-fontawesome';
 import Tooltip from 'rc-tooltip';
 
 import TabularListVisualizerTable from './TabularListVisualizerTable';

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -2,10 +2,10 @@ import React, { Component } from 'react';
 import { Row, Col } from 'react-flexbox-grid';
 import PropTypes from 'prop-types';
 import Lang from 'lodash';
-import { ListItemIcon, ListItemText } from 'material-ui/List';
-import Menu, { MenuItem } from 'material-ui/Menu';
+//import { ListItemIcon, ListItemText } from 'material-ui/List';
+//import Menu, { MenuItem } from 'material-ui/Menu';
 import { TableCell, TableRow } from 'material-ui/Table';
-import FontAwesome from 'react-fontawesome';
+//import FontAwesome from 'react-fontawesome';
 import Tooltip from 'rc-tooltip';
 
 import TabularListVisualizerTable from './TabularListVisualizerTable';
@@ -393,48 +393,8 @@ export default class TabularListVisualizer extends Component {
 
         let isSigned = true;
         if (Lang.isArray(element.value)) isSigned = !element.value[1];
-        
-        // Filter actions by whenToDisplay property on action
-        const filteredActions = subsectionActions.concat(this.props.actions).filter((a) => {
-            if (a.whenToDisplay.valueExists && Lang.isNull(element)) return false;
-            if (a.whenToDisplay.existingValueSigned !== "either" && a.whenToDisplay.existingValueSigned !== isSigned) return false;
-            if (a.whenToDisplay.displayInSubsections &&  !a.whenToDisplay.displayInSubsections.includes(subsectionName)) return false;
-            if (a.whenToDisplay.displayForColumns && !a.whenToDisplay.displayForColumns.includes(arrayIndex)) return false;
-            return a.whenToDisplay.editableNoteOpen === "either" || String(a.whenToDisplay.editableNoteOpen) === String(this.props.allowItemClick);
-        });
-
-        if (filteredActions.length === 0) return null;
-        return (
-            <Menu
-                open={elementToDisplayMenu === elementId}
-                anchorReference="anchorPosition"
-                anchorPosition={{ top: positionTop, left: positionLeft }}
-                onClose={(event) => this.closeInsertionMenu()}
-                className="narrative-inserter-tooltip"
-            >
-                {
-                    // map filteredActions to MenuItems
-                    filteredActions.map((a, index) => {
-                        const icon = a.icon ? (
-                            <ListItemIcon>
-                                <FontAwesome name={a.icon} />
-                            </ListItemIcon>
-                        ) : null;
-                        const text = a.text.replace("{elementText}", elementText);
-                        return (
-                            <MenuItem
-                                key={`${elementId}-${index}`}
-                                onClick={() => onMenuItemClicked(a.handler, element)}
-                                className="narrative-inserter-box"
-                            >
-                                {icon}
-                                <ListItemText className='narrative-inserter-menu-item' inset primary={text} />
-                            </MenuItem>
-                        )
-                    })
-                }
-            </Menu>
-        );
+        return this.props.filterAndDisplayActions((subsectionActions.concat(this.props.actions)), isSigned, arrayIndex, elementId,
+                                           element, elementText, this.closeInsertionMenu, onMenuItemClicked, elementToDisplayMenu, positionLeft, positionTop);
     }
 
     // Opens the insertion menu for the given element id, based on cursor location
@@ -466,6 +426,7 @@ TabularListVisualizer.propTypes = {
     patient: PropTypes.object,
     condition: PropTypes.object,
     conditionSection: PropTypes.object,
+    filterAndDisplayActions: PropTypes.func.isRequired,
     sectionTransform: PropTypes.func,
     isWide: PropTypes.bool,
     allowItemClick: PropTypes.bool,

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -376,7 +376,6 @@ export default class TabularListVisualizer extends Component {
     }
 
     // renders Menu for element and associated actions as Menu items
-    // Will check whether an action should be rendered as a Menu item based on criteria of each action
     renderedMenu = (element, elementId, elementText, subsectionName, subsectionActions, arrayIndex) => {
         const onMenuItemClicked = (fn, element) => {
             const callback = () => {

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -10,6 +10,7 @@ import Tooltip from 'rc-tooltip';
 
 import TabularListVisualizerTable from './TabularListVisualizerTable';
 import './TabularListVisualizer.css';
+import VisualizerMenu from './VisualizerMenu.jsx';
 
 /*
  A table view of one or more data summary items. Items could be pathology-related,
@@ -382,8 +383,6 @@ export default class TabularListVisualizer extends Component {
     // renders Menu for element and associated actions as Menu items
     // Will check whether an action should be rendered as a Menu item based on criteria of each action
     renderedMenu = (element, elementId, elementText, subsectionName, subsectionActions, arrayIndex) => {
-        const { elementToDisplayMenu, positionLeft, positionTop } = this.state;
-
         const onMenuItemClicked = (fn, element) => {
             const callback = () => {
                 fn(element);
@@ -391,10 +390,25 @@ export default class TabularListVisualizer extends Component {
             this.closeInsertionMenu(callback);
         }
 
+        //console.log(this.props.actions.concat(subsectionActions));
         let isSigned = true;
         if (Lang.isArray(element.value)) isSigned = !element.value[1];
-        return this.props.filterAndDisplayActions((subsectionActions.concat(this.props.actions)), isSigned, arrayIndex, elementId,
-                                           element, elementText, this.closeInsertionMenu, onMenuItemClicked, elementToDisplayMenu, positionLeft, positionTop);
+        return (
+            <VisualizerMenu
+                allowItemClick={this.props.allowItemClick}
+                arrayIndex={arrayIndex}
+                closeInsertionMenu={this.closeInsertionMenu}
+                element={element}
+                elementDisplayingMenu={this.state.elementToDisplayMenu}
+                elementId={elementId}
+                elementText={elementText}
+                isSigned={isSigned}
+                onMenuItemClicked={onMenuItemClicked}
+                positionLeft={this.state.positionLeft}
+                positionTop={this.state.positionTop}
+                subsectionName={subsectionName}
+                unfilteredActions={this.props.actions.concat(subsectionActions)}
+            />);
     }
 
     // Opens the insertion menu for the given element id, based on cursor location
@@ -426,7 +440,6 @@ TabularListVisualizer.propTypes = {
     patient: PropTypes.object,
     condition: PropTypes.object,
     conditionSection: PropTypes.object,
-    filterAndDisplayActions: PropTypes.func.isRequired,
     sectionTransform: PropTypes.func,
     isWide: PropTypes.bool,
     allowItemClick: PropTypes.bool,

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -1,14 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
+import Menu, { MenuItem } from 'material-ui/Menu';
 import Button from '../elements/Button';
 import './TargetedDataSection.css';
 import Lang from 'lodash';
+import FontAwesome from 'react-fontawesome';
+import { ListItemIcon, ListItemText } from 'material-ui/List';
 
 export default class TargetedDataSection extends Component {
     constructor(props) {
         super(props);
-
         const optionsForSection = this.getOptions(props.section);
         const defaultVisualizer = this.determineDefaultVisualizer(props.section, props.clinicalEvent, optionsForSection);
 
@@ -27,6 +28,50 @@ export default class TargetedDataSection extends Component {
             (this.state.chosenVisualizer !== null && !optionsForSection.includes(this.state.chosenVisualizer))) {
             this.setState({ defaultVisualizer, chosenVisualizer: null });
         }
+    }
+
+    filterAndDisplayActions = (unfilteredActions, isSigned, arrayIndex, subsectionName, element, elementText, closeInsertionMenu, onMenuItemClicked, elementDisplayingMenu, positionLeft, positionTop) => {
+        
+        const filteredActions = unfilteredActions.filter((a) => {
+            if (a.whenToDisplay.valueExists && Lang.isNull(element)) return false;
+            if (a.whenToDisplay.displayInSubsections &&  !a.whenToDisplay.displayInSubsections.includes(subsectionName)) return false;
+            if (a.whenToDisplay.displayForColumns && !a.whenToDisplay.displayForColumns.includes(arrayIndex)) return false;
+            if (a.whenToDisplay.existingValueSigned !== "either" && a.whenToDisplay.existingValueSigned !== isSigned) return false;
+            // Is allow item clicked going to update properly?
+            return a.whenToDisplay.editableNoteOpen === "either" || String(a.whenToDisplay.editableNoteOpen) === String(this.props.allowItemClick);
+        });
+        if (filteredActions.length === 0) return null;
+        return (
+            <Menu
+                open={elementDisplayingMenu === subsectionName}
+                anchorReference="anchorPosition"
+                anchorPosition={{ top: positionTop, left: positionLeft }}
+                onClose={(event) => closeInsertionMenu()}
+                className="narrative-inserter-tooltip"
+            >
+                {
+                    // map filterActions to MenuItems
+                    filteredActions.map((a, index) => {
+                        const icon = a.icon ? (
+                            <ListItemIcon>
+                                <FontAwesome name={a.icon} />
+                            </ListItemIcon>
+                        ) : null;
+                        const text = a.text.replace("{elementText}", elementText);
+                        return (
+                            <MenuItem
+                                key={`${subsectionName}-${index}`}
+                                onClick={() => onMenuItemClicked(a.handler, element)}
+                                className="narrative-inserter-box"
+                            >
+                                {icon}
+                                <ListItemText className='narrative-inserter-menu-item' inset primary={text} />
+                            </MenuItem>
+                        )
+                    })
+                }
+            </Menu>
+        );
     }
 
     determineDefaultVisualizer = (section, clinicalEvent, optionsForSection) => {
@@ -138,6 +183,7 @@ export default class TargetedDataSection extends Component {
             <Visualizer
                 patient={patient}
                 condition={condition}
+                filterAndDisplayActions={this.filterAndDisplayActions}
                 conditionSection={section}
                 sectionTransform={sectionTransform}
                 allowItemClick={allowItemClick}
@@ -177,7 +223,7 @@ TargetedDataSection.propTypes = {
     condition: PropTypes.object,
     onItemClicked: PropTypes.func,
     actions: PropTypes.array,
-    allowItemClick: PropTypes.bool,
+    allowItemClick: PropTypes.bool.isRequired,
     isWide: PropTypes.bool.isRequired,
     clinicalEvent: PropTypes.string.isRequired
 }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -174,7 +174,7 @@ TargetedDataSection.propTypes = {
     condition: PropTypes.object,
     onItemClicked: PropTypes.func,
     actions: PropTypes.array,
-    allowItemClick: PropTypes.bool.isRequired,
+    allowItemClick: PropTypes.bool,
     isWide: PropTypes.bool.isRequired,
     clinicalEvent: PropTypes.string.isRequired
 }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -1,11 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Menu, { MenuItem } from 'material-ui/Menu';
 import Button from '../elements/Button';
 import './TargetedDataSection.css';
 import Lang from 'lodash';
-import FontAwesome from 'react-fontawesome';
-import { ListItemIcon, ListItemText } from 'material-ui/List';
 
 export default class TargetedDataSection extends Component {
     constructor(props) {
@@ -28,50 +25,6 @@ export default class TargetedDataSection extends Component {
             (this.state.chosenVisualizer !== null && !optionsForSection.includes(this.state.chosenVisualizer))) {
             this.setState({ defaultVisualizer, chosenVisualizer: null });
         }
-    }
-
-    filterAndDisplayActions = (unfilteredActions, isSigned, arrayIndex, subsectionName, element, elementText, closeInsertionMenu, onMenuItemClicked, elementDisplayingMenu, positionLeft, positionTop) => {
-        
-        const filteredActions = unfilteredActions.filter((a) => {
-            if (a.whenToDisplay.valueExists && Lang.isNull(element)) return false;
-            if (a.whenToDisplay.displayInSubsections &&  !a.whenToDisplay.displayInSubsections.includes(subsectionName)) return false;
-            if (a.whenToDisplay.displayForColumns && !a.whenToDisplay.displayForColumns.includes(arrayIndex)) return false;
-            if (a.whenToDisplay.existingValueSigned !== "either" && a.whenToDisplay.existingValueSigned !== isSigned) return false;
-            // Is allow item clicked going to update properly?
-            return a.whenToDisplay.editableNoteOpen === "either" || String(a.whenToDisplay.editableNoteOpen) === String(this.props.allowItemClick);
-        });
-        if (filteredActions.length === 0) return null;
-        return (
-            <Menu
-                open={elementDisplayingMenu === subsectionName}
-                anchorReference="anchorPosition"
-                anchorPosition={{ top: positionTop, left: positionLeft }}
-                onClose={(event) => closeInsertionMenu()}
-                className="narrative-inserter-tooltip"
-            >
-                {
-                    // map filterActions to MenuItems
-                    filteredActions.map((a, index) => {
-                        const icon = a.icon ? (
-                            <ListItemIcon>
-                                <FontAwesome name={a.icon} />
-                            </ListItemIcon>
-                        ) : null;
-                        const text = a.text.replace("{elementText}", elementText);
-                        return (
-                            <MenuItem
-                                key={`${subsectionName}-${index}`}
-                                onClick={() => onMenuItemClicked(a.handler, element)}
-                                className="narrative-inserter-box"
-                            >
-                                {icon}
-                                <ListItemText className='narrative-inserter-menu-item' inset primary={text} />
-                            </MenuItem>
-                        )
-                    })
-                }
-            </Menu>
-        );
     }
 
     determineDefaultVisualizer = (section, clinicalEvent, optionsForSection) => {
@@ -175,7 +128,6 @@ export default class TargetedDataSection extends Component {
 
         const viz = this.props.visualizerManager.getVisualizer(type, visualization);
         if (Lang.isNull(viz)) return null;
-
         const sectionTransform = viz.transform;
         const Visualizer = viz.visualizer;
 
@@ -183,7 +135,6 @@ export default class TargetedDataSection extends Component {
             <Visualizer
                 patient={patient}
                 condition={condition}
-                filterAndDisplayActions={this.filterAndDisplayActions}
                 conditionSection={section}
                 sectionTransform={sectionTransform}
                 allowItemClick={allowItemClick}

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -36,7 +36,7 @@ class VisualizerManager {
         });
         return newsection;
     };
-    
+
     transformNameValuePairToColumns = (patient, condition, subsection) => {
         let newsection = {};
 

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -1,0 +1,74 @@
+import Menu, { MenuItem } from 'material-ui/Menu';
+import Lang from 'lodash';
+import FontAwesome from 'react-fontawesome';
+import { ListItemIcon, ListItemText } from 'material-ui/List';
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+
+export default class VisualizerMenu extends Component {
+
+    filterActions = () => {
+        const filteredActions = this.props.unfilteredActions.filter((a) => {
+            if (a.whenToDisplay.valueExists && Lang.isNull(this.props.element)) return false;
+            if (a.whenToDisplay.displayInSubsections && !a.whenToDisplay.displayInSubsections.includes(this.props.subsectionName)) return false;
+            if (a.whenToDisplay.displayForColumns && !a.whenToDisplay.displayForColumns.includes(this.props.arrayIndex)) return false;
+            if (a.whenToDisplay.existingValueSigned !== "either" && a.whenToDisplay.existingValueSigned !== this.props.isSigned) return false;
+            return a.whenToDisplay.editableNoteOpen === "either" || String(a.whenToDisplay.editableNoteOpen) === String(this.props.allowItemClick);
+        });
+        return filteredActions;
+    }
+    
+    render() {
+        const filteredActions = this.filterActions(this.props.unfilteredActions);
+        if (filteredActions.length === 0) return null;
+        return (
+            <Menu
+                open={this.props.elementDisplayingMenu === this.props.elementId}
+                anchorReference="anchorPosition"
+                anchorPosition={{ top: this.props.positionTop, left: this.props.positionLeft }}
+                onClose={(event) => this.props.closeInsertionMenu()}
+                className="narrative-inserter-tooltip"
+            >
+                {
+                    // map filterActions to MenuItems
+                    filteredActions.map((a, index) => {
+                        const icon = a.icon ? (
+                            <ListItemIcon>
+                                <FontAwesome name={a.icon} />
+                            </ListItemIcon>
+                        ) : null;
+                        const text = a.text.replace("{elementText}", this.props.elementText);
+                        return (
+                            <MenuItem
+                                key={`${this.props.elementId}-${index}`}
+                                onClick={() => this.props.onMenuItemClicked(a.handler, this.props.element)}
+                                className="narrative-inserter-box"
+                            >
+                                {icon}
+                                <ListItemText className='narrative-inserter-menu-item' inset primary={text} />
+                            </MenuItem>
+                        )
+                    })
+                }
+            </Menu>
+        );
+    }
+}
+
+VisualizerMenu.propTypes = {
+    allowItemClick: PropTypes.bool.isRequired,
+    arrayIndex: PropTypes.number.isRequired,
+    closeInsertionMenu: PropTypes.func.isRequired,
+    element: PropTypes.oneOfType([
+        PropTypes.object.isRequired,
+        PropTypes.string.isRequired]),
+    elementDisplayingMenu: PropTypes.string,
+    elementId: PropTypes.string.isRequired,
+    elementText: PropTypes.string.isRequired,
+    isSigned: PropTypes.bool.isRequired,
+    onMenuItemClicked: PropTypes.func.isRequired,
+    positionLeft: PropTypes.number.isRequired,
+    positionTop: PropTypes.number.isRequired,
+    subsectionName: PropTypes.string,
+    unfilteredActions: PropTypes.array.isRequired
+}

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -7,6 +7,7 @@ import React, {Component} from 'react';
 
 export default class VisualizerMenu extends Component {
 
+    // Filter Actions by whenToDisplay property on an actions.
     filterActions = () => {
         const filteredActions = this.props.unfilteredActions.filter((a) => {
             if (a.whenToDisplay.valueExists && Lang.isNull(this.props.element)) return false;
@@ -18,6 +19,7 @@ export default class VisualizerMenu extends Component {
         return filteredActions;
     }
     
+    // Renders a menu for an element with its associated meny items.
     render() {
         const filteredActions = this.filterActions(this.props.unfilteredActions);
         if (filteredActions.length === 0) return null;


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Moved the logic for filtering/displaying actions for a subsection into one file, VisualizerMenu.  VisualizerMenu now takes a subsection and a list of actions, and filters and displays them according to their whenToDisplay properties.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added Enzyme-UI tests for slim mode 
- Added Enzyme-UI tests for full mode
- Added backend tests for new functionality added
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
