### PR TITLE
IE scrollbars

### DIFF
--- a/src/dashboard/ClinicianDashboard.css
+++ b/src/dashboard/ClinicianDashboard.css
@@ -15,14 +15,14 @@
 /* For IE only */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
     #clinician-dashboard-content .fitted-panel {
-        max-height: calc(96vh - 106px - 16px); 
+        max-height: calc(92vh - 106px - 16px);
     }
 }
 
 /* For IE Edge 12+ only */
 @supports (-ms-ime-align:auto) {
     #clinician-dashboard-content .fitted-panel {
-        max-height: calc(96vh - 106px - 16px); 
+        max-height: calc(92vh - 106px - 16px); 
     }
 }
 

--- a/src/dashboard/ClinicianDashboard.css
+++ b/src/dashboard/ClinicianDashboard.css
@@ -7,8 +7,23 @@
     overflow-x: hidden;
     text-align: left;
     /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content*/
-    max-height: calc(96vh - 106px - 16px);
+    max-height: calc(100vh - 106px - 16px); 
     min-height: 400px !important;
+
+}
+
+/* For IE only */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    #clinician-dashboard-content .fitted-panel {
+        max-height: calc(96vh - 106px - 16px); 
+    }
+}
+
+/* For IE Edge 12+ only */
+@supports (-ms-ime-align:auto) {
+    #clinician-dashboard-content .fitted-panel {
+        max-height: calc(96vh - 106px - 16px); 
+    }
 }
 
 #clinician-dashboard-content .right-border-box {

--- a/src/dashboard/ClinicianDashboard.css
+++ b/src/dashboard/ClinicianDashboard.css
@@ -7,7 +7,7 @@
     overflow-x: hidden;
     text-align: left;
     /* 106px is the height of the Patient Control Panel, 16px is the height of the top margin of post encounter view content*/
-    max-height: calc(100vh - 106px - 16px);
+    max-height: calc(96vh - 106px - 16px);
     min-height: 400px !important;
 }
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -11,14 +11,14 @@
 /* For IE only */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
     .note-assistant-wrapper {
-        max-height: calc(96vh - 106px - 16px);
+        max-height: calc(92vh - 106px - 16px);
     }
 }
 
 /* For IE Edge 12+ only */
 @supports (-ms-ime-align:auto) {
     .note-assistant-wrapper {
-        max-height: calc(96vh - 106px - 16px);
+        max-height: calc(92vh - 106px - 16px);
     }
 }
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -4,7 +4,7 @@
     flex-direction: column;
     width: 175px;
     margin-left: auto;
-    max-height: calc(100vh - 106px - 16px);
+    max-height: calc(96vh - 106px - 16px);
     min-height: 400px !important;
 }
 

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -4,8 +4,22 @@
     flex-direction: column;
     width: 175px;
     margin-left: auto;
-    max-height: calc(96vh - 106px - 16px);
+    max-height: calc(100vh - 106px - 16px);
     min-height: 400px !important;
+}
+
+/* For IE only */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    .note-assistant-wrapper {
+        max-height: calc(96vh - 106px - 16px);
+    }
+}
+
+/* For IE Edge 12+ only */
+@supports (-ms-ime-align:auto) {
+    .note-assistant-wrapper {
+        max-height: calc(96vh - 106px - 16px);
+    }
 }
 
 .note-assistant-content-wrapper {

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -1,9 +1,21 @@
 .FullApp {
-    max-height: 96vh;
-    /* min-height: 100vh; */
-    /* padding-bottom: 0.3em; */
+    max-height: 100vh;
     background-color: #FFFFFF;
     overflow: hidden;
+}
+
+/* For IE only */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    .FullApp {
+        max-height: 96vh;
+    }
+}
+
+/* For IE Edge 12+ only */
+@supports (-ms-ime-align:auto) {
+    .FullApp {
+        max-height: 96vh;
+    }
 }
 
 /* Restricts app to max fixed width for very wide screens. */

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -1,5 +1,5 @@
 .FullApp {
-    min-height: 100vh;
+    max-height: 93vh;
     background-color: #FFFFFF;
     overflow: hidden;
 }

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -1,5 +1,7 @@
 .FullApp {
-    max-height: 93vh;
+    max-height: 96vh;
+    /* min-height: 100vh; */
+    /* padding-bottom: 0.3em; */
     background-color: #FFFFFF;
     overflow: hidden;
 }

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -7,14 +7,14 @@
 /* For IE only */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
     .FullApp {
-        max-height: 96vh;
+        max-height: 92vh;
     }
 }
 
 /* For IE Edge 12+ only */
 @supports (-ms-ime-align:auto) {
     .FullApp {
-        max-height: 96vh;
+        max-height: 92vh;
     }
 }
 


### PR DESCRIPTION
This PR addresses jira 787. In IE, there is an extra scrollbar on full app when the editor is open. This is what it looks like on fluxnotes.org currently:

![image](https://user-images.githubusercontent.com/26877672/42643737-e5c05db0-85c7-11e8-991a-6057ea1f26fa.png)

This PR removes the extra scrollbar by reducing the height of the app so that there is no scrollbar. The max height is set to 96vh (which is as close as it can get to 100vh before the scrollbar appears). Because the scrollbar issue is not an issue in chrome, the styling change is only applied to IE and Edge so there should be no difference in how the app is displayed in chrome. An important point to note is that I am targeting zoom at 100% in the browser. 

If others have better solutions for how to address the scroll bar issue (instead of introducing a small margin on the bottom of the page), I am open to other approaches. 

Below are approaches I have tried:
- Originally the styling used min-height. I had tried playing around with different values of min-height but in the end only changing min-height to max-height worked
- I looked at this: https://www.sitepoint.com/community/t/extra-scrollbar-when-body-height-is-100vh/257883/2. In index.css, it is already initializing the margin and padding to 0 so this fix did not work
- I had looked into this: https://github.com/vaadin/framework/issues/3364 but the fix to reduce spacing by setting font size to 0 did not work and messed up the styling for the rest of the app
- I looked at this: https://www.bennadel.com/blog/3391-margin-collapsing-causes-unexpected-scrollbar-with-100vh-body-in-webkit.htm and tried to remove any extra padding on components in the app but it did not look like the other components have extra padding. I tried removing the sign button component at the bottom of the app but it had no effect on the extra spacing that was appearing in the app when opened in IE
- I tried using calc(100vh - 40px) to see if the gap is smaller than setting the max-height to 96vh but there did not appear to be a difference in the size of the gap
- I also looked at https://code.tutsplus.com/tutorials/9-most-common-ie-bugs-and-how-to-fix-them--net-7764, specifically the section on "Double Margin on Floated Elements" but the fix did not work and the problem was not quite the same as the one in the app




_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE 

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added Enzyme-UI tests for slim mode 
- N/A Added Enzyme-UI tests for full mode
- N/A Added backend tests for new functionality added
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
