### PR TITLE
Show active medications

### DIFF
--- a/src/model/medication/FluxMedicationRequested.js
+++ b/src/model/medication/FluxMedicationRequested.js
@@ -76,6 +76,21 @@ class FluxMedicationRequested {
         return true;
     }
 
+    isActiveBetween(lowerDate, upperDate) {
+        const expectedPerformanceTime = this.expectedPerformanceTime;
+        if (!expectedPerformanceTime || !(this._medicationRequested.actionContext.expectedPerformanceTime.value instanceof TimePeriod)) return null;
+        const start = new moment(expectedPerformanceTime.timePeriodStart, "D MMM YYYY");
+        const end = new moment(expectedPerformanceTime.timePeriodEnd, "D MMM YYYY");
+        
+        // If the start date is in the future
+        if (start && start > upperDate) return false;
+
+        // If the medication ended before the lowerDate
+        if (end && end < lowerDate) return false;
+
+        return true;
+    }
+
     get entryInfo() {
         return this._medicationRequested.entryInfo;
     }

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -528,11 +528,7 @@ class PatientRecord {
         const sixMonthsAgo = new moment().subtract(6, "months");
 
         return allmeds.filter((med) => {
-            let medChanges = this.getMedicationChanges();
-            let expiredMedicationFound = medChanges.some((medChange) => {
-                return (medChange.medicationBeforeChange) && (med === this.getEntryFromReference(medChange.medicationBeforeChange.value))
-            });
-            return med.isActiveBetween(sixMonthsAgo, today) && !expiredMedicationFound;
+            return med.isActiveBetween(sixMonthsAgo, today);
         });
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -939,8 +939,6 @@ export default class SummaryMetadata {
             }
         });
         
-
-        console.log(medsToVisualize);
         // instead of returning meds, return list of medsToVisualize
         return medsToVisualize;
     }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -878,7 +878,7 @@ export default class SummaryMetadata {
     // TODO: fix bug. not displaying medication change in targeted data panel. make sure we are getting medication
     getItemListForMedications = (patient, condition) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
-        let meds = patient.getMedicationsForConditionChronologicalOrder(condition);
+        let meds = patient.getActiveMedicationsChronologicalOrder();
         const medicationChanges = patient.getMedicationChangesForConditionChronologicalOrder(condition);
 
         // For every medication in meds, create a new medToVisualize object that has the medication object and a medicationChange object
@@ -938,7 +938,9 @@ export default class SummaryMetadata {
                 }
             }
         });
+        
 
+        console.log(medsToVisualize);
         // instead of returning meds, return list of medsToVisualize
         return medsToVisualize;
     }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -907,7 +907,7 @@ export default class SummaryMetadata {
                     // Add the medBeforeChange to the med, for use in visualization
                     const medBeforeChangeRef = change.medicationBeforeChange.reference;
                     const medBeforeChange = patient.getEntryFromReference(medBeforeChangeRef);
-                    // medAfterChange.medicationBeforeChange = medBeforeChange;              
+                    // medAfterChange.medicationBeforeChange = medBeforeChange;
                     medToViz.medicationChange = {
                         type: change.type,
                         date: change.whenChanged,

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -880,7 +880,7 @@ export default class SummaryMetadata {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         
         // Only showing active medications
-        let meds = patient.getActiveMedicationsForConditionChronologicalOrder(condition);
+        let meds = patient.getActiveAndRecentlyStoppedMedicationsForConditionChronologicalOrder(condition);
         const medicationChanges = patient.getMedicationChangesForConditionChronologicalOrder(condition);
 
         // For every medication in meds, create a new medToVisualize object that has the medication object and a medicationChange object

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -878,7 +878,9 @@ export default class SummaryMetadata {
     // TODO: fix bug. not displaying medication change in targeted data panel. make sure we are getting medication
     getItemListForMedications = (patient, condition) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
-        let meds = patient.getActiveMedicationsChronologicalOrder();
+        
+        // Only showing active medications
+        let meds = patient.getActiveMedicationsForConditionChronologicalOrder(condition);
         const medicationChanges = patient.getMedicationChangesForConditionChronologicalOrder(condition);
 
         // For every medication in meds, create a new medToVisualize object that has the medication object and a medicationChange object


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Now only active medications will be shown by default.
Future work: Possibly adding a button to choose between seeing only active or all medications.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added Enzyme-UI tests for slim mode 
- Added Enzyme-UI tests for full mode
- Added backend tests for new functionality added
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
