### PR TITLE
Placeholder support

### DIFF
--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -26,6 +26,15 @@ class ContextPortal extends React.Component {
     componentWillUnmount = () => {
         document.removeEventListener('keydown', this.handleKeydownCP);
     }
+
+    shouldComponentUpdate = (nextProps, nextState) => {
+        const { openedPortal } = nextProps;
+
+        if (openedPortal !== null && openedPortal !== this.portalId) return false;
+        
+        return true;
+    }
+
     /*
      * Adjust the portal position anytime the portal updates
      */
@@ -46,7 +55,7 @@ class ContextPortal extends React.Component {
      * Sets state to record current contexts and portal activity
      */
     constructor(props) {
-        super()
+        super();
         props.callback.onSelected = props.onSelected;
         props.callback.closePortal = this.closePortal;
         props.callback.readOnly = false;
@@ -55,6 +64,7 @@ class ContextPortal extends React.Component {
             active: false,
             justActive: false
         }
+        this.portalId = "ContextPortal";
     }
     /*
      * When the portal opens, set flags appropriately and a decay timer for justActive
@@ -67,7 +77,9 @@ class ContextPortal extends React.Component {
      * Call onSelected with null context to indicate nothing selected and just clean up state
      */
     onClose = () => {
-        if (this.props.isOpened) {
+        const { openedPortal } = this.props;
+
+        if (openedPortal === this.portalId) {
             this.props.onChange(this.props.onSelected(this.props.state, null));
         }
         this.setState({ active: false, justActive: false }); // TEST: menu: null, 
@@ -224,7 +236,7 @@ class ContextPortal extends React.Component {
             <Portal 
                 closeOnEsc 
                 closeOnOutsideClick 
-                isOpened={this.props.isOpened} 
+                isOpened={this.props.openedPortal === this.portalId} 
                 onOpen={this.onOpen} 
                 onClose={this.onClose}
             >
@@ -242,8 +254,8 @@ ContextPortal.proptypes = {
     contextManager: PropTypes.object.isRequired,
     contexts: PropTypes.object,
     getPosition: PropTypes.func.isRequired,
-    isOpened: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
+    openedPortal: PropTypes.string.isRequired,
     onSelected: PropTypes.func.isRequired,
     state: PropTypes.object.isRequired,
     trigger: PropTypes.string.isRequired,

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -77,10 +77,10 @@ class ContextPortal extends React.Component {
      * Call onSelected with null context to indicate nothing selected and just clean up state
      */
     onClose = () => {
-        const { onChange, openedPortal, onSelected } = this.props;
+        const { onChange, openedPortal, onSelected, state } = this.props;
 
         if (openedPortal === this.portalId) {
-            onChange(onSelected(this.props.state, null));
+            onChange(onSelected(state, null));
         }
         this.setState({ active: false, justActive: false }); // TEST: menu: null, 
     }
@@ -218,7 +218,7 @@ class ContextPortal extends React.Component {
     render = () => {
         const TYPE_LIST = 0;
         const TYPE_CALENDAR = 1;
-        const { contexts } = this.props;
+        const { contexts, openedPortal } = this.props;
         let type;
         let className = "context-portal";
         if (Lang.isNull(contexts)) return null;
@@ -236,7 +236,7 @@ class ContextPortal extends React.Component {
             <Portal 
                 closeOnEsc 
                 closeOnOutsideClick 
-                isOpened={this.props.openedPortal === this.portalId} 
+                isOpened={openedPortal === this.portalId} 
                 onOpen={this.onOpen} 
                 onClose={this.onClose}
             >

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -30,7 +30,7 @@ class ContextPortal extends React.Component {
     shouldComponentUpdate = (nextProps, nextState) => {
         const { openedPortal } = nextProps;
 
-        if (openedPortal !== this.portalId) return false;
+        if (openedPortal !== null && openedPortal !== this.portalId) return false;
         
         return true;
     }
@@ -77,10 +77,10 @@ class ContextPortal extends React.Component {
      * Call onSelected with null context to indicate nothing selected and just clean up state
      */
     onClose = () => {
-        const { openedPortal } = this.props;
+        const { onChange, openedPortal, onSelected } = this.props;
 
         if (openedPortal === this.portalId) {
-            this.props.onChange(this.props.onSelected(this.props.state, null));
+            onChange(onSelected(this.props.state, null));
         }
         this.setState({ active: false, justActive: false }); // TEST: menu: null, 
     }

--- a/src/context/ContextPortal.jsx
+++ b/src/context/ContextPortal.jsx
@@ -30,7 +30,7 @@ class ContextPortal extends React.Component {
     shouldComponentUpdate = (nextProps, nextState) => {
         const { openedPortal } = nextProps;
 
-        if (openedPortal !== null && openedPortal !== this.portalId) return false;
+        if (openedPortal !== this.portalId) return false;
         
         return true;
     }

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -1,14 +1,16 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
-import TemplateViewModeContent from './TemplateViewModeContent'
-import ShortcutViewModeContent from './ShortcutViewModeContent'
-import './ContextTray.css';
+import TemplateViewModeContent from "./TemplateViewModeContent";
+import ShortcutViewModeContent from "./ShortcutViewModeContent";
+import "./ContextTray.css";
 
 export default class ContextTray extends Component {
     //these are the possible view mode constants
     TEMPLATE_VIEW = 0;
     SHORTCUT_VIEW = 1;
+    PLACEHOLDER_VIEW = 2;
+    
     constructor(props) {
         super(props);
 
@@ -16,17 +18,27 @@ export default class ContextTray extends Component {
             // viewMode keeps track of which context is active
             // 0 when Templates are selected. 1 when Patient is selected
             // In editor, viewMode is incremented by 1 for each context added (i.e @condition, #disease status)
-            viewMode: this.SHORTCUT_VIEW,
+            viewMode: this.SHORTCUT_VIEW
         };
     }
 
-    handleTemplateSectionClick = () => this.setState({ 
-        viewMode: this.TEMPLATE_VIEW 
-    })
-    
-    handlePatientSectionClick = () => this.setState({ 
-        viewMode: this.SHORTCUT_VIEW 
-    })
+    handleTemplateSectionClick = () => {
+        this.setState({
+            viewMode: this.TEMPLATE_VIEW
+        });
+    };
+
+    handleShortcutSectionClick = () => {
+        this.setState({
+            viewMode: this.SHORTCUT_VIEW
+        });
+    };
+
+    handlePlaceholderSectionClick = () => {
+        this.setState({
+            viewMode: this.PLACEHOLDER_VIEW
+        });
+    };
 
     render() {
         const { viewMode } = this.state;
@@ -35,38 +47,57 @@ export default class ContextTray extends Component {
             <div className="context-tray">
                 <section>
                     <div className="view-mode-section-menu">
-                    <div
-                        className={`view-mode-section-item${viewMode === this.TEMPLATE_VIEW ? ' selected' : ''}`}
-                        onClick={this.handleTemplateSectionClick}
-                    >
-                        TEMPLATES
-                    </div>                        
+                        <div
+                            className={`view-mode-section-item${
+                                viewMode === this.TEMPLATE_VIEW
+                                    ? " selected"
+                                    : ""
+                                }`}
+                            onClick={this.handleTemplateSectionClick}
+                        >
+                            TEMPLATES
+                        </div>
 
-                    <div
-                        className={`view-mode-section-item${viewMode === this.SHORTCUT_VIEW ? ' selected' : ''}`}
-                        onClick={this.handlePatientSectionClick}
-                    >
-                        SHORTCUTS
-                    </div>
+                        <div
+                            className={`view-mode-section-item${
+                                viewMode === this.SHORTCUT_VIEW
+                                    ? " selected"
+                                    : ""
+                                }`}
+                            onClick={this.handleShortcutSectionClick}
+                        >
+                            SHORTCUTS
+                        </div>
+
+                        <div
+                            className={`view-mode-section-item${
+                                viewMode === this.PLACEHOLDER_VIEW
+                                    ? " selected"
+                                    : ""
+                                }`}
+                            onClick={this.handlePlaceholderSectionClick}
+                        >
+                            PLACEHOLDERS
+                        </div>
                     </div>
                 </section>
 
-                {viewMode === this.TEMPLATE_VIEW &&
+                {viewMode === this.TEMPLATE_VIEW && (
                     <TemplateViewModeContent
                         onShortcutClicked={this.props.onShortcutClicked}
                         patient={this.props.patient}
                         setInsertingTemplate={this.props.setInsertingTemplate}
                     />
-                }
+                )}
 
-                {viewMode === this.SHORTCUT_VIEW &&
+                {viewMode === this.SHORTCUT_VIEW && (
                     <ShortcutViewModeContent
                         contextManager={this.props.contextManager}
                         handleClick={this.handleShortcutClick}
                         onShortcutClicked={this.props.onShortcutClicked}
                         shortcutManager={this.props.shortcutManager}
                     />
-                }
+                )}
             </div>
         );
     }
@@ -77,5 +108,5 @@ ContextTray.proptypes = {
     onShortcutClicked: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
     setInsertingTemplate: PropTypes.func.isRequired,
-    shortcutManager: PropTypes.object.isRequired,
-}
+    shortcutManager: PropTypes.object.isRequired
+};

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -1,17 +1,16 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-
-import TemplateViewModeContent from "./TemplateViewModeContent";
-import ShortcutViewModeContent from "./ShortcutViewModeContent";
-import PlaceholderViewModeContent from "./PlaceholderViewModeContent";
-import "./ContextTray.css";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import TemplateViewModeContent from './TemplateViewModeContent';
+import ShortcutViewModeContent from './ShortcutViewModeContent';
+import PlaceholderViewModeContent from './PlaceholderViewModeContent';
+import './ContextTray.css';
 
 export default class ContextTray extends Component {
     //these are the possible view mode constants
     TEMPLATE_VIEW = 0;
     SHORTCUT_VIEW = 1;
     PLACEHOLDER_VIEW = 2;
-    
+
     constructor(props) {
         super(props);
 

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import TemplateViewModeContent from "./TemplateViewModeContent";
 import ShortcutViewModeContent from "./ShortcutViewModeContent";
+import PlaceholderViewModeContent from "./PlaceholderViewModeContent";
 import "./ContextTray.css";
 
 export default class ContextTray extends Component {
@@ -42,6 +43,7 @@ export default class ContextTray extends Component {
 
     render() {
         const { viewMode } = this.state;
+        const { contextManager, onShortcutClicked, patient, setInsertingTemplate, shortcutManager } = this.props;
 
         return (
             <div className="context-tray">
@@ -84,18 +86,25 @@ export default class ContextTray extends Component {
 
                 {viewMode === this.TEMPLATE_VIEW && (
                     <TemplateViewModeContent
-                        onShortcutClicked={this.props.onShortcutClicked}
-                        patient={this.props.patient}
-                        setInsertingTemplate={this.props.setInsertingTemplate}
+                        onShortcutClicked={onShortcutClicked}
+                        patient={patient}
+                        setInsertingTemplate={setInsertingTemplate}
                     />
                 )}
 
                 {viewMode === this.SHORTCUT_VIEW && (
                     <ShortcutViewModeContent
-                        contextManager={this.props.contextManager}
+                        contextManager={contextManager}
                         handleClick={this.handleShortcutClick}
-                        onShortcutClicked={this.props.onShortcutClicked}
-                        shortcutManager={this.props.shortcutManager}
+                        onShortcutClicked={onShortcutClicked}
+                        shortcutManager={shortcutManager}
+                    />
+                )}
+
+                {viewMode === this.PLACEHOLDER_VIEW && (
+                    <PlaceholderViewModeContent
+                        onClick={onShortcutClicked}
+                        placeholders={shortcutManager.getAllPlaceholderShortcuts()}
                     />
                 )}
             </div>
@@ -103,7 +112,7 @@ export default class ContextTray extends Component {
     }
 }
 
-ContextTray.proptypes = {
+ContextTray.propTypes = {
     contextManager: PropTypes.object.isRequired,
     onShortcutClicked: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,

--- a/src/context/PlaceholderViewModeContent.jsx
+++ b/src/context/PlaceholderViewModeContent.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class PlaceholderViewModeContent extends Component {
+    handleClick(e, placeholderText) {
+        const { onClick } = this.props;
+
+        e.preventDefault();
+        onClick(placeholderText);
+    }
+
+    renderPlaceholder(placeholder) {
+        const placeholderText = `<${placeholder.name}>`;
+
+        return (
+            <div
+                className="context-option"
+                key={placeholder.name}
+                onClick={(e) => this.handleClick(e, placeholderText)}
+            >
+                {placeholderText}
+            </div>
+        );
+    }
+
+    render() {
+        const { placeholders } = this.props;
+
+        return (
+            <div>
+                {placeholders.map((placeholder) => {
+                    return this.renderPlaceholder(placeholder);
+                })}
+            </div>
+        );
+    }
+}
+
+PlaceholderViewModeContent.propTypes = {
+    onClick: PropTypes.func.isRequired,
+    placeholders: PropTypes.array.isRequired,
+};

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -18,7 +18,6 @@ class SuggestionPortal extends React.Component {
     shouldComponentUpdate = (nextProps, nextState) => {
         const { portalId, openedPortal } = nextProps;
 
-        if (portalId === "PlaceholdersPortal") return true;
         if (openedPortal !== null && openedPortal !== portalId) return false;
 
         return true;
@@ -296,7 +295,7 @@ class SuggestionPortal extends React.Component {
     // Closes portal
     closePortal = () => {
         const { menu } = this.state;
-        const { setOpenedPortal } = this.props;
+
         // No menu to close: return
         if (!menu) return;
 
@@ -305,7 +304,6 @@ class SuggestionPortal extends React.Component {
         menu.style.display = 'none';
         // Reset default suggestion for elements
         this.setDefaultSuggestion();
-        setOpenedPortal(null);
 
         return;
     }

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -15,9 +15,18 @@ class SuggestionPortal extends React.Component {
         this.adjustPosition()
     }
 
+    shouldComponentUpdate = (nextProps, nextState) => {
+        const { portalId, openedPortal } = nextProps;
+
+        if (portalId === "PlaceholdersPortal") return true;
+        if (openedPortal !== null && openedPortal !== portalId) return false;
+
+        return true;
+    }
+
     // Adjust position on each update
     componentDidUpdate = () => {
-        this.adjustPosition()
+        this.adjustPosition();
     }
 
     constructor(props) {
@@ -243,17 +252,14 @@ class SuggestionPortal extends React.Component {
     // Adjust menu styling and position when needed
     adjustPosition = () => {
         const { menu } = this.state;
+        const { openedPortal, portalId, setOpenedPortal } = this.props;
         // If there is no menu, return
         if (!menu) return;
 
-        // Prevent portal from opening when Context Portal is open
-        if (this.props.contextPortalOpen) {
-            this.closePortal();
-            return;
-        }
-
         const match = this.matchCapture();
         if (match === undefined) {
+            // if no match and opened portal is current portal, set it to null
+            if (openedPortal === portalId) setOpenedPortal(null);
             // No match: remove menu styling
             menu.removeAttribute('style');
             return;
@@ -265,6 +271,8 @@ class SuggestionPortal extends React.Component {
                 // menu.removeAttribute('style');
                 // menu.style.display = 'none'
             } else { 
+                if (openedPortal !== portalId) setOpenedPortal(portalId);
+                
                 menu.style.display = 'block'
                 menu.style.opacity = 1
                 if (window.innerHeight - rect.top < 230) {
@@ -288,6 +296,7 @@ class SuggestionPortal extends React.Component {
     // Closes portal
     closePortal = () => {
         const { menu } = this.state;
+        const { setOpenedPortal } = this.props;
         // No menu to close: return
         if (!menu) return;
 
@@ -296,6 +305,8 @@ class SuggestionPortal extends React.Component {
         menu.style.display = 'none';
         // Reset default suggestion for elements
         this.setDefaultSuggestion();
+        setOpenedPortal(null);
+
         return;
     }
 
@@ -326,4 +337,4 @@ class SuggestionPortal extends React.Component {
     }
 }
 
-export default SuggestionPortal
+export default SuggestionPortal;

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -304,6 +304,7 @@ class SuggestionPortal extends React.Component {
         menu.style.display = 'none';
         // Reset default suggestion for elements
         this.setDefaultSuggestion();
+        this.setSelectedIndex(0);
 
         return;
     }

--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -9,6 +9,10 @@
     background-color: #d9ebf9;
 }
 
+.placeholder {
+    color: #aaaaaa;
+}
+
 #clinical-notes #note-description p.note-description-detail-name {
     text-align: left;
     padding-bottom:2px;

--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -10,7 +10,7 @@
 }
 
 .placeholder {
-    color: #aaaaaa;
+    background-color: #dddddd;
 }
 
 #clinical-notes #note-description p.note-description-detail-name {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -153,14 +153,14 @@ class FluxNotesEditor extends React.Component {
             // console.log(shortcutNamesList)
             if (def.type === 'CreatorBase') {
                 console.log(triggers)
-                const placeHolderList = triggers.map(trigger => `<?${trigger.name.slice(1)}>$`);
+                const placeHolderList = triggers.map(trigger => `<${trigger.name}>$`);
                 shortcutNamesList = shortcutNamesList.concat(placeHolderList);
                 console.log(shortcutNamesList)
             }
             autoReplaceAfters = autoReplaceAfters.concat(shortcutNamesList);
             console.log(autoReplaceAfters)
         });
-        this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|").replace("?", "\\?") + ")", 'i');
+        this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');
         console.log('auto replace before reg exp')
         console.log(this.autoReplaceBeforeRegExp)
 
@@ -276,6 +276,12 @@ class FluxNotesEditor extends React.Component {
         console.log(def, transform, e, data, matches)
         // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
         const characterToAppend = e.data ? e.data : String.fromCharCode(data.code);
+        if (matches.before[0].startsWith("<#")) {
+            let result = this.structuredFieldPlugin.transforms.insertPlaceholder(transform, matches.before[0]);
+            // console.log("result[0]");
+            // console.log(result[0]);
+            return result[0].collapseToStartOfNextText().focus().insertText(characterToAppend);
+        }
         return this.insertShortcut(def, matches.before[0], "", transform).insertText(characterToAppend);
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -146,7 +146,7 @@ class FluxNotesEditor extends React.Component {
         let autoReplaceAfters = [];
         // Get all non-keyword shortcuts for autoreplace
         const allNonKeywordShortcuts = this.props.shortcutManager.getAllShortcutsWithTriggers();
-        console.log(allNonKeywordShortcuts)
+        
         allNonKeywordShortcuts.forEach((def) => {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(def.id);
             let shortcutNamesList = triggers.map(trigger => `${trigger.name}$`);
@@ -214,12 +214,11 @@ class FluxNotesEditor extends React.Component {
     }
 
     suggestionFunction(initialChar, text) {
-        console.log('suggestion function')
         if (Lang.isUndefined(text)) return [];
         let shortcuts = this.contextManager.getCurrentlyValidShortcuts(this.props.shortcutManager);
         let suggestionsShortcuts = [];
         const textLowercase = text.toLowerCase();
-        console.log(initialChar, text)
+        
         shortcuts.forEach((shortcut) => {
             //const triggers = shortcut.getStringTriggers();
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut);
@@ -235,7 +234,7 @@ class FluxNotesEditor extends React.Component {
             });
         });
         const placeHolderShortcuts = this.props.shortcutManager.getAllCreatorBaseShortcutsWithTriggers();
-
+        
         placeHolderShortcuts.forEach((shortcut) => {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut.id);
             triggers.forEach((trigger) => {
@@ -362,10 +361,13 @@ class FluxNotesEditor extends React.Component {
     // called from portal when an item is selected (selection is not null) or if portal is closed without
     // selection (selection is null)
     onPortalSelection = (state, selection) => {
-
         let shortcut = this.selectingForShortcut;
+
         this.selectingForShortcut = null;
-        this.setState({ openedPortal: null });
+        this.setState({ 
+            openedPortal: null,
+            portalOptions: null, 
+        });
         if (Lang.isNull(selection)) {
             // Removes the shortcut from its parent
             shortcut.onBeforeDeleted();
@@ -384,6 +386,7 @@ class FluxNotesEditor extends React.Component {
         } else {
             transform = this.state.state.transform();
         }
+        
         return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus().apply();
     }
 
@@ -1231,23 +1234,23 @@ class FluxNotesEditor extends React.Component {
                     </div>
 
                     <CreatorsPortal
-                        portalId={"CreatorsPortal"}
-                        openedPortal={this.state.openedPortal}
                         getPosition={this.getTextCursorPosition}
+                        openedPortal={this.state.openedPortal}
+                        portalId={"CreatorsPortal"}
                         setOpenedPortal={this.setOpenedPortal}
                         state={this.state.state}
                     />
                     <InsertersPortal
-                        portalId={"InsertersPortal"}
-                        openedPortal={this.state.openedPortal}
                         getPosition={this.getTextCursorPosition}
+                        openedPortal={this.state.openedPortal}
+                        portalId={"InsertersPortal"}
                         setOpenedPortal={this.setOpenedPortal}
                         state={this.state.state}
                     />
                     <PlaceholdersPortal
-                        portalId={"PlaceholdersPortal"}
-                        openedPortal={this.state.openedPortal}
                         getPosition={this.getTextCursorPosition}
+                        openedPortal={this.state.openedPortal}
+                        portalId={"PlaceholdersPortal"}
                         setOpenedPortal={this.setOpenedPortal}
                         state={this.state.state}
                     />
@@ -1257,8 +1260,8 @@ class FluxNotesEditor extends React.Component {
                         contextManager={this.contextManager}
                         contexts={this.state.portalOptions}
                         getPosition={this.getTextCursorPosition}
-                        isOpened={this.state.isPortalOpen}
                         onChange={this.onChange}
+                        openedPortal={this.state.openedPortal}
                         onSelected={this.onPortalSelection}
                         state={this.state.state}
                         trigger={"@"}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -303,7 +303,7 @@ class FluxNotesEditor extends React.Component {
         // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
         const characterToAppend = e.data ? e.data : String.fromCharCode(data.code);
 
-        // if text starts with '<#', insert placeholder
+        // if text starts with '<', insert placeholder
         if (matches.before[0].startsWith("<")) {
             return this.insertPlaceholder(matches.before[0], transform).insertText(characterToAppend);
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -150,19 +150,15 @@ class FluxNotesEditor extends React.Component {
         allNonKeywordShortcuts.forEach((def) => {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(def.id);
             let shortcutNamesList = triggers.map(trigger => `${trigger.name}$`);
-            // console.log(shortcutNamesList)
+            
             if (def.type === 'CreatorBase') {
-                console.log(triggers)
                 const placeHolderList = triggers.map(trigger => `<${trigger.name}>$`);
                 shortcutNamesList = shortcutNamesList.concat(placeHolderList);
-                console.log(shortcutNamesList)
             }
+
             autoReplaceAfters = autoReplaceAfters.concat(shortcutNamesList);
-            console.log(autoReplaceAfters)
         });
         this.autoReplaceBeforeRegExp = new RegExp("(" + autoReplaceAfters.join("|") + ")", 'i');
-        console.log('auto replace before reg exp')
-        console.log(this.autoReplaceBeforeRegExp)
 
         // now add an AutoReplace plugin instance for each shortcut we're supporting as well
         // can switch to the commented out trigger to support non-space characters but need to put
@@ -271,16 +267,22 @@ class FluxNotesEditor extends React.Component {
         return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
     }
 
+    insertPlaceholder = (transform = undefined, placeholderText) => {
+        if (Lang.isUndefined(transform)) {
+            transform = this.state.state.transform();
+        }
+
+        return this.structuredFieldPlugin.transforms.insertPlaceholder(transform, placeholderText);
+    }
+
     autoReplaceTransform(def, transform, e, data, matches) {
         console.log('auto replace transform')
         console.log(def, transform, e, data, matches)
         // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
         const characterToAppend = e.data ? e.data : String.fromCharCode(data.code);
+        // if text starts with '<#', insert placeholder
         if (matches.before[0].startsWith("<#")) {
-            let result = this.structuredFieldPlugin.transforms.insertPlaceholder(transform, matches.before[0]);
-            // console.log("result[0]");
-            // console.log(result[0]);
-            return result[0].collapseToStartOfNextText().focus().insertText(characterToAppend);
+            return this.insertPlaceholder(transform, matches.before[0]).insertText(characterToAppend);
         }
         return this.insertShortcut(def, matches.before[0], "", transform).insertText(characterToAppend);
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -164,7 +164,7 @@ class FluxNotesEditor extends React.Component {
 
         // now add an AutoReplace plugin instance for each shortcut we're supporting as well
         // can switch to the commented out trigger to support non-space characters but need to put
-        // character used instead of always space when inserting the structured field. 
+        // character used instead of always space when inserting the structured field.
         this.plugins.push(AutoReplace({
             "trigger": /[\s\r\n.!?;,)}\]]/,
             // "trigger": 'space',
@@ -217,40 +217,41 @@ class FluxNotesEditor extends React.Component {
 
     suggestionFunction(initialChar, text) {
         if (Lang.isUndefined(text)) return [];
-        let shortcuts = this.contextManager.getCurrentlyValidShortcuts(this.props.shortcutManager);
-        let suggestionsShortcuts = [];
+
+        const { shortcutManager } = this.props;
+        const shortcuts = this.contextManager.getCurrentlyValidShortcuts(shortcutManager);
+        const suggestionsShortcuts = [];
         const textLowercase = text.toLowerCase();
-        
+
         shortcuts.forEach((shortcut) => {
-            //const triggers = shortcut.getStringTriggers();
-            const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut);
+            const triggers = shortcutManager.getTriggersForShortcut(shortcut);
             triggers.forEach((trigger) => {
                 const triggerNoPrefix = trigger.name.substring(1);
                 if (trigger.name.substring(0, 1) === initialChar && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
                     suggestionsShortcuts.push({
-                        "key": triggerNoPrefix,
-                        "value": trigger,
-                        "suggestion": triggerNoPrefix,
+                        key: triggerNoPrefix,
+                        value: trigger,
+                        suggestion: triggerNoPrefix,
                     });
                 }
             });
         });
-        const placeHolderShortcuts = this.props.shortcutManager.getAllPlaceholderShortcuts();
-        
+        const placeHolderShortcuts = shortcutManager.getAllPlaceholderShortcuts();
+
         placeHolderShortcuts.forEach((shortcut) => {
-            const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut.id);
+            const triggers = shortcutManager.getTriggersForShortcut(shortcut.id);
             triggers.forEach((trigger) => {
                 const triggerNoPrefix = trigger.name.substring(1);
-                if (initialChar === "<" && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
+                if (initialChar === '<' && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
                     suggestionsShortcuts.push({
-                        "key": triggerNoPrefix,
-                        "value": `${initialChar}${triggerNoPrefix}>`,
-                        "suggestion": triggerNoPrefix,
+                        key: triggerNoPrefix,
+                        value: `${initialChar}${triggerNoPrefix}>`,
+                        suggestion: triggerNoPrefix,
                     });
                 }
             });
         });
-        
+
         return suggestionsShortcuts.slice(0, 10);
     }
 
@@ -267,9 +268,9 @@ class FluxNotesEditor extends React.Component {
     }
 
     choseSuggestedPlaceholder(suggestion) {
-        const {state} = this.state;
-        
-        const transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), "<");
+        const { state } = this.state;
+
+        const transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), '<');
         return this.insertPlaceholder(suggestion.value, transformBeforeInsert).apply();
     }
 
@@ -859,11 +860,13 @@ class FluxNotesEditor extends React.Component {
             let result = this.insertPlainText(transform, text.substring(0, returnIndex));
             result = this.insertNewLine(result);
             return this.insertPlainText(result, text.substring(returnIndex + 1));
-        } else if (divReturnIndex >= 0) {
+        }
+        if (divReturnIndex >= 0) {
             let result = this.insertPlainText(transform, text.substring(0, divReturnIndex));
             result = this.insertNewLine(result);
             return this.insertPlainText(result, text.substring(divReturnIndex + 6)); // cuts off </div>
-        } else if (placeholderStartIndex >= 0) {
+        }
+        if (placeholderStartIndex >= 0) {
             const placeholderEndIndex = text.indexOf('>', placeholderStartIndex);
             const placeholderText = text.slice(placeholderStartIndex, placeholderEndIndex + 1);
 
@@ -876,7 +879,7 @@ class FluxNotesEditor extends React.Component {
 
         this.insertTextWithStyles(transform, text);
         // FIXME: Need a trailing character for replacing keywords -- insert temporarily and then delete
-        transform.insertText(' ')
+        transform.insertText(' ');
         const [newTransform,] = this.singleHashtagKeywordStructuredFieldPlugin.utils.replaceAllRelevantKeywordsInBlock(transform.state.anchorBlock, transform, transform.state)
         return newTransform.deleteBackward(1).focus();
     }
@@ -885,7 +888,6 @@ class FluxNotesEditor extends React.Component {
      * Handle updates when we have a new insert text with structured phrase
      */
     insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true, shouldPortalOpen = true) => {
-        let state;
         const currentState = this.state.state;
 
         let transform = (currentTransform) ? currentTransform : currentState.transform();
@@ -939,11 +941,11 @@ class FluxNotesEditor extends React.Component {
             });
         }
         if (!Lang.isUndefined(remainder) && remainder.length > 0) {
-                transform = this.insertPlainText(transform, remainder);
+            transform = this.insertPlainText(transform, remainder);
         }
 
-        state = transform.apply();
-        this.setState({state: state});
+        const state = transform.apply();
+        this.setState({ state });
     }
 
     /**
@@ -1340,7 +1342,7 @@ FluxNotesEditor.propTypes = {
     updateLocalDocumentText: PropTypes.func.isRequired,
     updateSelectedNote: PropTypes.func.isRequired,
     updateNoteAssistantMode: PropTypes.func.isRequired,
-    updateContextTrayItemToInsert: PropTypes.func.isRequired
-}
+    updateContextTrayItemToInsert: PropTypes.func.isRequired,
+};
 
 export default FluxNotesEditor;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -233,7 +233,7 @@ class FluxNotesEditor extends React.Component {
                 }
             });
         });
-        const placeHolderShortcuts = this.props.shortcutManager.getAllCreatorBaseShortcutsWithTriggers();
+        const placeHolderShortcuts = this.props.shortcutManager.getAllPlaceholderShortcuts();
         
         placeHolderShortcuts.forEach((shortcut) => {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut.id);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -128,7 +128,7 @@ class FluxNotesEditor extends React.Component {
             trigger: '@',
         });
         this.suggestionsPluginPlaceholders = SuggestionsPlugin({
-            capture: /<([\w\s\-,?>#]*)/,
+            capture: /<([\w\s\-,?>]*)/,
             onEnter: this.choseSuggestedPlaceholder.bind(this),
             suggestions: this.suggestionFunction.bind(this, '<'),
             trigger: '<',
@@ -239,10 +239,10 @@ class FluxNotesEditor extends React.Component {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut.id);
             triggers.forEach((trigger) => {
                 const triggerNoPrefix = trigger.name.substring(1);
-                if (initialChar === "<" && text.substring(0, 1) === "#" && triggerNoPrefix.toLowerCase().includes(textLowercase.substring(1))) {
+                if (initialChar === "<" && triggerNoPrefix.toLowerCase().includes(textLowercase.substring(1))) {
                     suggestionsShortcuts.push({
                         "key": triggerNoPrefix,
-                        "value": `${initialChar}#${triggerNoPrefix}>`,
+                        "value": `${initialChar}${triggerNoPrefix}>`,
                         "suggestion": triggerNoPrefix,
                     });
                 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -929,7 +929,7 @@ class FluxNotesEditor extends React.Component {
             });
         }
         if (!Lang.isUndefined(remainder) && remainder.length > 0) {
-            if (remainder.startsWith("<") && remainder.endsWith(">")) {
+            if (this.placeholderCheck(remainder)) {
                 transform = this.insertPlaceholder(remainder, transform);
             } else {
                 transform = this.insertPlainText(transform, remainder);
@@ -1028,6 +1028,28 @@ class FluxNotesEditor extends React.Component {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut);
             return triggers.some((trigger) => {
                 return trigger.name.toLowerCase() === shortcutTrigger.toLowerCase();
+            });
+        });
+    }
+
+    /**
+     *  Check if text is a placeholder
+     *  text should begin with '<' and end with '>'
+     *  text within the brackets should match text from placeholder shortcuts
+     */
+    placeholderCheck = (text) => {
+        const { shortcutManager } = this.props;
+
+        if (!text.startsWith("<") || !text.endsWith(">")) return false;
+        const placeholderShortcuts = shortcutManager.getAllPlaceholderShortcuts();
+        const remainderText = text.slice(1, -1).toLowerCase();
+
+        return placeholderShortcuts.some((placeholderShortcut) => {
+            const triggers = shortcutManager.getTriggersForShortcut(placeholderShortcut.id);
+
+            return triggers.some((trigger) => {
+                const triggerNoPrefix = trigger.name.slice(1);
+                return triggerNoPrefix.toLowerCase() === remainderText;
             });
         });
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -116,19 +116,19 @@ class FluxNotesEditor extends React.Component {
 
         // setup suggestions plugin (autocomplete)
         this.suggestionsPluginCreators = SuggestionsPlugin({
-            capture: /#([\w\s\-,?]*)/,
+            capture: /#([\w\s\-,]*)/,
             onEnter: this.choseSuggestedShortcut.bind(this),
             suggestions: this.suggestionFunction.bind(this, '#'),
             trigger: '#',
         });
         this.suggestionsPluginInserters = SuggestionsPlugin({
-            capture: /@([\w\s\-,?]*)/,
+            capture: /@([\w\s\-,]*)/,
             onEnter: this.choseSuggestedShortcut.bind(this),
             suggestions: this.suggestionFunction.bind(this, '@'),
             trigger: '@',
         });
         this.suggestionsPluginPlaceholders = SuggestionsPlugin({
-            capture: /<([\w\s\-,?>]*)/,
+            capture: /<([\w\s\-,>]*)/,
             onEnter: this.choseSuggestedPlaceholder.bind(this),
             suggestions: this.suggestionFunction.bind(this, '<'),
             trigger: '<',
@@ -224,7 +224,7 @@ class FluxNotesEditor extends React.Component {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut);
             triggers.forEach((trigger) => {
                 const triggerNoPrefix = trigger.name.substring(1);
-                if (trigger.name.substring(0, 1) === initialChar && triggerNoPrefix.toLowerCase().includes(textLowercase) && this.state.openedPortal !== "PlaceholdersPortal") {
+                if (trigger.name.substring(0, 1) === initialChar && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
                     suggestionsShortcuts.push({
                         "key": triggerNoPrefix,
                         "value": trigger,
@@ -239,7 +239,7 @@ class FluxNotesEditor extends React.Component {
             const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut.id);
             triggers.forEach((trigger) => {
                 const triggerNoPrefix = trigger.name.substring(1);
-                if (initialChar === "<" && triggerNoPrefix.toLowerCase().includes(textLowercase.substring(1))) {
+                if (initialChar === "<" && triggerNoPrefix.toLowerCase().includes(textLowercase)) {
                     suggestionsShortcuts.push({
                         "key": triggerNoPrefix,
                         "value": `${initialChar}${triggerNoPrefix}>`,

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -6,6 +6,7 @@ import getWindow from 'get-window';
 function createOpts(opts) {
     opts = opts || {};
     opts.typeStructuredField = opts.typeStructuredField || 'structured_field';
+    opts.typePlaceholder = opts.typePlaceholder || 'placeholder';
 	return opts;
 }
 
@@ -49,37 +50,45 @@ function StructuredFieldPlugin(opts) {
     }
 
     const schema = {
-		nodes: {
-			structured_field:      props => {
-				let shortcut = props.node.get('data').get('shortcut');
-				return <span contentEditable={false} className='structured-field' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
-			},
-		},
-		rules: [
-			{
-				match: (node) => {
-					return node.kind === 'block' && node.type === 'inline'
-				},
-				render: (props) => {
-					return (
-						<span {...props.attributes} style={{ position: 'relative', width:'100%', height:'100%'}}>
-							{props.children}
-							{props.editor.props.placeholder
-								? <Slate.Placeholder
-									className={props.editor.props.placeholderClassName}
-									node={props.node}
-									parent={props.state.document}
-									state={props.state}
-									style={{position: 'relative',top:'-18px',width:'100%', height:'100%',opacity:'0.333',...props.editor.props.placeholderStyle}}
-								  >{props.editor.props.placeholder}
-								  </Slate.Placeholder>
-								: null}
-						</span>
-					);
-				}
-			}
-		]
-	};
+        nodes: {
+            structured_field: props => {
+                let shortcut = props.node.get('data').get('shortcut');
+                return <span contentEditable={false} className='structured-field' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+            },
+            placeholder: props => {
+                console.log('placeholder props')
+                console.log(props)
+                console.log(props.node.get('data').get('text'))
+                console.log(props.node.data.text)
+                const placeholderText = props.node.get('data').get('text');
+                return <span contentEditable={false} className='placeholder'>{placeholderText}</span>;
+            },
+        },
+        rules: [
+            {
+                match: (node) => {
+                    return node.kind === 'block' && node.type === 'inline'
+                },
+                render: (props) => {
+                    return (
+                        <span {...props.attributes} style={{ position: 'relative', width: '100%', height: '100%' }}>
+                            {props.children}
+                            {props.editor.props.placeholder
+                                ? <Slate.Placeholder
+                                    className={props.editor.props.placeholderClassName}
+                                    node={props.node}
+                                    parent={props.state.document}
+                                    state={props.state}
+                                    style={{ position: 'relative', top: '-18px', width: '100%', height: '100%', opacity: '0.333', ...props.editor.props.placeholderStyle }}
+                                >{props.editor.props.placeholder}
+                                </Slate.Placeholder>
+                                : null}
+                        </span>
+                    );
+                }
+            }
+        ]
+    };
 
     function convertSlateNodesToText(nodes) {
         let result = '';
@@ -115,6 +124,8 @@ function StructuredFieldPlugin(opts) {
             } else if (node.type === 'structured_field') {
                 let shortcut = node.data.shortcut;
                 result += shortcut.getResultText();
+            } else if (node.type === 'placeholder') {
+                result += node.data.text;
             } else if (node.type === 'bulleted-list') {
                 result += `<ul>${convertSlateNodesToText(node.nodes)}</ul>`;
             } else if (node.type === 'numbered-list') {
@@ -285,7 +296,8 @@ function StructuredFieldPlugin(opts) {
         },
 
         transforms: {
-            insertStructuredField:     	insertStructuredField.bind(null, opts)
+            insertStructuredField:     	insertStructuredField.bind(null, opts),
+            insertPlaceholder: insertPlaceholder.bind(null, opts),
         }
     };
 }
@@ -338,4 +350,33 @@ function createStructuredField(opts, shortcut) {
 	return sf;
 }
 
-export default StructuredFieldPlugin
+function insertPlaceholder(opts, transform, text) {
+    const { state } = transform;
+    if (!state.selection.startKey) return false;
+
+    // Create the placeholder node
+    const placeholder = createPlaceholder(opts, text);
+
+    if (placeholder.kind === 'block') {
+        return [transform.insertBlock(placeholder)];
+    } else {
+        return [transform.insertInline(placeholder)];
+    }
+}
+
+function createPlaceholder(opts, text) {
+    const nodes = [];
+    const properties = {
+        type: opts.typePlaceholder,
+        nodes: nodes,
+        isVoid: true,
+        data: {
+            text,
+        }
+    };
+    const placeholder = Slate.Inline.create(properties);
+
+    return placeholder;
+}
+
+export default StructuredFieldPlugin;

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -56,10 +56,6 @@ function StructuredFieldPlugin(opts) {
                 return <span contentEditable={false} className='structured-field' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
             },
             placeholder: props => {
-                console.log('placeholder props')
-                console.log(props)
-                console.log(props.node.get('data').get('text'))
-                console.log(props.node.data.text)
                 const placeholderText = props.node.get('data').get('text');
                 return <span contentEditable={false} className='placeholder'>{placeholderText}</span>;
             },

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -108,8 +108,11 @@ class ShortcutManager {
         return this.shortcutDefinitions.filter((s) => s.keywords !== undefined);
     }
 
-    getAllCreatorBaseShortcutsWithTriggers() {
-        return this.getAllShortcutsWithTriggers().filter((s) => s.type === "CreatorBase");
+    getAllPlaceholderShortcuts() {
+        console.log(this.shortcutDefinitions)
+        return this.shortcutDefinitions.filter((s) => {
+            return s.type === "CreatorBase" || s.type === "SingleHashtagKeyword" || s.type === "UpdaterBase";
+        });
     }
     
     getAllStringTriggers() {

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -107,6 +107,10 @@ class ShortcutManager {
     getAllShortcutsWithKeywords() {
         return this.shortcutDefinitions.filter((s) => s.keywords !== undefined);
     }
+
+    getAllCreatorBaseShortcutsWithTriggers() {
+        return this.getAllShortcutsWithTriggers().filter((s) => s.type === "CreatorBase");
+    }
     
     getAllStringTriggers() {
         return Object.keys(this.shortcutMap);

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -109,7 +109,6 @@ class ShortcutManager {
     }
 
     getAllPlaceholderShortcuts() {
-        console.log(this.shortcutDefinitions)
         return this.shortcutDefinitions.filter((s) => {
             return s.type === "CreatorBase" || s.type === "SingleHashtagKeyword" || s.type === "UpdaterBase";
         });


### PR DESCRIPTION
Addresses JIRA-1173.

- Added functionality to insert placeholders into editor.
    -  CreatorBase, UpdaterBase, and SingleHashtagKeyword shortcuts are allowed to be inserted as placeholders.
    -  Placeholders use `<` as the trigger.
- Added a Placeholder view to the context tray so users can insert placeholders from context tray.
- Added placeholders to suggestion and autoreplace functions.
- Added placeholder type to structuredfieldplugin.

JIRA-1183 will add a new mode to replace placeholders in the note.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
