### PR TITLE
Refactor saving of notes

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -61,7 +61,6 @@ export class FullApp extends Component {
             clinicalEvent: "pre-encounter",
             condition: null,
             contextManager: this.contextManager,
-            documentText: "",
             errors: [],
             layout: "",
             isNoteViewerVisible: false,
@@ -157,10 +156,6 @@ export class FullApp extends Component {
         this.setFullAppState('condition', condition)
     }
 
-    setDocumentText = (documentText) => {
-        this.setFullAppState('documentText', documentText);
-    }
-
     setNoteViewerVisible = (value) => {
         this.setFullAppState('isNoteViewerVisible', value);
     }
@@ -221,10 +216,6 @@ export class FullApp extends Component {
         this.setState({
             openClinicalNote: openClinicalNote
         });
-    }
-
-    setDocumentTextWithCallback = (documentText, callback) => {
-        this.setFullAppStateWithCallback({ documentText }, callback);
     }
 
     openReferencedNote = (item, arrayIndex = -1) => {
@@ -310,8 +301,6 @@ export class FullApp extends Component {
                             onContextUpdate={this.onContextUpdate}
                             possibleClinicalEvents={this.possibleClinicalEvents}
                             searchSelectedItem={this.state.searchSelectedItem}
-                            setDocumentText={this.setDocumentText}
-                            setDocumentTextWithCallback={this.setDocumentTextWithCallback}
                             setNoteClosed={this.setNoteClosed}
                             setNoteViewerEditable={this.setNoteViewerEditable}
                             setNoteViewerVisible={this.setNoteViewerVisible}

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -182,7 +182,6 @@ export default class ClinicianDashboard extends Component {
                         contextManager={this.props.contextManager}
                         currentViewMode={this.props.appState.clinicalEvent}
                         dataAccess={this.props.dataAccess}
-                        documentText={this.props.appState.documentText}
                         errors={this.props.appState.errors}
                         handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                         isNoteViewerEditable={isNoteViewerEditable}
@@ -194,8 +193,6 @@ export default class ClinicianDashboard extends Component {
                         openClinicalNote={this.props.appState.openClinicalNote}
                         patient={this.props.appState.patient}
                         searchSelectedItem={this.props.searchSelectedItem}
-                        setDocumentText={this.props.setDocumentText}
-                        setDocumentTextWithCallback={this.props.setDocumentTextWithCallback}
                         setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                         setLayout={this.props.setLayout}
                         setNoteClosed={this.props.setNoteClosed}
@@ -228,7 +225,6 @@ ClinicianDashboard.proptypes = {
     onContextUpdate: PropTypes.func.isRequired,
     possibleClinicalEvents: PropTypes.array.isRequired,
     searchSelectedItem: PropTypes.object,
-    setDocumentTextWithCallback: PropTypes.func.isRequired,
     setForceRefresh: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,
     setLayout: PropTypes.func.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -387,28 +387,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     getNoteText = (state) => {
-        let indexOfLastNode = state.toJSON().document.nodes.length - 1;
-        let endOfNoteKey = state.toJSON().document.nodes[indexOfLastNode].key;
-        let endOfNoteOffset = 0;
-        // If the editor has no structured phrases, use the number of characters in the first 'node'
-        if (Lang.isEqual(indexOfLastNode, 0) && !Lang.isUndefined(state.toJSON().document.nodes["0"].nodes["0"].characters)) {
-            endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
-        } else {
-            if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)) {
-                endOfNoteOffset = this.props.documentText.length;
-            }
-        }
-
-        // 'copy' the text every time into the note
-        // Need to artificially set selection to the whole document
-        // state.selection only has a getter for these values so create a new object
-        const entireNote = {
-            startKey: "0",
-            startOffset: 0,
-            endKey: endOfNoteKey,
-            endOffset: endOfNoteOffset
-        };
-        const documentText = this.structuredFieldPlugin.convertToText(state, entireNote);
+        const documentText = this.structuredFieldPlugin.convertToText(state);
 
         return documentText;
     }
@@ -1226,34 +1205,30 @@ class FluxNotesEditor extends React.Component {
     }
 }
 
-// TODO Update propTypes and make sure it's validating
-FluxNotesEditor.proptypes = {
+FluxNotesEditor.propTypes = {
     closeNote: PropTypes.func.isRequired,
     contextManager: PropTypes.object.isRequired,
     currentViewMode: PropTypes.string.isRequired,
-    documentText: PropTypes.object,
     errors: PropTypes.array.isRequired,
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
     inModal: PropTypes.bool.isRequired,
-    itemInserted: PropTypes.object,
+    itemInserted: PropTypes.func.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     noteAssistantMode: PropTypes.string.isRequired,
     patient: PropTypes.object.isRequired,
     saveNote: PropTypes.func.isRequired,
     selectedNote: PropTypes.object,
-    setDocumentTextWithCallback: PropTypes.func,
-    setFullAppState: PropTypes.func.isRequired,
-    setFullAppStateWithCallback: PropTypes.func.isRequired,
     setLayout: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     shouldEditorContentUpdate: PropTypes.bool.isRequired,
     structuredFieldMapManager: PropTypes.object.isRequired,
     summaryItemToInsert: PropTypes.string.isRequired,
-    contextTrayItemToInsert: PropTypes.string.isRequired,
+    contextTrayItemToInsert: PropTypes.string,
     updatedEditorNote: PropTypes.object,
     updateErrors: PropTypes.func.isRequired,
+    updateLocalDocumentText: PropTypes.func.isRequired,
     updateSelectedNote: PropTypes.func.isRequired,
     updateNoteAssistantMode: PropTypes.func.isRequired,
     updateContextTrayItemToInsert: PropTypes.func.isRequired

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -176,8 +176,14 @@ class FluxNotesEditor extends React.Component {
         });
     }
 
+    componentWillUnmount() {
+        // TODO: Save current note on unmounting to not lose content
+        console.log("FNE unmounting")
+    }
+
     // Reset the editor to the initial state when the app is first constructed.
     resetEditorState() {
+        // TODO Can we use resetEditorState as a way to trigger saving notes?
         this.state = {
             state: initialState,
             isPortalOpen: false,
@@ -380,6 +386,13 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (state) => {
+        let documentText = this.getNoteText(state);
+        this.props.updateLocalDocumentText(documentText);
+
+        this.setState({ state });
+    }
+
+    getNoteText = (state) => {
         let indexOfLastNode = state.toJSON().document.nodes.length - 1;
         let endOfNoteKey = state.toJSON().document.nodes[indexOfLastNode].key;
         let endOfNoteOffset = 0;
@@ -403,12 +416,20 @@ class FluxNotesEditor extends React.Component {
         };
         const documentText = this.structuredFieldPlugin.convertToText(state, entireNote);
 
-        this.props.setDocumentTextWithCallback(documentText, () => {
-            // save note after documentText gets set
-            this.props.saveNoteOnChange();
-        });
+        return documentText;
+    }
 
-        this.setState({ state });
+    closeNote = () => {
+        const documentText = this.getNoteText(this.state.state);
+        this.props.closeNote(documentText);
+
+        // this.props.saveNoteOnChange(documentText);
+        // this.props.setDocumentTextWithCallback(documentText, () => {
+        //     // save note after documentText gets set
+        //     this.props.saveNoteOnChange();
+        // });
+
+        // this.setState({ state });
     }
 
     onFocus = () => {
@@ -1112,7 +1133,7 @@ class FluxNotesEditor extends React.Component {
                                     raised 
                                     className="close-note-btn"
                                     disabled={this.context_disabled}
-                                    onClick={this.props.closeNote}
+                                    onClick={this.closeNote}
                                     style={{
                                         float: "right",
                                         lineHeight: "2.1rem"
@@ -1218,6 +1239,7 @@ class FluxNotesEditor extends React.Component {
     }
 }
 
+// TODO Update propTypes and make sure it's validating
 FluxNotesEditor.proptypes = {
     closeNote: PropTypes.func.isRequired,
     contextManager: PropTypes.object.isRequired,
@@ -1231,7 +1253,6 @@ FluxNotesEditor.proptypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     noteAssistantMode: PropTypes.string.isRequired,
     patient: PropTypes.object.isRequired,
-    saveNoteOnChange: PropTypes.func.isRequired,
     selectedNote: PropTypes.object,
     setDocumentTextWithCallback: PropTypes.func,
     setFullAppState: PropTypes.func.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -176,14 +176,8 @@ class FluxNotesEditor extends React.Component {
         });
     }
 
-    componentWillUnmount() {
-        // TODO: Save current note on unmounting to not lose content
-        console.log("FNE unmounting")
-    }
-
     // Reset the editor to the initial state when the app is first constructed.
     resetEditorState() {
-        // TODO Can we use resetEditorState as a way to trigger saving notes?
         this.state = {
             state: initialState,
             isPortalOpen: false,
@@ -421,15 +415,8 @@ class FluxNotesEditor extends React.Component {
 
     closeNote = () => {
         const documentText = this.getNoteText(this.state.state);
-        this.props.closeNote(documentText);
-
-        // this.props.saveNoteOnChange(documentText);
-        // this.props.setDocumentTextWithCallback(documentText, () => {
-        //     // save note after documentText gets set
-        //     this.props.saveNoteOnChange();
-        // });
-
-        // this.setState({ state });
+        this.props.saveNote(documentText)
+        this.props.closeNote();
     }
 
     onFocus = () => {
@@ -1253,6 +1240,7 @@ FluxNotesEditor.proptypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     noteAssistantMode: PropTypes.string.isRequired,
     patient: PropTypes.object.isRequired,
+    saveNote: PropTypes.func.isRequired,
     selectedNote: PropTypes.object,
     setDocumentTextWithCallback: PropTypes.func,
     setFullAppState: PropTypes.func.isRequired,

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -180,10 +180,8 @@ export default class NoteAssistant extends Component {
         }
     }
 
-    // TODO Support deleting notes
     deleteSelectedNote = () => {
         this.props.deleteSelectedNote();
-        // this.closeNote(); //TODO Need correct close note function.
     }
 
     // Render the content for the Note Assistant panel

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -246,7 +246,6 @@ export default class NoteAssistant extends Component {
                                 closeNote={this.props.closeNote}
                                 contextManager={this.props.contextManager}
                                 currentViewMode={'pre-encounter'}
-                                documentText={this.props.documentText}
                                 errors={this.props.errors}
                                 handleUpdateEditorWithNote={this.props.handleUpdateEditorWithNote}
                                 isNoteViewerEditable={false}
@@ -255,8 +254,9 @@ export default class NoteAssistant extends Component {
                                 newCurrentShortcut={this.props.newCurrentShortcut}
                                 noteAssistantMode={this.props.noteAssistantMode}
                                 patient={this.props.patient}
+                                saveNote={this.props.saveNote}
                                 selectedNote={this.props.selectedNote}
-                                setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
+                                setLayout={this.props.setLayout}
                                 setNoteViewerEditable={this.props.setNoteViewerEditable}
                                 shortcutManager={this.props.shortcutManager}
                                 shouldEditorContentUpdate={this.props.shouldEditorContentUpdate}
@@ -266,6 +266,7 @@ export default class NoteAssistant extends Component {
                                 // Pass in note that the editor is to be updated with
                                 updatedEditorNote={this.props.updatedEditorNote}
                                 updateErrors={this.props.updateErrors}
+                                updateLocalDocumentText={this.props.updateLocalDocumentText}
                                 updateSelectedNote={this.props.updateSelectedNote}
                                 updateNoteAssistantMode={this.props.updateNoteAssistantMode}
                                 arrayOfPickLists={this.props.arrayOfPickLists}
@@ -544,7 +545,6 @@ NoteAssistant.propTypes = {
     contextManager: PropTypes.object.isRequired,
     contextTrayItemToInsert: PropTypes.string,
     deleteSelectedNote: PropTypes.func.isRequired,
-    documentText: PropTypes.string.isRequired,
     handleSummaryItemSelected: PropTypes.func.isRequired,
     handleUpdateArrayOfPickLists: PropTypes.func.isRequired,
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
@@ -557,7 +557,6 @@ NoteAssistant.propTypes = {
     patient: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
     selectedNote: PropTypes.object,
-    setFullAppStateWithCallback: PropTypes.func.isRequired,
     setLayout: PropTypes.func.isRequired,
     setNoteClosed: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -123,51 +123,6 @@ export default class NoteAssistant extends Component {
         this.toggleView("context-tray");
     }
 
-    updateExistingNote = (content) => {
-        this.updateNote(this.props.currentlyEditingEntryId, content);
-    }
-
-    updateNote = (entryId, content) => {
-        // Only update if there is a note in progress
-        if (!Lang.isEqual(entryId, -1)) {
-            // List the notes to verify that they are being updated each invocation of this function:
-            var found = this.props.patient.getNotes().find(function (element) {
-                return Lang.isEqual(element.entryInfo.entryId, entryId);
-            });
-            if (!Lang.isNull(found) && !Lang.isUndefined(found)) {
-                found.content = content;
-                this.props.patient.updateExistingEntry(found);
-                this.props.updateSelectedNote(found);
-            }
-        }
-    }
-
-    // creates blank new note and puts it on the screen
-    createBlankNewNote = () => {
-        this.props.setNoteClosed(false);
-        // Create info to be set for new note
-        let date = new moment().format("D MMM YYYY");
-        let subject = "New Note";
-        let hospital = "Dana Farber";
-        let clinician = this.props.loginUser;
-        let content = "";
-        let signed = false;
-
-        // Add new unsigned note to patient record
-        var currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
-        this.props.updateCurrentlyEditingEntryId(currentlyEditingEntryId);
-
-        var newNote = this.props.patient.getNotes().find(function (curNote) {
-            return Lang.isEqual(curNote.entryInfo.entryId, currentlyEditingEntryId);
-        });
-
-        // Select note in the clinical notes view
-        this.props.updateSelectedNote(newNote);
-        this.props.loadNote(newNote);
-        this.props.setNoteViewerEditable(true);
-        this.toggleView("context-tray");
-    }
-
     // Gets called when clicking on one of the notes in the clinical notes view
     openNote = (isInProgressNote, note) => {
         this.props.openExistingNote(isInProgressNote, note);
@@ -566,7 +521,6 @@ NoteAssistant.propTypes = {
     shortcutManager: PropTypes.object.isRequired,
     shouldEditorContentUpdate: PropTypes.bool.isRequired,
     structuredFieldMapManager: PropTypes.object.isRequired,
-    updateCurrentlyEditingEntryId: PropTypes.func.isRequired,
     updateNoteAssistantMode: PropTypes.func.isRequired,
     updateSelectedNote: PropTypes.func.isRequired,
     arrayOfPickLists: PropTypes.array.isRequired,

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -127,13 +127,11 @@ function StructuredFieldPlugin(opts) {
         return result;
     }
 
-    function convertToText(state, selection) {
+    function convertToText(state) {
         return `${convertSlateNodesToText(state.document.toJSON().nodes)}`;
     }
 
     function onCopy(event, data, state, editor) {
-        let { selection } = state;
-
         const window = getWindow(event.target);
         const native = window.getSelection();
         const { endBlock, endInline } = state;
@@ -144,7 +142,7 @@ function StructuredFieldPlugin(opts) {
         // If the selection is collapsed, and it isn't inside a void node, abort.
         if (native.isCollapsed && !isVoid) return;
 
-        let fluxString = convertToText(state, selection);
+        let fluxString = convertToText(state);
         // console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));
         const range = native.getRangeAt(0);

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -106,8 +106,6 @@ export default class NotesPanel extends Component {
                     noteAssistantMode: mode,
                     currentlyEditingEntryId: parseInt(note.entryInfo.entryId, 10)
                 });
-                // TODO Get rid of all the old documentText references
-                this.props.setDocumentText(note.content);
                 this.props.setOpenClinicalNote(note);
             });
         }
@@ -328,7 +326,6 @@ export default class NotesPanel extends Component {
                     closeNote={this.closeNote}
                     contextManager={this.props.contextManager}
                     currentViewMode={this.props.currentViewMode}
-                    documentText={this.props.documentText}
                     errors={this.props.errors}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
@@ -339,10 +336,8 @@ export default class NotesPanel extends Component {
                     patient={this.props.patient}
                     saveNote={this.saveNote}
                     selectedNote={this.state.selectedNote}
-                    setDocumentTextWithCallback={this.props.setDocumentTextWithCallback}
-                    setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
-                    setLayout={this.setLayout}
+                    setLayout={this.props.setLayout}
                     shortcutManager={this.props.shortcutManager}
                     shouldEditorContentUpdate={this.state.noteAssistantMode !== 'pick-list-options-panel'}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
@@ -371,11 +366,12 @@ export default class NotesPanel extends Component {
                     contextManager={this.props.contextManager}
                     contextTrayItemToInsert={this.state.contextTrayItemToInsert}
                     deleteSelectedNote={this.deleteSelectedNote}
-                    documentText={this.state.localDocumentText}
+                    errors={this.props.errors}
                     handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                     handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
+                    itemInserted={this.props.itemInserted}
                     loadNote={this.handleUpdateEditorWithNote}
                     loginUser={this.props.loginUser}
                     newCurrentShortcut={this.props.newCurrentShortcut}
@@ -384,9 +380,9 @@ export default class NotesPanel extends Component {
                     openNewNote={this.openNewNote}
                     openExistingNote={this.openExistingNote}
                     patient={this.props.patient}
+                    saveNote={this.saveNote}
                     searchSelectedItem={this.props.searchSelectedItem}
                     selectedNote={this.state.selectedNote}
-                    setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     setLayout={this.props.setLayout} 
                     setNoteClosed={this.props.setNoteClosed}
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
@@ -396,7 +392,9 @@ export default class NotesPanel extends Component {
                     shortcutManager={this.props.shortcutManager}
                     shouldEditorContentUpdate={this.state.noteAssistantMode === 'pick-list-options-panel'}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
+                    summaryItemToInsert={this.props.summaryItemToInsert}
                     updateCurrentlyEditingEntryId={this.handleUpdateCurrentlyEditingEntryId}
+                    updateLocalDocumentText={this.updateLocalDocumentText}
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
                     updateSelectedNote={this.updateSelectedNote}
                     arrayOfPickLists={this.state.arrayOfPickLists}
@@ -422,7 +420,6 @@ NotesPanel.propTypes = {
     contextManager: PropTypes.object,
     currentViewMode: PropTypes.string.isRequired,
     dataAccess: PropTypes.object.isRequired,
-    documentText: PropTypes.string.isRequired,
     errors: PropTypes.array.isRequired,
     handleSummaryItemSelected: PropTypes.func.isRequired,
     isNoteViewerVisible: PropTypes.bool.isRequired,
@@ -434,8 +431,6 @@ NotesPanel.propTypes = {
     openClinicalNote: PropTypes.object,
     patient: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
-    setDocumentText: PropTypes.func.isRequired,
-    setDocumentTextWithCallback: PropTypes.func.isRequired,
     setNoteClosed: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -122,7 +122,7 @@ export default class NotesPanel extends Component {
             var noteToUpdate = this.props.patient.getNotes().find(function (element) {
                 return Lang.isEqual(element.entryInfo.entryId, entryId);
             });
-            if (!Lang.isNull(noteToUpdate) && !Lang.isUndefined(noteToUpdate)) {
+            if (!Lang.isNull(noteToUpdate) && !Lang.isUndefined(noteToUpdate) && !noteToUpdate.signed) {
                 noteToUpdate.content = noteContent;
                 this.props.patient.updateExistingEntry(noteToUpdate);
                 this.updateSelectedNote(noteToUpdate);
@@ -230,8 +230,9 @@ export default class NotesPanel extends Component {
     }
 
     handleSignButtonClick = () => {
-        // Set signed attribute on the selected note to be true
+        this.saveNote(this.state.localDocumentText);
 
+        // Set signed attribute on the selected note to be true
         const tempNote = this.state.selectedNote;
         tempNote.signed = true;
         this.setState({selectedNote: tempNote});
@@ -245,7 +246,6 @@ export default class NotesPanel extends Component {
         });
 
         // Close the current note
-        this.saveNote(this.state.localDocumentText);
         this.closeNote();
     }
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -144,7 +144,7 @@ export default class NotesPanel extends Component {
     // Close a note
     closeNote = () => {
         this.props.setOpenClinicalNote(null);
-        this.setState({ // TODO are any of these state variables not needed?
+        this.setState({
             updatedEditorNote: null,
             noteAssistantMode: "context-tray",
             // selectedNote is the note that is selected in the clinical notes view in the NoteAssistant

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -111,10 +111,6 @@ export default class NotesPanel extends Component {
         }
     }
 
-    handleUpdateCurrentlyEditingEntryId = (id) => {
-        this.setState({currentlyEditingEntryId: parseInt(id, 10)});
-    }
-
     handleUpdateArrayOfPickLists = (array) => {
         this.setState({arrayOfPickLists: array})
     }
@@ -161,16 +157,8 @@ export default class NotesPanel extends Component {
         this.props.setNoteViewerEditable(false);
     }
 
-    // TODO Can you consolidate openNewNote and openExistingNote?
-    // Open a blank note
+    // Create and open a blank note
     openNewNote = () => {
-        // Saves then closes the current note
-        this.saveNote(this.state.localDocumentText);
-        this.updateLocalDocumentText(''); // Reset localDocumentText when opening note
-
-        // Then open a blank note
-        this.props.setNoteClosed(false);
-
         // Create info to be set for new note
         const date = new moment().format("D MMM YYYY");
         const subject = "New Note";
@@ -181,28 +169,30 @@ export default class NotesPanel extends Component {
 
         // Add new unsigned note to patient record
         const currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
-        this.handleUpdateCurrentlyEditingEntryId(currentlyEditingEntryId);
 
         const newNote = this.props.patient.getNotes().find(function (curNote) {
             return Lang.isEqual(curNote.entryInfo.entryId, currentlyEditingEntryId);
         });
 
-        // Select note in the clinical notes view
-        this.updateSelectedNote(newNote);
-        this.handleUpdateEditorWithNote(newNote);
-        this.props.setNoteViewerEditable(true);
+        this.openNote(newNote, true);
     }
 
     // Open an existing note
     openExistingNote = (isInProgress, note) => {
-        this.saveNote(this.state.localDocumentText);
-        this.updateLocalDocumentText(''); // Reset localDocumentText when opening note
+        this.openNote(note, isInProgress);
+    }
 
+    openNote = (note, isInProgress) => {
+        // Saves the current note and resets localDocumentText before opening the next note.
+        this.saveNote(this.state.localDocumentText);
+        this.updateLocalDocumentText('');
+
+        // Open a note
         this.props.setNoteClosed(false);
         this.props.setLayout('split');
         this.props.setNoteViewerVisible(true);
 
-        // Old note above these lines: "the lines below are duplicative"
+        // Old note above these lines: 'the lines below are duplicative'
         this.updateSelectedNote(note);
         this.handleUpdateEditorWithNote(note);
 
@@ -393,7 +383,6 @@ export default class NotesPanel extends Component {
                     shouldEditorContentUpdate={this.state.noteAssistantMode === 'pick-list-options-panel'}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
                     summaryItemToInsert={this.props.summaryItemToInsert}
-                    updateCurrentlyEditingEntryId={this.handleUpdateCurrentlyEditingEntryId}
                     updateLocalDocumentText={this.updateLocalDocumentText}
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
                     updateSelectedNote={this.updateSelectedNote}

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -165,7 +165,7 @@ class PatientSearch extends React.Component {
     // Will be called every time suggestion is selected via mouse or keyboard.
     onSuggestionSelected = (event, { suggestion, suggestionValue, suggestionIndex, sectionIndex, method }) => { 
         const contextNotes = this.props.patient.getNotes();
-        const selectedNote = contextNotes.find(function(note){ return note.entryInfo.entryId === suggestion.note.entryInfo.entryId});
+        const selectedNote = contextNotes.find(note => note.entryInfo.entryId === suggestion.note.entryInfo.entryId);
 
         this.props.setSearchSelectedItem(selectedNote);
     }

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -321,10 +321,22 @@ describe('6 FluxNotesEditor', function() {
             setFullAppState={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
-            saveNoteUponKeypress={jest.fn()}
             shouldEditorContentUpdate={true}
             setNoteViewerEditable={jest.fn()}
             setNoteViewerVisible={jest.fn()}
+            currentViewMode={''}
+            errors={[]}
+            inModal={false}
+            itemInserted={jest.fn()}
+            noteAssistantMode={''}
+            patient={{}}
+            saveNote={jest.fn()}
+            summaryItemToInsert={''}
+            updateErrors={jest.fn()}
+            updateLocalDocumentText={jest.fn()}
+            updateSelectedNote={jest.fn()}
+            updateNoteAssistantMode={jest.fn()}
+            updateContextTrayItemToInsert={jest.fn()}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -449,14 +461,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -500,14 +509,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -567,11 +573,22 @@ describe('6 FluxNotesEditor', function() {
             setFullAppState={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
-            saveNoteUponKeypress={jest.fn()}
             shouldEditorContentUpdate={true}
             setNoteViewerEditable={jest.fn()}
             setNoteViewerVisible={jest.fn()}
+            currentViewMode={''}
+            errors={[]}
+            inModal={false}
+            itemInserted={jest.fn()}
+            noteAssistantMode={''}
+            patient={{}}
+            saveNote={jest.fn()}
+            summaryItemToInsert={''}
+            updateErrors={jest.fn()}
+            updateLocalDocumentText={jest.fn()}
+            updateSelectedNote={jest.fn()}
+            updateNoteAssistantMode={jest.fn()}
+            updateContextTrayItemToInsert={jest.fn()}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -620,10 +637,22 @@ describe('6 FluxNotesEditor', function() {
             setFullAppState={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
-            saveNoteUponKeypress={jest.fn()}
             shouldEditorContentUpdate={true}
             setNoteViewerEditable={jest.fn()}
             setNoteViewerVisible={jest.fn()}
+            currentViewMode={''}
+            errors={[]}
+            inModal={false}
+            itemInserted={jest.fn()}
+            noteAssistantMode={''}
+            patient={{}}
+            saveNote={jest.fn()}
+            summaryItemToInsert={''}
+            updateErrors={jest.fn()}
+            updateLocalDocumentText={jest.fn()}
+            updateSelectedNote={jest.fn()}
+            updateNoteAssistantMode={jest.fn()}
+            updateContextTrayItemToInsert={jest.fn()}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -676,10 +705,22 @@ describe('6 FluxNotesEditor', function() {
             setFullAppState={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
-            saveNoteUponKeypress={jest.fn()}
             shouldEditorContentUpdate={true}
             setNoteViewerEditable={jest.fn()}
             setNoteViewerVisible={jest.fn()}
+            currentViewMode={''}
+            errors={[]}
+            inModal={false}
+            itemInserted={jest.fn()}
+            noteAssistantMode={''}
+            patient={{}}
+            saveNote={jest.fn()}
+            summaryItemToInsert={''}
+            updateErrors={jest.fn()}
+            updateLocalDocumentText={jest.fn()}
+            updateSelectedNote={jest.fn()}
+            updateNoteAssistantMode={jest.fn()}
+            updateContextTrayItemToInsert={jest.fn()}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -729,14 +770,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -792,14 +830,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -862,14 +897,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -932,14 +964,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -1004,10 +1033,22 @@ describe('6 FluxNotesEditor', function() {
             setFullAppState={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
-            saveNoteUponKeypress={jest.fn()}
             shouldEditorContentUpdate={true}
             setNoteViewerEditable={jest.fn()}
             setNoteViewerVisible={jest.fn()}
+            currentViewMode={''}
+            errors={[]}
+            inModal={false}
+            itemInserted={jest.fn()}
+            noteAssistantMode={''}
+            patient={{}}
+            saveNote={jest.fn()}
+            summaryItemToInsert={''}
+            updateErrors={jest.fn()}
+            updateLocalDocumentText={jest.fn()}
+            updateSelectedNote={jest.fn()}
+            updateNoteAssistantMode={jest.fn()}
+            updateContextTrayItemToInsert={jest.fn()}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -1057,14 +1098,11 @@ describe('6 FluxNotesEditor', function() {
             //Others that are required but not used in test
             currentViewMode={''}
             dataAccess={{}}
-            documentText={''}
             errors={[]}
             handleSummaryItemSelected={jest.fn()}
             itemInserted={jest.fn()}
             loginUser={''}
             noteClosed={false}
-            setDocumentText={jest.fn()}
-            setDocumentTextWithCallback={jest.fn()}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -1123,14 +1161,11 @@ describe('6 FluxNotesEditor', function() {
     //         //Others that are required but not used in test
     //         currentViewMode={''}
     //         dataAccess={{}}
-    //         documentText={''}
     //         errors={[]}
     //         handleSummaryItemSelected={jest.fn()}
     //         itemInserted={jest.fn()}
     //         loginUser={''}
     //         noteClosed={false}
-    //         setDocumentText={jest.fn()}
-    //         setDocumentTextWithCallback={jest.fn()}
     //         setFullAppStateWithCallback={jest.fn()}
     //         setLayout={jest.fn()}
     //         setOpenClinicalNote={jest.fn()}


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

As part of looking into the selection bug in the upgraded version of Slate, we looked at refactoring now notes are saved. This changes so that all saving happens at the NotesPanel level. Saving only happens when a note is closed with the close button, when you click New Note, or when you change to viewing a different note. I also removed documentText since we no longer pass that all the way up to FullApp, and updated some of the propTypes on FluxNotesEditor.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
