### PR TITLE
Selection fix slate upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,11 @@
     "redux-thunk": "^2.2.0",
     "run-script-os": "1.0.2",
     "shr_rest_client": "^0.0.6",
-    "slate": "0.20.2",
-    "slate-auto-replace": "0.5.0",
+    "slate": "^0.34.5",
+    "slate-auto-replace": "^0.9.1",
+    "slate-dev-environment": "^0.1.2",
+    "slate-plain-serializer": "^0.5.20",
+    "slate-react": "^0.13.2",
     "sync-request": "^4.1.0"
   },
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/logos/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/logos/favicon-16x16.png">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i" rel="stylesheet">
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 
     <title>Flux Notes - Powered by SHR</title>
   </head>

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -61,7 +61,6 @@ export class FullApp extends Component {
             clinicalEvent: "pre-encounter",
             condition: null,
             contextManager: this.contextManager,
-            documentText: "",
             errors: [],
             layout: "",
             isNoteViewerVisible: false,
@@ -157,10 +156,6 @@ export class FullApp extends Component {
         this.setFullAppState('condition', condition)
     }
 
-    setDocumentText = (documentText) => {
-        this.setFullAppState('documentText', documentText);
-    }
-
     setNoteViewerVisible = (value) => {
         this.setFullAppState('isNoteViewerVisible', value);
     }
@@ -221,10 +216,6 @@ export class FullApp extends Component {
         this.setState({
             openClinicalNote: openClinicalNote
         });
-    }
-
-    setDocumentTextWithCallback = (documentText, callback) => {
-        this.setFullAppStateWithCallback({ documentText }, callback);
     }
 
     openReferencedNote = (item, arrayIndex = -1) => {
@@ -310,8 +301,6 @@ export class FullApp extends Component {
                             onContextUpdate={this.onContextUpdate}
                             possibleClinicalEvents={this.possibleClinicalEvents}
                             searchSelectedItem={this.state.searchSelectedItem}
-                            setDocumentText={this.setDocumentText}
-                            setDocumentTextWithCallback={this.setDocumentTextWithCallback}
                             setNoteClosed={this.setNoteClosed}
                             setNoteViewerEditable={this.setNoteViewerEditable}
                             setNoteViewerVisible={this.setNoteViewerVisible}

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -182,7 +182,6 @@ export default class ClinicianDashboard extends Component {
                         contextManager={this.props.contextManager}
                         currentViewMode={this.props.appState.clinicalEvent}
                         dataAccess={this.props.dataAccess}
-                        documentText={this.props.appState.documentText}
                         errors={this.props.appState.errors}
                         handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                         isNoteViewerEditable={isNoteViewerEditable}
@@ -194,8 +193,6 @@ export default class ClinicianDashboard extends Component {
                         openClinicalNote={this.props.appState.openClinicalNote}
                         patient={this.props.appState.patient}
                         searchSelectedItem={this.props.searchSelectedItem}
-                        setDocumentText={this.props.setDocumentText}
-                        setDocumentTextWithCallback={this.props.setDocumentTextWithCallback}
                         setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                         setLayout={this.props.setLayout}
                         setNoteClosed={this.props.setNoteClosed}
@@ -228,7 +225,6 @@ ClinicianDashboard.proptypes = {
     onContextUpdate: PropTypes.func.isRequired,
     possibleClinicalEvents: PropTypes.array.isRequired,
     searchSelectedItem: PropTypes.object,
-    setDocumentTextWithCallback: PropTypes.func.isRequired,
     setForceRefresh: PropTypes.func.isRequired,
     setFullAppStateWithCallback: PropTypes.func.isRequired,
     setLayout: PropTypes.func.isRequired,

--- a/src/index.js
+++ b/src/index.js
@@ -26,3 +26,17 @@ render(
   </Provider>,
   target
 );
+if (!Element.prototype.matches)	
+    Element.prototype.matches = Element.prototype.msMatchesSelector || 	
+                                Element.prototype.webkitMatchesSelector;	
+	
+if (!Element.prototype.closest)	
+    Element.prototype.closest = function(s) {	
+        var el = this;	
+        if (!document.documentElement.contains(el)) return null;	
+        do {	
+            if (el.matches(s)) return el;	
+            el = el.parentElement || el.parentNode;	
+        } while (el !== null && el.nodeType === 1); 	
+        return null;	
+    }; 

--- a/src/lib/slate-suggestions-dist/index.js
+++ b/src/lib/slate-suggestions-dist/index.js
@@ -6,47 +6,48 @@ import {
     ENTER_KEY
 } from './constants'
 
-function matchTrigger(state, trigger) {
-    const currentNode = state.blocks.first()
+function matchTrigger(editorValue, trigger) {
+    const currentNode = editorValue.blocks.first()
 
-    return state.isFocused && trigger.test(currentNode.text)
+    return editorValue.isFocused && trigger.test(currentNode.text)
 }
 
 function SuggestionsPlugin(opts) {
     const capture = opts.capture
     const callback = {}
 
-    function onKeyDown(e, data, state, editor) {
-        const keyCode = e.keyCode
+    function onKeyDown(event, change, editor) {
+        const keyCode = event.keyCode
         callback.editor = editor
 
-        if (matchTrigger(state, capture)) {
+        if (matchTrigger(change.value, capture)) {
             // Prevent default up and down arrow key press when portal is open
             if ((keyCode === UP_ARROW_KEY || keyCode === DOWN_ARROW_KEY)) {
-                e.preventDefault()
+                event.preventDefault()
             }
 
             // Prevent default return/enter key press when portal is open
             if (keyCode === ENTER_KEY) {
-                e.preventDefault()
+                event.preventDefault()
                 // Handle enter
                 if (callback.onEnter && callback.suggestion !== undefined) {
-                    const newEditorState =  callback.onEnter(callback.suggestion)
+                    const newEditorState =  callback.onEnter(change, callback.suggestion)
 
                     // Close portal -- resets suggestion to default, so must be done after onEnter
                     if (callback.closePortal) {
                         callback.closePortal()
                     }
-                    return newEditorState
+                    // return newEditorState
                 } else { 
                     // Close portal
                     if (callback.closePortal) {
                         callback.closePortal()
                     }
                 }
+                return true
             } else {
                 if (callback.onKeyDown) {
-                    callback.onKeyDown(keyCode, data);
+                    callback.onKeyDown(event);
                 }
             }
         }

--- a/src/lib/slate-suggestions-dist/suggestion-portal.js
+++ b/src/lib/slate-suggestions-dist/suggestion-portal.js
@@ -73,7 +73,11 @@ class SuggestionPortal extends React.Component {
     }
 
     // Use new key-presses to update the current suggestion
-    onKeyDown = (keyCode, data) => {
+    onKeyDown = (event) => {
+        // Adjust position every keypress
+        this.adjustPosition()
+        // Handles browsers that use either keyCode or which, and handles case where which === 0 and triggers false neg in 1st case.
+        const keyCode = event.which || event.keyCode || 0;
         if (keyCode === DOWN_ARROW_KEY || keyCode === UP_ARROW_KEY) {
             const height = this.refs.suggestionPortal.offsetHeight;
             const numberOfElementsVisible = Math.floor(height/32);
@@ -88,7 +92,7 @@ class SuggestionPortal extends React.Component {
             this.refs.suggestionPortal.scrollTop = (newIndex - (numberOfElementsVisible - 1)) * 32 + 10;
         } else {
             // Else, determine character and update suggestions accordingly
-            const newFilteredSuggestions  = this.getFilteredSuggestions(data);
+            const newFilteredSuggestions  = this.getFilteredSuggestions(event);
             this.setSelectedIndex(0)
             if (typeof newFilteredSuggestions.then === 'function') {
                 newFilteredSuggestions.then(newFilteredSuggestions => {
@@ -147,7 +151,7 @@ class SuggestionPortal extends React.Component {
     }
 
     // Filter suggestions based on incoming data 
-    getFilteredSuggestions = (incomingData) => {
+    getFilteredSuggestions = (event) => {
         const { suggestions, state, capture, resultSize, trigger } = this.props
 
         if (!state.selection.anchorKey) return [];
@@ -156,9 +160,9 @@ class SuggestionPortal extends React.Component {
 
         let nextChar = "";
         // If there is incoming data from a keydown, include that as next char
-        if (incomingData !== undefined) { 
-            nextChar = this.convertSlateDataObjectToCharacter(incomingData);
-            if (nextChar == null) return [];
+        if (event !== undefined) { 
+            nextChar = this.convertEventToCharacter(event);
+            if (nextChar === null) return [];
         }
 
         // Put together newText based on nextCharacter; change offset if char is -
@@ -202,9 +206,9 @@ class SuggestionPortal extends React.Component {
     }
 
     // Turn event data into characters to match against
-    convertSlateDataObjectToCharacter = (data) => {
-        const code = data.code;
-        const isShift = data.isShift;
+    convertEventToCharacter = (event) => {
+        const code = event.which || event.keyCode || 0;
+        const isShift = event.shiftKey;
         if (code === 8) return "backspace";
         if (code < 48) return null;
         if (code < 58) { // number keys

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -410,35 +410,24 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (change) => {
-        // FIXME: Just used document.nodes instead of creating a whole doc selection
-        const editorValue = change.value;
-        let indexOfLastNode = editorValue.toJSON().document.nodes.length - 1;
-        let endOfNoteKey = editorValue.toJSON().document.nodes[indexOfLastNode].key;
-        let endOfNoteOffset = 0;
-        // If the editor has no structured phrases, use the number of characters in the first 'node'
-        if (Lang.isEqual(indexOfLastNode, 0) && !Lang.isUndefined(editorValue.toJSON().document.nodes["0"].nodes["0"].characters)) {
-            endOfNoteOffset = editorValue.toJSON().document.nodes["0"].nodes["0"].characters.length;
-        } else {
-            if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)) {
-                endOfNoteOffset = this.props.documentText.length;
-            }
-        }
-
-        // 'copy' the text every time into the note
-        // Need to artificially set selection to the whole document
-        // editorValue.selection only has a getter for these values so create a new object
-        const entireNote = {
-            startKey: "0",
-            startOffset: 0,
-            endKey: endOfNoteKey,
-            endOffset: endOfNoteOffset
-        };
-        const documentText = this.structuredFieldPlugin.convertToText(editorValue, entireNote);
-        console.log('documentText')
-        console.log(documentText)
-        this.props.saveNoteOnChange(documentText);
+        let editorValue = change.value;
+        let documentText = this.getNoteText(editorValue);
+        // NOTE: Removing this function call allows selection to happen in IE.
+        // this.props.updateLocalDocumentText(documentText);
+        // NOTE: Will need to add in adjustActiveContexts - which will also break selection in IE.
 
         this.setState({ editorValue });
+    }
+
+    getNoteText = (change) => {
+        const documentText = this.structuredFieldPlugin.convertToText(change);
+        return documentText;
+    }
+
+    closeNote = () => {
+        const documentText = this.getNoteText(this.state.editorValue);
+        this.props.saveNote(documentText);
+        this.props.closeNote();
     }
 
     onFocus = () => {
@@ -1137,7 +1126,7 @@ class FluxNotesEditor extends React.Component {
                                     raised 
                                     className="close-note-btn"
                                     disabled={this.context_disabled}
-                                    onClick={this.props.closeNote}
+                                    onClick={this.closeNote}
                                     style={{
                                         float: "right",
                                         lineHeight: "2.1rem"

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import Slate from '../lib/slate';
+import Plain from 'slate-plain-serializer'
+import { Editor, findDOMNode } from 'slate-react'
 import Moment from 'moment'
 import Lang from 'lodash';
 import FontAwesome from 'react-fontawesome';
@@ -23,22 +25,7 @@ import NoteParser from '../noteparser/NoteParser';
 import './FluxNotesEditor.css';
 
 // This forces the initial block to be inline instead of a paragraph. When insert structured field, prevents adding new lines
-const initialState = Slate.Plain.deserialize('');
-const schema = {
-    nodes: {
-        paragraph: props => <p {...props.attributes}>{props.children}</p>,
-        heading: props => <h1 {...props.attributes}>{props.children}</h1>,
-        'bulleted-list-item': props => <li {...props.attributes}>{props.children}</li>,
-        'numbered-list-item': props => <li {...props.attributes}>{props.children}</li>,
-        'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
-        'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
-    },
-    marks: {
-        bold: (props) => <strong>{props.children}</strong>,
-        italic: (props) => <em>{props.children}</em>,
-        underlined: (props) => <u>{props.children}</u>,
-    }
-};
+const initialState = Plain.deserialize('');
 
 const structuredFieldTypes = [
     {
@@ -82,7 +69,6 @@ class FluxNotesEditor extends React.Component {
 
         this.selectingForShortcut = null;
         this.onChange = this.onChange.bind(this);
-        this.onSelectionChange = this.onSelectionChange.bind(this);
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
         this.plugins = [];
@@ -108,7 +94,7 @@ class FluxNotesEditor extends React.Component {
             shortcutManager: this.props.shortcutManager,
             structuredFieldMapManager: this.structuredFieldMapManager,
             createShortcut: this.props.newCurrentShortcut,
-            insertStructuredFieldTransform: this.insertStructuredFieldTransform,
+            insertStructuredFieldChange: this.insertStructuredFieldChange,
         };
 
         this.structuredFieldPlugin = StructuredFieldPlugin(structuredFieldPluginOptions);
@@ -153,7 +139,7 @@ class FluxNotesEditor extends React.Component {
             "trigger": /[\s\r\n.!?;,)}\]]/,
             // "trigger": 'space',
             "before": this.autoReplaceBeforeRegExp,
-            "transform": this.autoReplaceTransform.bind(this, null)
+            "transform": this.autoReplaceChange.bind(this, null)
         }));
 
         // let's see if we have any regular expression shortcuts
@@ -170,16 +156,57 @@ class FluxNotesEditor extends React.Component {
                     "trigger": /[\s\r\n.!?;,)}\]]/,
                     // "trigger": 'space',
                     "before": triggerRegExpModified,
-                    "transform": this.autoReplaceTransform.bind(this, def)
+                    "transform": this.autoReplaceChange.bind(this, def)
                 }));
             }
         });
+    }
+    
+    renderNode = (props) => {
+        switch (props.node.type) {
+            case "paragraph": 
+                return <p {...props.attributes}>{props.children}</p>
+            case "heading": 
+                return <h1 {...props.attributes}>{props.children}</h1>
+            case 'bulleted-list-item': 
+                return <li {...props.attributes}>{props.children}</li>
+            case 'numbered-list-item': 
+                return <li {...props.attributes}>{props.children}</li>
+            case 'bulleted-list': 
+                return <ul {...props.attributes}>{props.children}</ul>
+            case 'numbered-list': 
+                return <ol {...props.attributes}>{props.children}</ol>
+            case this.structuredFieldPlugin.helpers.getStructuredFieldType(): 
+                const StructuredField = this.structuredFieldPlugin.components.StructuredField;
+                return <StructuredField {...props}/>
+            case 'line': 
+                // We don't want any special styling for lines
+                return null 
+            default: 
+                console.error(`trying to render node of type ${props.node.type}; we don't recognize that type`)
+                return null;
+        }
+    }
+    
+    renderMark = (props) => {   
+        const { mark } = props
+        switch (mark.type) {
+            case "bold":
+                return <strong>{props.children}</strong>
+            case "italic":
+                return <em>{props.children}</em>
+            case "underlined":
+                return <u>{props.children}</u>
+            default: 
+                console.error(`trying to render mark of type ${mark.type}; type not recognized`)
+                return null;
+        }
     }
 
     // Reset the editor to the initial state when the app is first constructed.
     resetEditorState() {
         this.state = {
-            state: initialState,
+            editorValue: initialState,
             isPortalOpen: false,
             portalOptions: null,
         };
@@ -222,45 +249,47 @@ class FluxNotesEditor extends React.Component {
     }
 
     choseSuggestedShortcut(suggestion) {
-        const {state} = this.state;
+        const {editorValue} = this.state;
         const shortcut = this.props.newCurrentShortcut(null, suggestion.value.name);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
-            return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
+            return this.openPortalToSelectValueForShortcut(shortcut, true, editorValue.change()).apply();
         } else {
-            const transformBeforeInsert = this.suggestionDeleteExistingTransform(state.transform(), shortcut.getPrefixCharacter());
-            const transformAfterInsert = this.insertStructuredFieldTransform(transformBeforeInsert, shortcut).collapseToStartOfNextText().focus();
-            return transformAfterInsert.apply();
+            const changeBeforeInsert = this.suggestionDeleteExistingChange(editorValue.change(), shortcut.getPrefixCharacter());
+            const changeAfterInsert = this.insertStructuredFieldChange(changeBeforeInsert, shortcut).collapseToStartOfNextText().focus();
+            return changeAfterInsert.apply();
         }
     }
 
-    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, shouldPortalOpen = true) => {
-        if (Lang.isUndefined(transform)) {
-            transform = this.state.state.transform();
+    insertShortcut = (shortcutC, shortcutTrigger, text, change = undefined, updatePatient = true, shouldPortalOpen = true) => {
+        if (Lang.isUndefined(change)) {
+            change = this.state.editorValue.change();
         }
 
         // check if shortcutTrigger is currently valid
         if (!this.shortcutTriggerCheck(shortcutC, shortcutTrigger)) {
-            return this.insertPlainText(transform, shortcutTrigger);
+            return this.insertPlainText(change, shortcutTrigger);
         }
 
         let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, text, updatePatient);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions() && text.length === 0) {
-            return this.openPortalToSelectValueForShortcut(shortcut, false, transform, shouldPortalOpen);
+            return this.openPortalToSelectValueForShortcut(shortcut, false, change, shouldPortalOpen);
         }
-        return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
+        return this.insertStructuredFieldChange(change, shortcut).collapseToStartOfNextText().focus();
     }
 
-    autoReplaceTransform(def, transform, e, data, matches) {
-        // need to use Transform object provided to this method, which AutoReplace .apply()s after return.
-        const characterToAppend = e.data ? e.data : String.fromCharCode(data.code);
-        return this.insertShortcut(def, matches.before[0], "", transform).insertText(characterToAppend);
+    // The change to apply when auto-replacing
+    autoReplaceChange(def, change, e, matches) {
+        // get keycode as a fallback if browser doesn't define e.key
+        const keyCode = e.keyCode || e.which || 0;
+        const characterToAppend = e.key ? e.key : String.fromCharCode(keyCode);
+        return this.insertShortcut(def, matches.before[0], "", change).insertText(characterToAppend);
     }
 
     getTextCursorPosition = () => {
         const positioningUsingSlateNodes = () => { 
             const pos = {};
-            const parentNode = this.state.state.document.getParent(this.state.state.selection.startKey);
-            const el = Slate.findDOMNode(parentNode);
+            const parentNode = this.state.editorValue.document.getParent(this.state.editorValue.selection.startKey);
+            const el = findDOMNode(parentNode);
             const children = el.childNodes;
 
             for (const child of children) {
@@ -289,7 +318,7 @@ class FluxNotesEditor extends React.Component {
         return this.lastPosition;
     }
 
-    openPortalToSelectValueForShortcut(shortcut, needToDelete, transform, shouldPortalOpen = true) {
+    openPortalToSelectValueForShortcut(shortcut, needToDelete, change, shouldPortalOpen = true) {
         // If the portal should not open, insert the plain text trigger instead. Will eventually be replaced.
         if (!shouldPortalOpen) {
             this.setState({
@@ -297,8 +326,8 @@ class FluxNotesEditor extends React.Component {
                 needToDelete: needToDelete,
             });
             this.selectingForShortcut = null;
-            this.insertPlainText(transform, shortcut.initiatingTrigger);
-            return transform.blur();
+            this.insertPlainText(change, shortcut.initiatingTrigger);
+            return change.blur();
         }
         
         let portalOptions = shortcut.getValueSelectionOptions();
@@ -309,12 +338,13 @@ class FluxNotesEditor extends React.Component {
             needToDelete: needToDelete,
         });
         this.selectingForShortcut = shortcut;
-        return transform.blur();
+        return change.blur();
     }
 
     // called from portal when an item is selected (selection is not null) or if portal is closed without
     // selection (selection is null)
-    onPortalSelection = (state, selection) => {
+    // FIXME: we need to retyurn changes not editorValues
+    onPortalSelection = (editorValue, selection) => {
 
         let shortcut = this.selectingForShortcut;
         this.selectingForShortcut = null;
@@ -322,7 +352,7 @@ class FluxNotesEditor extends React.Component {
         if (Lang.isNull(selection)) {
             // Removes the shortcut from its parent
             shortcut.onBeforeDeleted();
-            return state;
+            return editorValue;
         }
 
         shortcut.clearValueSelectionOptions();
@@ -331,26 +361,26 @@ class FluxNotesEditor extends React.Component {
             shortcut.setValueObject(selection.object);
         }
         this.contextManager.contextUpdated();
-        let transform;
+        let change;
         if (this.state.needToDelete) {
-            transform = this.suggestionDeleteExistingTransform(null, shortcut.getPrefixCharacter());
+            change = this.suggestionDeleteExistingChange(null, shortcut.getPrefixCharacter());
         } else {
-            transform = this.state.state.transform();
+            change = this.state.editorValue.change();
         }
-        return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus().apply();
+        return this.insertStructuredFieldChange(change, shortcut).collapseToStartOfNextText().focus().apply();
     }
 
     // consider reusing this method to replace code in choseSuggestedShortcut function
-    suggestionDeleteExistingTransform = (transform = null, prefixCharacter) => {
-        const {state} = this.state;
-        if (Lang.isNull(transform)) {
-            transform = state.transform();
+    suggestionDeleteExistingChange = (change = null, prefixCharacter) => {
+        const {editorValue} = this.state;
+        if (Lang.isNull(change)) {
+            change = editorValue.change();
         }
-        let {anchorText, anchorOffset} = state;
-        let anchorKey = state.anchorBlock.key;
+        let {anchorText, anchorOffset} = editorValue;
+        let anchorKey = editorValue.anchorBlock.key;
         let text = anchorText.text
         if (text.length === 0) {
-            const block = state.document.getPreviousSibling(anchorKey);
+            const block = editorValue.document.getPreviousSibling(anchorKey);
             if (block) {
                 text = block.getFirstText().text;
                 anchorOffset = text.length;
@@ -366,26 +396,27 @@ class FluxNotesEditor extends React.Component {
         // const newText = `${text.substring(0, index.start)}`
         const charactersInStructuredPhrase = (text.length - index.start)
 
-        return transform
+        return change
             .deleteBackward(0)
             .deleteBackward(charactersInStructuredPhrase);
     }
 
-    insertStructuredFieldTransform = (transform, shortcut) => {
-        if (Lang.isNull(shortcut)) return transform.focus();
-        let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
+    insertStructuredFieldChange = (change, shortcut) => {
+        if (Lang.isNull(shortcut)) return change.focus();
+        let result = this.structuredFieldPlugin.changes.insertStructuredField(change, shortcut);
         // console.log("result[0]");
         // console.log(result[0]);
         return result[0];
     }
 
-    onChange = (state) => {
-        let indexOfLastNode = state.toJSON().document.nodes.length - 1;
-        let endOfNoteKey = state.toJSON().document.nodes[indexOfLastNode].key;
+    onChange = (change) => {
+        const editorValue = change.value;
+        let indexOfLastNode = editorValue.toJSON().document.nodes.length - 1;
+        let endOfNoteKey = editorValue.toJSON().document.nodes[indexOfLastNode].key;
         let endOfNoteOffset = 0;
         // If the editor has no structured phrases, use the number of characters in the first 'node'
-        if (Lang.isEqual(indexOfLastNode, 0) && !Lang.isUndefined(state.toJSON().document.nodes["0"].nodes["0"].characters)) {
-            endOfNoteOffset = state.toJSON().document.nodes["0"].nodes["0"].characters.length;
+        if (Lang.isEqual(indexOfLastNode, 0) && !Lang.isUndefined(editorValue.toJSON().document.nodes["0"].nodes["0"].characters)) {
+            endOfNoteOffset = editorValue.toJSON().document.nodes["0"].nodes["0"].characters.length;
         } else {
             if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText)) {
                 endOfNoteOffset = this.props.documentText.length;
@@ -394,27 +425,27 @@ class FluxNotesEditor extends React.Component {
 
         // 'copy' the text every time into the note
         // Need to artificially set selection to the whole document
-        // state.selection only has a getter for these values so create a new object
+        // editorValue.selection only has a getter for these values so create a new object
         const entireNote = {
             startKey: "0",
             startOffset: 0,
             endKey: endOfNoteKey,
             endOffset: endOfNoteOffset
         };
-        const documentText = this.structuredFieldPlugin.convertToText(state, entireNote);
+        const documentText = this.structuredFieldPlugin.convertToText(editorValue, entireNote);
 
         this.props.setDocumentTextWithCallback(documentText, () => {
             // save note after documentText gets set
             this.props.saveNoteOnChange();
         });
 
-        this.setState({ state });
+        this.setState({ editorValue });
     }
 
     onFocus = () => {
-        const state = this.state.state;
-        const selection = state.selection;
-        this.adjustActiveContexts(selection, state);
+        const editorValue = this.state.editorValue;
+        const selection = editorValue.selection;
+        this.adjustActiveContexts(selection, editorValue);
         this.editorHasFocus = true;
     }
 
@@ -434,7 +465,7 @@ class FluxNotesEditor extends React.Component {
             }
         }
         // Create an updated state with the text replaced.
-        var nextState = this.state.state.transform().select({
+        var nextState = this.state.editorValue.change().select({
             anchorKey: data.anchorKey,
             anchorOffset: data.anchorOffset,
             focusKey: data.focusKey,
@@ -444,30 +475,30 @@ class FluxNotesEditor extends React.Component {
         this.insertTextWithStructuredPhrases(data.newText, nextState)
     }
 
-    isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
-        if (Lang.isUndefined(state)) {
-            state = this.state.state;
+    isBlock1BeforeBlock2(key1, offset1, key2, offset2, editorValue) {
+        if (Lang.isUndefined(editorValue)) {
+            editorValue = this.state.editorValue;
         }
         if (Lang.isNull(key1)) {
-            key1 = state.selection.endKey;
+            key1 = editorValue.selection.endKey;
         }
         if (key1 === key2) {
             return offset1 < offset2;
         } else {
-            return state.document.areDescendantsSorted(key1, key2);
+            return editorValue.document.areDescendantsSorted(key1, key2);
         }
     }
 
-    isNodeTypeBetween(key1, key2, typeToFind, state) {
-        if (Lang.isUndefined(state)) {
-            state = this.state.state;
+    isNodeTypeBetween(key1, key2, typeToFind, editorValue) {
+        if (Lang.isUndefined(editorValue)) {
+            editorValue = this.state.editorValue;
         }
         if (Lang.isNull(key1)) {
-            key1 = state.selection.endKey;
+            key1 = editorValue.selection.endKey;
         }
         let beforeKey1 = true;
         let foundTypeBetween = false;
-        state.document.forEachDescendant((n) => {
+        editorValue.document.forEachDescendant((n) => {
             if (beforeKey1) {
                 if (n.key === key1) {
                     beforeKey1 = false;
@@ -485,19 +516,15 @@ class FluxNotesEditor extends React.Component {
         return foundTypeBetween;
     }
 
-    onSelectionChange = (selection, state) => {
-        this.adjustActiveContexts(selection, state);
-    }
-
-    adjustActiveContexts = (selection, state) => {
+    adjustActiveContexts = (selection, editorValue) => {
         this.contextManager.adjustActiveContexts((context) => {
             // return true if context should be active because it's before selection
             // also need to make sure context is in current paragraph or global
-            const isBeforeSelection = this.isBlock1BeforeBlock2(context.getKey(), 0, selection.endKey, selection.endOffset, state);
+            const isBeforeSelection = this.isBlock1BeforeBlock2(context.getKey(), 0, selection.endKey, selection.endOffset, editorValue);
             if (isBeforeSelection) {
                 // need to see if we have a paragraph between them now
                 if (context.isGlobalContext()) return true;
-                return !this.isNodeTypeBetween(context.getKey(), selection.endKey, 'line', state);
+                return !this.isNodeTypeBetween(context.getKey(), selection.endKey, 'line', editorValue);
             }
             return false;
         });
@@ -566,7 +593,7 @@ class FluxNotesEditor extends React.Component {
         // Check if mode is changing from 'pick-list-options-panel' to 'context-tray'
         // This means user either clicked the OK or Cancel button on the modal
         if (this.props.noteAssistantMode === 'pick-list-options-panel' && nextProps.noteAssistantMode === 'context-tray') {
-            this.adjustActiveContexts(this.state.state.selection, this.state.state); 
+            this.adjustActiveContexts(this.state.editorValue.selection, this.state.editorValue); 
             this.props.contextManager.clearNonActiveContexts();
             // User clicked cancel button
             if (nextProps.contextTrayItemToInsert === null) {
@@ -579,12 +606,12 @@ class FluxNotesEditor extends React.Component {
         }
     }
 
-    insertNewLine = (transform) => {
-        return transform
+    insertNewLine = (change) => {
+        return change
             .splitBlock();
     }
 
-    insertTextWithStyles = (transform, text) => {
+    insertTextWithStyles = (change, text) => {
         let boldStartIndex = text.indexOf('<strong>');
         let boldEndIndex = text.indexOf('</strong>');
         let italicStartIndex = text.indexOf('<em>');
@@ -605,7 +632,7 @@ class FluxNotesEditor extends React.Component {
             && unorderedListStartIndex === -1 && unorderedListEndIndex === -1
             && orderedListStartIndex === -1 && orderedListEndIndex === -1
             && listItemStartIndex === -1 && listItemEndIndex === -1) {
-            return transform.insertText(text);
+            return change.insertText(text);
         }
 
         // Order the styles to know which to apply next
@@ -627,56 +654,56 @@ class FluxNotesEditor extends React.Component {
         let firstStyle = styleMarkings[styleMarkings.findIndex(a => a.value > -1)];
 
         if (firstStyle.name === 'boldStartIndex' || firstStyle.name === 'boldEndIndex') {
-            this.insertBoldText(transform, text, boldStartIndex, boldEndIndex);
+            this.insertBoldText(change, text, boldStartIndex, boldEndIndex);
         } else if (firstStyle.name === 'italicStartIndex' || firstStyle.name === 'italicEndIndex') {
-            this.insertItalicText(transform, text, italicStartIndex, italicEndIndex);
+            this.insertItalicText(change, text, italicStartIndex, italicEndIndex);
         } else if (firstStyle.name === 'underlinedStartIndex' || firstStyle.name === 'underlinedEndIndex') {
-            this.insertUnderlinedText(transform, text, underlinedStartIndex, underlinedEndIndex);
+            this.insertUnderlinedText(change, text, underlinedStartIndex, underlinedEndIndex);
         } else if (firstStyle.name === 'unorderedListStartIndex') {
-            this.startList(transform, text, unorderedListStartIndex, unorderedListEndIndex, 'bulleted-list');
+            this.startList(change, text, unorderedListStartIndex, unorderedListEndIndex, 'bulleted-list');
         } else if (firstStyle.name === 'unorderedListEndIndex') {
-            this.endList(transform, text, unorderedListStartIndex, unorderedListEndIndex, 'bulleted-list');
+            this.endList(change, text, unorderedListStartIndex, unorderedListEndIndex, 'bulleted-list');
         } else if (firstStyle.name === 'orderedListStartIndex') {
-            this.startList(transform, text, orderedListStartIndex, orderedListEndIndex, 'numbered-list');
+            this.startList(change, text, orderedListStartIndex, orderedListEndIndex, 'numbered-list');
         } else if (firstStyle.name === 'orderedListEndIndex') {
-            this.endList(transform, text, orderedListStartIndex, orderedListEndIndex, 'numbered-list');
+            this.endList(change, text, orderedListStartIndex, orderedListEndIndex, 'numbered-list');
         } else if (firstStyle.name === 'listItemStartIndex' || firstStyle.name === 'listItemEndIndex') {
             const currentList = styleMarkings.find(a => 
                 a.value > -1 &&
                 (a.name === 'orderedListStartIndex' || a.name === 'orderedListEndIndex'
                 || a.name === 'unorderedListStartIndex' || a.name === 'unorderedListEndIndex'))
             if (currentList.name === 'orderedListStartIndex' || currentList.name === 'orderedListEndIndex') {
-                this.insertListItem(transform, text, 'numbered-list');
+                this.insertListItem(change, text, 'numbered-list');
             } else {
-                this.insertListItem(transform, text, 'bulleted-list');
+                this.insertListItem(change, text, 'bulleted-list');
             }
         }
     }
 
-    insertBoldText = (transform, text, startIndex, endIndex) => {
+    insertBoldText = (change, text, startIndex, endIndex) => {
         if (startIndex === -1 && endIndex === -1) {
-            return transform.insertText(text);
+            return change.insertText(text);
         }
-        this.addStyle(transform, text, startIndex, endIndex, 8, 'bold');
+        this.addStyle(change, text, startIndex, endIndex, 8, 'bold');
     }
 
-    insertItalicText = (transform, text, startIndex, endIndex) => {
+    insertItalicText = (change, text, startIndex, endIndex) => {
         if (startIndex === -1 && endIndex === -1) {
-            return transform.insertText(text);
+            return change.insertText(text);
         }
-        this.addStyle(transform, text, startIndex, endIndex, 4, 'italic');
+        this.addStyle(change, text, startIndex, endIndex, 4, 'italic');
     }
 
-    insertUnderlinedText = (transform, text, startIndex, endIndex) => {
+    insertUnderlinedText = (change, text, startIndex, endIndex) => {
         if (startIndex === -1 && endIndex === -1) {
-            return transform.insertText(text);
+            return change.insertText(text);
         }
-        this.addStyle(transform, text, startIndex, endIndex, 3, 'underlined');
+        this.addStyle(change, text, startIndex, endIndex, 3, 'underlined');
     }
 
-    startList = (transform, text, startIndex, endIndex, type) => {
+    startList = (change, text, startIndex, endIndex, type) => {
         if (startIndex === -1 && endIndex === -1) {
-            return transform.insertText(text);
+            return change.insertText(text);
         }
 
         let { calculatedStartIndex, calculatedEndIndex, startOffset, endOffset } = this.getOffsets(text, startIndex, -1, 4);
@@ -686,16 +713,16 @@ class FluxNotesEditor extends React.Component {
         text = beforeListText + listText + afterListText;
 
         if (beforeListText !== '') {
-            transform.insertText(beforeListText);
-            transform.splitBlock();
+            change.insertText(beforeListText);
+            change.splitBlock();
         }
-        transform.wrapBlock(type);
-        this.insertListItem(transform, listText, type);
+        change.wrapBlock(type);
+        this.insertListItem(change, listText, type);
     }
 
-    endList = (transform, text, startIndex, endIndex, type) => {
+    endList = (change, text, startIndex, endIndex, type) => {
         if (startIndex === -1 && endIndex === -1) {
-            return transform.insertText(text);
+            return change.insertText(text);
         }
 
         let { calculatedStartIndex, calculatedEndIndex, startOffset, endOffset } = this.getOffsets(text, -1, endIndex, 4);
@@ -704,14 +731,14 @@ class FluxNotesEditor extends React.Component {
         let afterListText = text.substring(calculatedEndIndex + endOffset);
         text = beforeListText + listText + afterListText;
 
-        transform
+        change
             .setBlock('line')
             .unwrapBlock('bulleted-list')
             .unwrapBlock('numbered-list');
-        this.insertTextWithStyles(transform, afterListText);
+        this.insertTextWithStyles(change, afterListText);
     }
 
-    insertListItem = (transform, listText, type) => {
+    insertListItem = (change, listText, type) => {
         let bullets = [];
         let liStartIndex = listText.indexOf('<li>');
         let liEndIndex = listText.indexOf('</li>');
@@ -738,19 +765,19 @@ class FluxNotesEditor extends React.Component {
             }
         }
 
-        transform.setBlock(type + '-item');
+        change.setBlock(type + '-item');
         for (let i = 0; i < bullets.length; i++) {
-            this.insertTextWithStyles(transform, bullets[i]);
+            this.insertTextWithStyles(change, bullets[i]);
             if (structuredFieldToFollow) {
                 if (i < bullets.length - 1) {
-                    transform.splitBlock();
+                    change.splitBlock();
                 }
             } else {
-                transform.splitBlock();
+                change.splitBlock();
             }
         }
         after += nextListString;
-        this.insertTextWithStyles(transform, after);
+        this.insertTextWithStyles(change, after);
     }
 
     getOffsets = (text, startIndex, endIndex, wordOffset) => {
@@ -781,20 +808,20 @@ class FluxNotesEditor extends React.Component {
         return { calculatedStartIndex: startIndex, calculatedEndIndex: endIndex, startOffset, endOffset };
     }
 
-    addStyle = (transform, text, startIndex, endIndex, wordOffset, type) => {
+    addStyle = (change, text, startIndex, endIndex, wordOffset, type) => {
         let { calculatedStartIndex, calculatedEndIndex, startOffset, endOffset } = this.getOffsets(text, startIndex, endIndex, wordOffset);
 
         let beforeBoldText = text.substring(0, calculatedStartIndex);
         let boldText = text.substring(calculatedStartIndex + startOffset, calculatedEndIndex);
         let afterBoldText = text.substring(calculatedEndIndex + endOffset);
         text = beforeBoldText + boldText + afterBoldText; // Update text to remove <someStyle> </someStyle>
-        transform.insertText(beforeBoldText).toggleMark(type);
-        this.insertTextWithStyles(transform, boldText);
-        transform.toggleMark(type);
-        this.insertTextWithStyles(transform, afterBoldText);
+        change.insertText(beforeBoldText).toggleMark(type);
+        this.insertTextWithStyles(change, boldText);
+        change.toggleMark(type);
+        this.insertTextWithStyles(change, afterBoldText);
     }
 
-    insertPlainText = (transform, text) => {
+    insertPlainText = (change, text) => {
         // Check for \r\n, \r, or \n to insert a new line in Slate
         let divReturnIndex = -1;
         let returnIndex = text.indexOf("\r\n");
@@ -809,29 +836,28 @@ class FluxNotesEditor extends React.Component {
         }
         
         if (returnIndex >= 0) {
-            let result = this.insertPlainText(transform, text.substring(0, returnIndex));
+            let result = this.insertPlainText(change, text.substring(0, returnIndex));
             result = this.insertNewLine(result);
             return this.insertPlainText(result, text.substring(returnIndex + 1));
         } else if (divReturnIndex >= 0) {
-            let result = this.insertPlainText(transform, text.substring(0, divReturnIndex));
+            let result = this.insertPlainText(change, text.substring(0, divReturnIndex));
             result = this.insertNewLine(result);
             return this.insertPlainText(result, text.substring(divReturnIndex + 6)); // cuts off </div>
         } else {
-            this.insertTextWithStyles(transform, text);
+            this.insertTextWithStyles(change, text);
             // FIXME: Need a trailing character for replacing keywords -- insert temporarily and then delete
-            transform.insertText(' ')
-            const [newTransform, ] = this.singleHashtagKeywordStructuredFieldPlugin.utils.replaceAllRelevantKeywordsInBlock(transform.state.anchorBlock, transform, transform.state)
-            return newTransform.deleteBackward(1).focus();
+            change.insertText(' ')
+            const [newChange, ] = this.singleHashtagKeywordStructuredFieldPlugin.utils.replaceAllRelevantKeywordsInBlock(change.value.anchorBlock, change, change.value)
+            return newChange.deleteBackward(1).focus();
         }
     }
     /*
      * Handle updates when we have a new insert text with structured phrase
      */
-    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true, shouldPortalOpen = true) => {
-        let state;
-        const currentState = this.state.state;
+    insertTextWithStructuredPhrases = (textToBeInserted, currentChange = undefined, updatePatient = true, shouldPortalOpen = true) => {
+        const currentEditorValue = this.state.editorValue;
 
-        let transform = (currentTransform) ? currentTransform : currentState.transform();
+        let change = (currentChange) ? currentChange : currentEditorValue.change();
         let remainder = textToBeInserted;
         let start, end;
         let before = '', after = '';
@@ -848,13 +874,13 @@ class FluxNotesEditor extends React.Component {
                 start = remainder.indexOf(trigger.trigger);
                 if (start > 0) {
                     before = remainder.substring(0, start);
-                    transform = this.insertPlainText(transform, before);
+                    change = this.insertPlainText(change, before);
                 }
                 remainder = remainder.substring(start + trigger.trigger.length);
 
                 // FIXME: Temporary work around that adds spaces when needed to @-phrases inserted via mic
                 if (start !== 0 && trigger.trigger.startsWith('@') && !before.endsWith(' ')) {
-                    transform = this.insertPlainText(transform, ' ');
+                    change = this.insertPlainText(change, ' ');
                 }
 
                 // Deals with @condition phrases inserted via data summary panel buttons. 
@@ -877,15 +903,15 @@ class FluxNotesEditor extends React.Component {
                 } else {
                     after = "";
                 }
-                transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, shouldPortalOpen);
+                change = this.insertShortcut(trigger.definition, trigger.trigger, after, change, updatePatient, shouldPortalOpen);
             });
         }
         if (!Lang.isUndefined(remainder) && remainder.length > 0) {
-            transform = this.insertPlainText(transform, remainder);
+            change = this.insertPlainText(change, remainder);
         }
 
-        state = transform.apply();
-        this.setState({state: state});
+        const editorValue = change.value;
+        this.setState({editorValue: editorValue});
     }
 
     /**
@@ -984,16 +1010,16 @@ class FluxNotesEditor extends React.Component {
      * Check if the current selection has a mark with `type` in it.
      */
     handleMarkCheck = (type) => {
-        const {state} = this.state;
-        return state.marks.some(mark => mark.type === type);
+        const {editorValue} = this.state;
+        return editorValue.marks.some(mark => mark.type === type);
     }
 
     /**
      * Check if the any of the currently selected blocks are of `type`.
      */
     handleBlockCheck = (type) => {
-        const {state} = this.state;
-        return state.blocks.some((node) => {
+        const {editorValue} = this.state;
+        return editorValue.blocks.some((node) => {
             return node.type === type;
 
         });
@@ -1003,42 +1029,42 @@ class FluxNotesEditor extends React.Component {
      * Handle any changes to the current mark type.
      */
     handleMarkUpdate = (type) => {
-        let {state} = this.state
-        state = state
-            .transform()
+        let {editorValue} = this.state
+        editorValue = editorValue
+            .change()
             .toggleMark(type)
             .apply()
-        this.setState({state});
+        this.setState({editorValue});
     }
 
     /**
      * Handle any changes to the current block type.
      */
     handleBlockUpdate = (type) => {
-        let {state} = this.state;
-        const transform = state.transform();
-        const { document } = state;
+        let {editorValue} = this.state;
+        const change = editorValue.change();
+        const { document } = editorValue;
         const DEFAULT_NODE = "line";
 
         // Handle list buttons.
         if (type === 'bulleted-list' || type === 'numbered-list') {
             const isList = this.handleBlockCheck(type + '-item')
 
-            const isType = state.blocks.some((block) => {
+            const isType = editorValue.blocks.some((block) => {
                 return !!document.getClosest(block.key, parent => parent.type === type)
             });
 
             if (isList && isType) {
-                transform
+                change
                     .setBlock(DEFAULT_NODE)
                     .unwrapBlock('bulleted-list')
                     .unwrapBlock('numbered-list')
             } else if (isList) {
-                transform
+                change
                     .unwrapBlock(type === 'bulleted-list' ? 'numbered-list' : 'bulleted-list')
                     .wrapBlock(type)
             } else {
-                transform
+                change
                     .setBlock(type + '-item')
                     .wrapBlock(type)
             }
@@ -1046,8 +1072,8 @@ class FluxNotesEditor extends React.Component {
             // We don't handle any other kinds of block style formatting right now, but if we did it would go here.
         }
 
-        state = transform.apply()
-        this.setState({state});
+        editorValue = change.value;
+        this.setState({editorValue});
 
     }
 
@@ -1171,21 +1197,21 @@ class FluxNotesEditor extends React.Component {
                         />
                     }
                     <div className={editorClassName}>
-                        <Slate.Editor
+                        <Editor
                             className="editor-panel"
                             placeholder={'Enter your clinical note here or choose a template to start from...'}
                             plugins={this.plugins}
                             readOnly={!this.props.isNoteViewerEditable}
-                            state={this.state.state}
                             ref={function (c) {
                                 editor = c;
                             }}
                             onChange={this.onChange}
-                            onInput={this.onInput}
+                                // onInput={this.onInput}
                             onBlur={this.onBlur}
                             onFocus={this.onFocus}
-                            onSelectionChange={this.onSelectionChange}
-                            schema={schema}
+                            renderMark={this.renderMark}
+                            renderNode={this.renderNode}
+                            value={this.state.editorValue}
                         />
                         {errorDisplay}
                     </div>
@@ -1193,12 +1219,14 @@ class FluxNotesEditor extends React.Component {
                     <CreatorsPortal
                         contextPortalOpen={this.state.isPortalOpen}
                         getPosition={this.getTextCursorPosition}
-                        state={this.state.state}
+                        // fIXME
+                        state={this.state.editorValue}
                     />
                     <InsertersPortal
                         contextPortalOpen={this.state.isPortalOpen}
                         getPosition={this.getTextCursorPosition}
-                        state={this.state.state}
+                        // FIXME
+                        state={this.state.editorValue}
                     />
                     <ContextPortal
                         capture={/@([\w]*)/}
@@ -1209,7 +1237,8 @@ class FluxNotesEditor extends React.Component {
                         isOpened={this.state.isPortalOpen}
                         onChange={this.onChange}
                         onSelected={this.onPortalSelection}
-                        state={this.state.state}
+                        //FIXME
+                        state={this.state.editorValue}
                         trigger={"@"}
                     />
                 </div>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -410,6 +410,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     onChange = (change) => {
+        // FIXME: Just used document.nodes instead of creating a whole doc selection
         const editorValue = change.value;
         let indexOfLastNode = editorValue.toJSON().document.nodes.length - 1;
         let endOfNoteKey = editorValue.toJSON().document.nodes[indexOfLastNode].key;
@@ -433,11 +434,9 @@ class FluxNotesEditor extends React.Component {
             endOffset: endOfNoteOffset
         };
         const documentText = this.structuredFieldPlugin.convertToText(editorValue, entireNote);
-
-        this.props.setDocumentTextWithCallback(documentText, () => {
-            // save note after documentText gets set
-            this.props.saveNoteOnChange();
-        });
+        console.log('documentText')
+        console.log(documentText)
+        this.props.saveNoteOnChange(documentText);
 
         this.setState({ editorValue });
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -125,23 +125,27 @@ export default class NoteAssistant extends Component {
 
     // Gets called when clicking on the "new note" button
     handleOnNewNoteButtonClick = () => {
-        this.updateExistingNote();
         this.createBlankNewNote();
     }
 
-    updateExistingNote = () => {
-        this.updateNote(this.props.currentlyEditingEntryId);
+    updateExistingNote = (content) => {
+        this.updateNote(this.props.currentlyEditingEntryId, content);
     }
 
-    updateNote = (entryId) => {
+    updateNote = (entryId, content) => {
+        console.log('update note')
         // Only update if there is a note in progress
         if (!Lang.isEqual(entryId, -1)) {
+            console.log('we have entry')
             // List the notes to verify that they are being updated each invocation of this function:
             var found = this.props.patient.getNotes().find(function (element) {
                 return Lang.isEqual(element.entryInfo.entryId, entryId);
             });
             if (!Lang.isNull(found) && !Lang.isUndefined(found)) {
-                found.content = this.props.documentText;
+                console.log('we  have a note with that id')
+                console.log('content')
+                console.log(content)
+                found.content = content;
                 this.props.patient.updateExistingEntry(found);
                 this.props.updateSelectedNote(found);
             }
@@ -175,10 +179,10 @@ export default class NoteAssistant extends Component {
     }
 
     // save the note after every editor change. Invoked by FluxNotesEditor.
-    saveNoteOnChange = () => {
+    saveNoteOnChange = (content) => {
         // Only save if note is currently open
         if (this.props.currentlyEditingEntryId !== -1) {
-            this.updateExistingNote();
+            this.updateExistingNote(content);
         }
     }
 
@@ -189,9 +193,9 @@ export default class NoteAssistant extends Component {
         this.props.setNoteViewerVisible(true);
 
         // Don't start saving until there is content in the editor
-        if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText) && this.props.documentText.length > 0) {
-            this.updateExistingNote();
-        }
+        // if (!Lang.isNull(this.props.documentText) && !Lang.isUndefined(this.props.documentText) && this.props.documentText.length > 0) {
+        //     this.updateExistingNote();
+        // }
         this.props.updateCurrentlyEditingEntryId(note.entryInfo.entryId);
         // the lines below are duplicative
         this.props.updateSelectedNote(note);
@@ -284,7 +288,7 @@ export default class NoteAssistant extends Component {
                                 closeNote={this.props.closeNote}
                                 contextManager={this.props.contextManager}
                                 currentViewMode={'pre-encounter'}
-                                documentText={this.props.documentText}
+                                // documentText={this.props.documentText}
                                 errors={this.props.errors}
                                 handleUpdateEditorWithNote={this.props.handleUpdateEditorWithNote}
                                 isNoteViewerEditable={false}
@@ -583,7 +587,7 @@ NoteAssistant.propTypes = {
     contextManager: PropTypes.object.isRequired,
     contextTrayItemToInsert: PropTypes.string,
     deleteSelectedNote: PropTypes.func.isRequired,
-    documentText: PropTypes.string.isRequired,
+    // documentText: PropTypes.string.isRequired,
     handleSummaryItemSelected: PropTypes.func.isRequired,
     handleUpdateArrayOfPickLists: PropTypes.func.isRequired,
     handleUpdateEditorWithNote: PropTypes.func.isRequired,

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -61,10 +61,13 @@ function StructuredFieldPlugin(opts) {
             if (node.type === 'line') {
                 result += `<div>${convertSlateNodesToText(node.nodes)}</div>`;
                 //FIXME: No longerf a Text.characters; now uses something else
-            } else if (node.characters && node.characters.length > 0) {
-                node.characters.forEach(char => {
-                    const inMarksNotLocal = Lang.differenceBy(char.marks, localStyle, 'type');
-                    const inLocalNotMarks = Lang.differenceBy(localStyle, char.marks, 'type');
+            } else if (node.type === getStructuredFieldType()) {
+                let shortcut = node.data.shortcut;
+                result += shortcut.getResultText();
+            } else if (node.object === "text" ) {
+                node.leaves.forEach(leaf => {
+                    const inMarksNotLocal = Lang.differenceBy(leaf.marks, localStyle, 'type');
+                    const inLocalNotMarks = Lang.differenceBy(localStyle, leaf.marks, 'type');
                     if (inMarksNotLocal.length > 0) {
                         inMarksNotLocal.forEach(mark => {
                             result += `<${markToHTMLTag[mark.type]}>`;
@@ -75,8 +78,8 @@ function StructuredFieldPlugin(opts) {
                             result += `</${markToHTMLTag[mark.type]}>`;
                         });
                     }
-                    localStyle = char.marks;
-                    result += char.text;
+                    localStyle = leaf.marks;
+                    result += leaf.text;
                 });
                 if (localStyle.length > 0) {
                     Lang.reverse(localStyle).forEach(mark => {

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import Slate from '../lib/slate';
+import { Inline, Range } from 'slate';
+import { findDOMNode } from 'slate-react'
+import { IS_IE, IS_CHROME, IS_SAFARI } from 'slate-dev-environment'
 import Lang from 'lodash';
 import getWindow from 'get-window';
 
@@ -17,11 +19,13 @@ function StructuredFieldPlugin(opts) {
     let insertText = opts.insertText;
     const clearStructuredFieldMap = opts.structuredFieldMapManager.clearStructuredFieldMap;
 
-    function onChange(state, editor) {
+    function onChange(change) {
+        if (change.operations.size === 0) return
+        const editorValue = change.value;
         var deletedKeys = [];
         const keyToShortcutMap = opts.structuredFieldMapManager.keyToShortcutMap;
         const idToShortcutMap = opts.structuredFieldMapManager.idToShortcutMap;
-        const nodes = state.document.getInlines();
+        const nodes = editorValue.document.getInlinesAsArray();
         if (nodes.size !== keyToShortcutMap.size) {
             var currentNodesMap = new Map(nodes.map((i) => [i.key, i]));
             keyToShortcutMap.forEach((value, key) => {
@@ -33,7 +37,7 @@ function StructuredFieldPlugin(opts) {
         // Sort the keys in reverse order of creation -- new keys are always > old keys
         deletedKeys.sort((a, b) => b - a)
         var shortcut;
-        let result = state;
+        const result = editorValue;
         deletedKeys.forEach((key) => {
             shortcut = keyToShortcutMap.get(key);
             if (shortcut.onBeforeDeleted()) {
@@ -41,45 +45,11 @@ function StructuredFieldPlugin(opts) {
                 idToShortcutMap.delete(shortcut.metadata.id)
                 contextManager.contextUpdated();
             } else {
-                result = editor.getState(); // don't allow state change
                 updateErrors([ "Unable to delete " + shortcut.getLabel() + " because " + shortcut.getChildren().map((child) => { return child.getText(); }).join() + " " + ((shortcut.getChildren().length > 1) ? "depend" : "depends") + " on it." ]);
             }
         });
         return result;
     }
-
-    const schema = {
-		nodes: {
-			structured_field:      props => {
-				let shortcut = props.node.get('data').get('shortcut');
-				return <span contentEditable={false} className='structured-field' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
-			},
-		},
-		rules: [
-			{
-				match: (node) => {
-					return node.kind === 'block' && node.type === 'inline'
-				},
-				render: (props) => {
-					return (
-						<span {...props.attributes} style={{ position: 'relative', width:'100%', height:'100%'}}>
-							{props.children}
-							{props.editor.props.placeholder
-								? <Slate.Placeholder
-									className={props.editor.props.placeholderClassName}
-									node={props.node}
-									parent={props.state.document}
-									state={props.state}
-									style={{position: 'relative',top:'-18px',width:'100%', height:'100%',opacity:'0.333',...props.editor.props.placeholderStyle}}
-								  >{props.editor.props.placeholder}
-								  </Slate.Placeholder>
-								: null}
-						</span>
-					);
-				}
-			}
-		]
-	};
 
     function convertSlateNodesToText(nodes) {
         let result = '';
@@ -90,6 +60,7 @@ function StructuredFieldPlugin(opts) {
             // console.log(node)
             if (node.type === 'line') {
                 result += `<div>${convertSlateNodesToText(node.nodes)}</div>`;
+                //FIXME: No longerf a Text.characters; now uses something else
             } else if (node.characters && node.characters.length > 0) {
                 node.characters.forEach(char => {
                     const inMarksNotLocal = Lang.differenceBy(char.marks, localStyle, 'type');
@@ -127,8 +98,8 @@ function StructuredFieldPlugin(opts) {
         return result;
     }
 
-    function convertToText(state, selection) {
-        return `${convertSlateNodesToText(state.document.toJSON().nodes)}`;
+    function convertToText(editorValue, selection) {
+        return `${convertSlateNodesToText(editorValue.document.toJSON().nodes)}`;
     }
 
     function onCopy(event, data, state, editor) {
@@ -156,7 +127,7 @@ function StructuredFieldPlugin(opts) {
         if (isVoid) {
             //console.log("isVoid: " + isVoid);
             const r = range.cloneRange();
-            const node = Slate.Utils.findDOMNode(isVoidBlock ? endBlock : endInline);
+            const node = findDOMNode(isVoidBlock ? endBlock : endInline);
             r.setEndAfter(node);
             contents = r.cloneContents();
             attach = contents.childNodes[contents.childNodes.length - 1].firstChild;
@@ -170,7 +141,7 @@ function StructuredFieldPlugin(opts) {
         // COMPAT: In Chrome and Safari, if the last element in the selection to
         // copy has `contenteditable="false"` the copy will fail, and nothing will
         // be put in the clipboard. So we remove them all. (2017/05/04)
-        if (Slate.IS_CHROME || Slate.IS_SAFARI) {
+        if (IS_CHROME || IS_SAFARI) {
             const els = [].slice.call(contents.querySelectorAll('[contenteditable="false"]'));
             els.forEach(el => el.removeAttribute('contenteditable'));
         }
@@ -216,6 +187,9 @@ function StructuredFieldPlugin(opts) {
             native.addRange(range);
         })
         return state;
+    }
+    function isNodeStructuredField(node) { 
+        return node.type === getStructuredFieldType();
     }
 
     const FRAGMENT_MATCHER = / flux-string="([^\s]+)"/;
@@ -278,15 +252,19 @@ function StructuredFieldPlugin(opts) {
         onCut,
         onCopy,
         onPaste,
-        schema,
         convertToText,
 
         utils: {
             //isSelectionInStructuredField
             convertSlateNodesToText: convertSlateNodesToText,
         },
+        helpers: {
+            convertToText: convertToText,
+            convertSlateNodesToText: convertSlateNodesToText,
+            getStructuredFieldType: getStructuredFieldType,
+        },
 
-        transforms: {
+        changes: {
             insertStructuredField:     	insertStructuredField.bind(null, opts)
         }
     };
@@ -332,12 +310,15 @@ function createStructuredField(opts, shortcut) {
             shortcut: shortcut
         }
     };
-    let sf = Slate.Inline.create(properties);
+    let sf = Inline.create(properties);
     opts.structuredFieldMapManager.keyToShortcutMap.set(sf.key, shortcut);
     opts.structuredFieldMapManager.idToShortcutMap.set(shortcut.metadata.id, shortcut);
     // console.log("sf")
     // console.log(sf)
 	return sf;
+}
+function getStructuredFieldType () { 
+    return 'structured-field'
 }
 
 export default StructuredFieldPlugin

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -101,12 +101,11 @@ function StructuredFieldPlugin(opts) {
         return result;
     }
 
-    function convertToText(editorValue, selection) {
+    function convertToText(editorValue) {
         return `${convertSlateNodesToText(editorValue.document.toJSON().nodes)}`;
     }
 
     function onCopy(event, data, state, editor) {
-        let { selection } = state;
 
         const window = getWindow(event.target);
         const native = window.getSelection();
@@ -118,7 +117,7 @@ function StructuredFieldPlugin(opts) {
         // If the selection is collapsed, and it isn't inside a void node, abort.
         if (native.isCollapsed && !isVoid) return;
 
-        let fluxString = convertToText(state, selection);
+        let fluxString = convertToText(state);
         // console.log("copy: " + fluxString);
         const encoded = window.btoa(window.encodeURIComponent(fluxString));
         const range = native.getRangeAt(0);

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -4,6 +4,7 @@ import {Row, Col} from 'react-flexbox-grid';
 import FluxNotesEditor from '../notes/FluxNotesEditor';
 import Button from '../elements/Button';
 import Lang from 'lodash';
+import moment from 'moment';
 import NoteAssistant from '../notes/NoteAssistant';
 import NoteParser from '../noteparser/NoteParser';
 import './NotesPanel.css';
@@ -21,6 +22,7 @@ export default class NotesPanel extends Component {
             currentlyEditingEntryId: -1,
             arrayOfPickLists: [],
             contextTrayItemToInsert: null,
+            localDocumentText: ''
         };
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
@@ -31,6 +33,10 @@ export default class NotesPanel extends Component {
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
             this.handleUpdateEditorWithNote(nextProps.openClinicalNote);
         }
+    }
+
+    updateLocalDocumentText = (text) => {
+        this.setState({ localDocumentText: text });
     }
 
     updateNoteAssistantMode = (mode) => {
@@ -99,29 +105,44 @@ export default class NotesPanel extends Component {
                     noteAssistantMode: mode,
                     currentlyEditingEntryId: parseInt(note.entryInfo.entryId, 10)
                 });
-                this.props.setDocumentText(note.content);
                 this.props.setOpenClinicalNote(note);
             });
         }
-    }
-
-    handleUpdateCurrentlyEditingEntryId = (id) => {
-        this.setState({currentlyEditingEntryId: parseInt(id, 10)});
     }
 
     handleUpdateArrayOfPickLists = (array) => {
         this.setState({arrayOfPickLists: array})
     }
 
-    // Save the note after every editor change. This function invokes the note saving logic in NoteAssistant
-    saveNoteOnChange = (content) => {
-        this.saveNoteChild(content);
+    updateNote = (entryId, noteContent) => {
+        // Only update if there is a note in progress
+        if (!Lang.isEqual(entryId, -1)) {
+            // List the notes to verify that they are being updated each invocation of this function:
+            var noteToUpdate = this.props.patient.getNotes().find(function (element) {
+                return Lang.isEqual(element.entryInfo.entryId, entryId);
+            });
+            if (!Lang.isNull(noteToUpdate) && !Lang.isUndefined(noteToUpdate)) {
+                noteToUpdate.content = noteContent;
+                this.props.patient.updateExistingEntry(noteToUpdate);
+                this.updateSelectedNote(noteToUpdate);
+            }
+        }
     }
 
-    // invokes closing logic in NoteAssistant
+    updateExistingNote = (noteContent) => {
+        this.updateNote(this.state.currentlyEditingEntryId, noteContent);
+    }
+
+    // Save a note
+    saveNote = (noteContent) => {
+        if (this.state.currentlyEditingEntryId !== -1) {
+            console.log('saving')
+            this.updateExistingNote(noteContent);
+        }
+    }
+
+    // Close a note
     closeNote = () => {
-        this.closeNoteChild();
-        this.props.setDocumentText("");
         this.props.setOpenClinicalNote(null);
         this.setState({
             updatedEditorNote: null,
@@ -130,13 +151,65 @@ export default class NotesPanel extends Component {
             selectedNote: null,
             currentlyEditingEntryId: -1
         });
+        this.props.setNoteClosed(true);
+        this.props.setLayout('right-collapsed');
+        this.props.setNoteViewerVisible(false);
+        this.props.setNoteViewerEditable(false);
+    }
+
+    // Create and open a blank note
+    openNewNote = () => {
+        // Create info to be set for new note
+        const date = new moment().format("D MMM YYYY");
+        const subject = "New Note";
+        const hospital = "Dana Farber";
+        const clinician = this.props.loginUser;
+        const content = "";
+        const signed = false;
+
+        // Add new unsigned note to patient record
+        const currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
+
+        const newNote = this.props.patient.getNotes().find(function (curNote) {
+            return Lang.isEqual(curNote.entryInfo.entryId, currentlyEditingEntryId);
+        });
+
+        this.openNote(newNote, true);
+    }
+
+    // Open an existing note
+    openExistingNote = (isInProgress, note) => {
+        this.openNote(note, isInProgress);
+    }
+
+    openNote = (note, isInProgress) => {
+        // Saves the current note and resets localDocumentText before opening the next note.
+        this.saveNote(this.state.localDocumentText);
+        this.updateLocalDocumentText('');
+
+        // Open a note
+        this.props.setNoteClosed(false);
+        this.props.setLayout('split');
+        this.props.setNoteViewerVisible(true);
+
+        // Old note above these lines: 'the lines below are duplicative'
+        this.updateSelectedNote(note);
+        this.handleUpdateEditorWithNote(note);
+
+        if (isInProgress) {
+            this.props.setNoteViewerEditable(true);
+        } else {
+            this.props.setNoteViewerEditable(false);
+        }
     }
 
     // Removes a note from patient object if the note is unsigned 
     deleteSelectedNote = () => {
+        this.closeNote(this.state.localDocumentText);
         if (this.state.selectedNote && !this.state.selectedNote.signed) {
             // Find the shortcuts in the current note.
-            const recognizedShortcutsObjects = this.noteParser.getListOfTriggersFromText(this.state.selectedNote.content)[0].reverse();
+            // Use this.state.localDocumentText since note is not saved on every keypress and need full content here.
+            const recognizedShortcutsObjects = this.noteParser.getListOfTriggersFromText(this.state.localDocumentText)[0].reverse();
             for (const index in recognizedShortcutsObjects) {
                 // Get the actual shortcut obj from structuredFieldMapManager lookup -- need id of shortcut to retrieve
                 const currentShortcutTrigger = recognizedShortcutsObjects[index].trigger.toLowerCase();
@@ -172,6 +245,7 @@ export default class NotesPanel extends Component {
         });
 
         // Close the current note
+        this.saveNote(this.state.localDocumentText)
         this.closeNote();
     }
 
@@ -242,7 +316,6 @@ export default class NotesPanel extends Component {
                     closeNote={this.closeNote}
                     contextManager={this.props.contextManager}
                     currentViewMode={this.props.currentViewMode}
-                    documentText={this.props.documentText}
                     errors={this.props.errors}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
@@ -251,12 +324,12 @@ export default class NotesPanel extends Component {
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     noteAssistantMode={this.state.noteAssistantMode}
                     patient={this.props.patient}
-                    saveNoteOnChange={this.saveNoteOnChange}
+                    saveNote={this.saveNote}
                     selectedNote={this.state.selectedNote}
                     setDocumentTextWithCallback={this.props.setDocumentTextWithCallback}
                     setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
-                    setLayout={this.setLayout}
+                    setLayout={this.props.setLayout}
                     shortcutManager={this.props.shortcutManager}
                     shouldEditorContentUpdate={this.state.noteAssistantMode !== 'pick-list-options-panel'}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
@@ -266,6 +339,7 @@ export default class NotesPanel extends Component {
                     updatedEditorNote={this.state.updatedEditorNote}
                     updateErrors={this.props.updateErrors}
                     updateSelectedNote={this.updateSelectedNote}
+                    updateLocalDocumentText={this.updateLocalDocumentText}
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
                     arrayOfPickLists={this.arrayOfPickLists}
                     handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
@@ -279,12 +353,12 @@ export default class NotesPanel extends Component {
         return (
             <div className="fitted-panel panel-content dashboard-panel">
                 <NoteAssistant
-                    closeNote={click => this.closeNoteChild = click}
+                    closeNote={this.closeNote}
                     currentlyEditingEntryId={this.state.currentlyEditingEntryId}
                     contextManager={this.props.contextManager}
                     contextTrayItemToInsert={this.state.contextTrayItemToInsert}
                     deleteSelectedNote={this.deleteSelectedNote}
-                    documentText={this.props.documentText}
+                    errors={this.props.errors}
                     handleSummaryItemSelected={this.props.handleSummaryItemSelected}
                     handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
@@ -294,8 +368,10 @@ export default class NotesPanel extends Component {
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     noteAssistantMode={this.state.noteAssistantMode}
                     noteClosed={this.props.noteClosed}
+                    openNewNote={this.openNewNote}
+                    openExistingNote={this.openExistingNote}
                     patient={this.props.patient}
-                    saveNote={click => this.saveNoteChild = click}
+                    saveNote={this.saveNote}
                     saveNoteOnChange={this.saveNoteOnChange}
                     searchSelectedItem={this.props.searchSelectedItem}
                     selectedNote={this.state.selectedNote}
@@ -313,6 +389,7 @@ export default class NotesPanel extends Component {
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
                     updateSelectedNote={this.updateSelectedNote}
                     arrayOfPickLists={this.state.arrayOfPickLists}
+                    updateLocalDocumentText={this.updateLocalDocumentText}
                     updateContextTrayItemToInsert={this.updateContextTrayItemToInsert}
                     updateContextTrayItemWithSelectedPickListOptions={this.updateContextTrayItemWithSelectedPickListOptions}
                     updatedEditorNote={this.state.updatedEditorNote}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -37,7 +37,7 @@ export default class NotesPanel extends Component {
         this.setState({noteAssistantMode: mode});
     }
 
-    updateSelectedNote = (note) => {
+    updateSelectedNote = (note) => {        
         this.setState({selectedNote: note});
     }
 
@@ -114,8 +114,8 @@ export default class NotesPanel extends Component {
     }
 
     // Save the note after every editor change. This function invokes the note saving logic in NoteAssistant
-    saveNoteOnChange = () => {
-        this.saveNoteChild();
+    saveNoteOnChange = (content) => {
+        this.saveNoteChild(content);
     }
 
     // invokes closing logic in NoteAssistant

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,27 +1490,6 @@ check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
-cheerio@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash.assignin "^4.0.9"
-    lodash.bind "^4.1.4"
-    lodash.defaults "^4.0.1"
-    lodash.filter "^4.4.0"
-    lodash.flatten "^4.2.0"
-    lodash.foreach "^4.3.0"
-    lodash.map "^4.4.0"
-    lodash.merge "^4.4.0"
-    lodash.pick "^4.2.1"
-    lodash.reduce "^4.4.0"
-    lodash.reject "^4.4.0"
-    lodash.some "^4.4.0"
-
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -2133,9 +2112,15 @@ debug@2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.3.2, debug@^2.6.0, debug@^2.6.3, debug@^2.6.4, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0, debug@^2.6.3, debug@^2.6.4, debug@^2.6.6, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
@@ -2491,7 +2476,7 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
-es6-map@^0.1.3, es6-map@^0.1.4:
+es6-map@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   dependencies:
@@ -3490,7 +3475,7 @@ ignore@^3.2.0:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
 
-immutable@3.8.1, immutable@^3.8.1:
+immutable@3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
 
@@ -3695,6 +3680,14 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-hotkey@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.0.3.tgz#3713fea135f86528c87cf39810b3934e45151390"
+
+is-hotkey@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.2.tgz#aeda5e4f542284700ae18b46980fb0637c021198"
+
 is-in-browser@^1.0.2, is-in-browser@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
@@ -3740,7 +3733,7 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1:
+is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -3821,6 +3814,10 @@ isobject@^2.0.0:
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+isomorphic-base64@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz#f426aae82569ba8a4ec5ca73ad21a44ab1ee7803"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
@@ -4393,14 +4390,6 @@ lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
-lodash.assignin@^4.0.9:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
-
-lodash.bind@^4.1.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -4420,25 +4409,9 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.defaults@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-
-lodash.filter@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-
-lodash.flatten@^4.2.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
-lodash.foreach@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -4456,41 +4429,17 @@ lodash.keys@^3.0.0, lodash.keys@^3.1.2:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.map@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.merge@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
-lodash.pick@^4.2.1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
 lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
-
-lodash.reduce@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
-
-lodash.reject@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
-
-lodash.some@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.toarray@^4.4.0:
   version "4.4.0"
@@ -4507,6 +4456,10 @@ lodash@4.16.4:
 "lodash@4.6.1 || ^4.16.1", "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.1.1:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-update@^1.0.2:
   version "1.0.2"
@@ -5977,6 +5930,10 @@ react-ga@2.2.0:
     object-assign "^4.0.1"
     prop-types "^15.5.6"
 
+react-immutable-proptypes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
+
 react-jss@^8.1.0:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.2.1.tgz#b2905063ba8b950f095a139a75232d851c79e15e"
@@ -6805,30 +6762,84 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-auto-replace@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/slate-auto-replace/-/slate-auto-replace-0.5.0.tgz#52ecbe4f5ba1838a4aaacc797caa8134118f8f7e"
+slate-auto-replace@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/slate-auto-replace/-/slate-auto-replace-0.9.1.tgz#31080199df3eb02191952b9a28a2a09fe3798425"
   dependencies:
+    is-hotkey "^0.0.3"
     type-of "^2.0.1"
 
-slate@0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.20.2.tgz#e7842ebdfa0b81d1c9039229c4af69f3f9a23fff"
+slate-base64-serializer@^0.2.39:
+  version "0.2.39"
+  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.39.tgz#8ea625cdeae3309a926546fd5b845099ba50fade"
   dependencies:
-    cheerio "^0.22.0"
-    debug "^2.3.2"
-    direction "^0.1.5"
-    es6-map "^0.1.4"
-    esrever "^0.2.0"
-    get-window "^1.1.1"
-    immutable "^3.8.1"
-    is-empty "^1.0.0"
+    isomorphic-base64 "^1.0.2"
+
+slate-dev-environment@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/slate-dev-environment/-/slate-dev-environment-0.1.2.tgz#743a8bd7f427dc272425b0439a29e83ca5521688"
+  dependencies:
     is-in-browser "^1.1.3"
+
+slate-dev-logger@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
+
+slate-hotkeys@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/slate-hotkeys/-/slate-hotkeys-0.1.2.tgz#2e35a08a42eaaa113b64d438d537e77a582c8d4a"
+  dependencies:
+    is-hotkey "^0.1.1"
+    slate-dev-environment "^0.1.2"
+
+slate-plain-serializer@^0.5.20:
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.5.20.tgz#4877b0980cafbea0528a8ff1e75ca75363368b3b"
+  dependencies:
+    slate-dev-logger "^0.1.39"
+
+slate-prop-types@^0.4.37:
+  version "0.4.37"
+  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.4.37.tgz#ac7706dd64fd166066cd8313c4d3942df64ad7f0"
+  dependencies:
+    slate-dev-logger "^0.1.39"
+
+slate-react@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.13.2.tgz#9b010236fa79aa1c574d97d8cde906ad42232338"
+  dependencies:
+    debug "^3.1.0"
+    get-window "^1.1.1"
     is-window "^1.0.2"
     keycode "^2.1.2"
+    lodash "^4.1.1"
     prop-types "^15.5.8"
+    react-immutable-proptypes "^2.1.0"
     react-portal "^3.1.0"
     selection-is-backward "^1.0.0"
+    slate-base64-serializer "^0.2.39"
+    slate-dev-environment "^0.1.2"
+    slate-dev-logger "^0.1.39"
+    slate-hotkeys "^0.1.2"
+    slate-plain-serializer "^0.5.20"
+    slate-prop-types "^0.4.37"
+
+slate-schema-violations@^0.1.18:
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.18.tgz#bc760e17dab85a613cd9a5399b98cbf867db0eb7"
+
+slate@^0.34.5:
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.34.5.tgz#4bc30dc300c924193d42371a7afcc168676f2798"
+  dependencies:
+    debug "^3.1.0"
+    direction "^0.1.5"
+    esrever "^0.2.0"
+    is-empty "^1.0.0"
+    is-plain-object "^2.0.4"
+    lodash "^4.17.4"
+    slate-dev-logger "^0.1.39"
+    slate-schema-violations "^0.1.18"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

This branch was created while trying to debug the selection in IE. When using the upgraded version of Slate in Internet Explorer, selecting text (highlighting with a mouse or keyboard shortcuts) does not work. We created this branch to try to isolate where the bug happens. When upgrading slate, the selection bug surfaced. We found that commenting out saving notes and commenting out adjusting active contexts fixes the selection bug.

We also tried to refactor saving notes only on closing notes to try to fix the bug. Those changes are made in the latest commit on this branch (b96c134). This did not fix the selection bug. Removing the one call to setting a state variable in NotesPanel from FluxNotesEditor (in onChange() - this.props.updateLocalDocumentText()) allows selection to happen. Notably, the adjust active contexts function is not added in onChange yet. 

We may need to refactor further to not need the current document text in NotesPanel. We will also need to figure out how adjust active contexts correctly. It is possible to determine if a selection is changing within the onChange function, but it may not be simple to fix the bug since selecting text is changing selection. This will be looked at further at a later time.

This pull request is being made only to preserve the history of what was tried. It will be closed immediately.

## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
