### PR TITLE
New note show template view

### DIFF
--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -13,13 +13,18 @@ export default class ContextTray extends Component {
 
     constructor(props) {
         super(props);
-
+        const viewMode = this.props.showTemplateView ? this.TEMPLATE_VIEW : this.SHORTCUT_VIEW;
         this.state = {
             // viewMode keeps track of which context is active
             // 0 when Templates are selected. 1 when Patient is selected
             // In editor, viewMode is incremented by 1 for each context added (i.e @condition, #disease status)
-            viewMode: this.SHORTCUT_VIEW
+            viewMode,
         };
+    }
+
+    componentWillReceiveProps = (nextProps) => {
+        const viewMode = nextProps.showTemplateView ? this.TEMPLATE_VIEW : this.SHORTCUT_VIEW;
+        this.setState ({ viewMode });
     }
 
     handleTemplateSectionClick = () => {
@@ -116,5 +121,6 @@ ContextTray.propTypes = {
     onShortcutClicked: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
     setInsertingTemplate: PropTypes.func.isRequired,
-    shortcutManager: PropTypes.object.isRequired
-};
+    shortcutManager: PropTypes.object.isRequired,
+    showTemplateView: PropTypes.bool.isRequired,
+}

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -48,7 +48,6 @@ export default class ContextTray extends Component {
     };
 
     handleShortcutClick = (contextTrayItem) => {
-        console.log(contextTrayItem);
         this.props.updateShowTemplateView(false);  
         this.props.onShortcutClicked(contextTrayItem);
     }

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -47,7 +47,7 @@ export default class ContextTray extends Component {
         });
     };
 
-    handleShortcutClick = (contextTrayItem) => {
+    handleShortcutClick = (contextTrayItem) => {     
         this.props.updateShowTemplateView(false);  
         this.props.onShortcutClicked(contextTrayItem);
     }

--- a/src/context/ContextTray.jsx
+++ b/src/context/ContextTray.jsx
@@ -16,14 +16,16 @@ export default class ContextTray extends Component {
         const viewMode = this.props.showTemplateView ? this.TEMPLATE_VIEW : this.SHORTCUT_VIEW;
         this.state = {
             // viewMode keeps track of which context is active
-            // 0 when Templates are selected. 1 when Patient is selected
+            // 0 when Templates are selected. 1 when Shortcuts is selected. 2 when Placholder is selected
             // In editor, viewMode is incremented by 1 for each context added (i.e @condition, #disease status)
             viewMode,
         };
     }
 
     componentWillReceiveProps = (nextProps) => {
-        const viewMode = nextProps.showTemplateView ? this.TEMPLATE_VIEW : this.SHORTCUT_VIEW;
+        // If show template view is true, set the view to template view, otherwise check if current view is template view. If the view is currently a template go to shortcut view, else leave the view as is
+        // (ex. if in placeholder view, stay in placeholder view)
+        const viewMode = nextProps.showTemplateView ? this.TEMPLATE_VIEW : (this.state.viewMode === this.TEMPLATE_VIEW ? this.SHORTCUT_VIEW : this.state.viewMode);
         this.setState ({ viewMode });
     }
 
@@ -44,6 +46,12 @@ export default class ContextTray extends Component {
             viewMode: this.PLACEHOLDER_VIEW
         });
     };
+
+    handleShortcutClick = (contextTrayItem) => {
+        console.log(contextTrayItem);
+        this.props.updateShowTemplateView(false);  
+        this.props.onShortcutClicked(contextTrayItem);
+    }
 
     render() {
         const { viewMode } = this.state;
@@ -107,7 +115,7 @@ export default class ContextTray extends Component {
 
                 {viewMode === this.PLACEHOLDER_VIEW && (
                     <PlaceholderViewModeContent
-                        onClick={onShortcutClicked}
+                        onClick={this.handleShortcutClick}
                         placeholders={shortcutManager.getAllPlaceholderShortcuts()}
                     />
                 )}
@@ -123,4 +131,5 @@ ContextTray.propTypes = {
     setInsertingTemplate: PropTypes.func.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     showTemplateView: PropTypes.bool.isRequired,
+    updateShowTemplateView: PropTypes.func.isRequired
 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1369,6 +1369,7 @@ class FluxNotesEditor extends React.Component {
 FluxNotesEditor.propTypes = {
     closeNote: PropTypes.func.isRequired,
     contextManager: PropTypes.object.isRequired,
+    contextTrayItemToInsert: PropTypes.string,
     currentViewMode: PropTypes.string.isRequired,
     errors: PropTypes.array.isRequired,
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
@@ -1386,7 +1387,6 @@ FluxNotesEditor.propTypes = {
     shouldEditorContentUpdate: PropTypes.bool.isRequired,
     structuredFieldMapManager: PropTypes.object.isRequired,
     summaryItemToInsert: PropTypes.string.isRequired,
-    contextTrayItemToInsert: PropTypes.string,
     updatedEditorNote: PropTypes.object,
     updateErrors: PropTypes.func.isRequired,
     updateLocalDocumentText: PropTypes.func.isRequired,

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -24,8 +24,7 @@ export default class NoteAssistant extends Component {
             // insertingTemplate indicates whether a shortcut or template is being inserted
             // false indicates a shortcut is being inserted
             // true indicates a template is being inserted
-            insertingTemplate: false,
-            showTemplateView: false
+            insertingTemplate: false
         };
         // On creating of NoteAssistant, check if the note viewer is editable
         if (this.props.isNoteViewerEditable) {
@@ -83,6 +82,7 @@ export default class NoteAssistant extends Component {
     }
 
     setInsertingTemplate = (insertingTemplate) => {
+        console.log("in insert template");
         this.setState({ insertingTemplate }); 
         this.props.updateShowTemplateView(false);           
     }
@@ -159,6 +159,7 @@ export default class NoteAssistant extends Component {
                             setInsertingTemplate={this.setInsertingTemplate}
                             shortcutManager={this.props.shortcutManager}
                             showTemplateView={this.props.showTemplateView}
+                            updateShowTemplateView={this.props.updateShowTemplateView}
                         />
                         {this.props.isNoteViewerEditable ? this.renderDeleteNoteButton() : null}
                     </div>

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -82,7 +82,6 @@ export default class NoteAssistant extends Component {
     }
 
     setInsertingTemplate = (insertingTemplate) => {
-        console.log("in insert template");
         this.setState({ insertingTemplate }); 
         this.props.updateShowTemplateView(false);           
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -25,6 +25,7 @@ export default class NoteAssistant extends Component {
             // false indicates a shortcut is being inserted
             // true indicates a template is being inserted
             insertingTemplate: false,
+            showTemplateView: false
         };
         // On creating of NoteAssistant, check if the note viewer is editable
         if (this.props.isNoteViewerEditable) {
@@ -82,7 +83,8 @@ export default class NoteAssistant extends Component {
     }
 
     setInsertingTemplate = (insertingTemplate) => {
-        this.setState({ insertingTemplate });
+        this.setState({ insertingTemplate }); 
+        this.props.updateShowTemplateView(false);           
     }
 
     onNotesToggleButtonClicked() {
@@ -121,6 +123,7 @@ export default class NoteAssistant extends Component {
     handleOnNewNoteButtonClick = () => {
         this.props.openNewNote();
         this.toggleView("context-tray");
+  
     }
 
     // Gets called when clicking on one of the notes in the clinical notes view
@@ -155,6 +158,7 @@ export default class NoteAssistant extends Component {
                             patient={this.props.patient}
                             setInsertingTemplate={this.setInsertingTemplate}
                             shortcutManager={this.props.shortcutManager}
+                            showTemplateView={this.props.showTemplateView}
                         />
                         {this.props.isNoteViewerEditable ? this.renderDeleteNoteButton() : null}
                     </div>
@@ -476,6 +480,7 @@ export default class NoteAssistant extends Component {
 
     // Main render method
     render() {
+
         // If the note viewer is editable then we want to be able to edit notes and view the context tray
         // If the note viewer is read only the we want to be able to view the clinical notes
         // If the editor is read only because we need to select picklists, then we need the note assistant mode to open the portal
@@ -495,6 +500,7 @@ export default class NoteAssistant extends Component {
 }
 
 NoteAssistant.propTypes = {
+    arrayOfPickLists: PropTypes.array.isRequired,
     closeNote: PropTypes.func.isRequired,
     currentlyEditingEntryId: PropTypes.number.isRequired,
     contextManager: PropTypes.object.isRequired,
@@ -503,6 +509,7 @@ NoteAssistant.propTypes = {
     handleSummaryItemSelected: PropTypes.func.isRequired,
     handleUpdateArrayOfPickLists: PropTypes.func.isRequired,
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
+    showTemplateView: PropTypes.bool.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
     loadNote: PropTypes.func.isRequired,
     loginUser: PropTypes.string.isRequired,
@@ -523,9 +530,9 @@ NoteAssistant.propTypes = {
     structuredFieldMapManager: PropTypes.object.isRequired,
     updateNoteAssistantMode: PropTypes.func.isRequired,
     updateSelectedNote: PropTypes.func.isRequired,
-    arrayOfPickLists: PropTypes.array.isRequired,
     updateContextTrayItemToInsert: PropTypes.func.isRequired,
     updateContextTrayItemWithSelectedPickListOptions: PropTypes.func.isRequired,
     updatedEditorNote: PropTypes.object,
-    updateErrors: PropTypes.func.isRequired
+    updateErrors: PropTypes.func.isRequired,
+    updateShowTemplateView: PropTypes.func.isRequired
 };

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -43,8 +43,6 @@ export default class NotesPanel extends Component {
     }
 
     updateLocalDocumentText = (text) => {      
-
-        console.log(text);
         if (text) {
             this.setState({showTemplateView: false});
         } 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -59,6 +59,7 @@ export default class NotesPanel extends Component {
 
     updateContextTrayItemToInsert = (contextTrayItem) => {
         this.setState({ contextTrayItemToInsert: contextTrayItem });
+        this.setState({showTemplateView: false});
     }
 
     updateContextTrayItemWithSelectedPickListOptions = (selectedPickListOptions) => {

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -43,6 +43,8 @@ export default class NotesPanel extends Component {
     }
 
     updateLocalDocumentText = (text) => {      
+
+        console.log(text);
         if (text) {
             this.setState({showTemplateView: false});
         } 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -23,7 +23,8 @@ export default class NotesPanel extends Component {
             currentlyEditingEntryId: -1,
             arrayOfPickLists: [],
             contextTrayItemToInsert: null,
-            localDocumentText: ''
+            localDocumentText: '',
+            showTemplateView: false
         };
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
@@ -37,7 +38,14 @@ export default class NotesPanel extends Component {
         }
     }
 
-    updateLocalDocumentText = (text) => {
+    updateShowTemplateView = (showTemplateView) => {
+        this.setState({ showTemplateView });
+    }
+
+    updateLocalDocumentText = (text) => {      
+        if (text) {
+            this.setState({showTemplateView: false});
+        } 
         this.setState({ localDocumentText: text });
     }
 
@@ -153,6 +161,7 @@ export default class NotesPanel extends Component {
             selectedNote: null,
             currentlyEditingEntryId: -1
         });
+        
         this.props.setNoteClosed(true);
         this.props.setLayout('right-collapsed');
         this.props.setNoteViewerVisible(false);
@@ -177,14 +186,19 @@ export default class NotesPanel extends Component {
         });
 
         this.openNote(newNote, true);
+
+        this.setState({ showTemplateView: true });
     }
 
     // Open an existing note
     openExistingNote = (isInProgress, note) => {
         this.openNote(note, isInProgress);
+        this.setState({ showTemplateView: false });
+       
     }
 
     openNote = (note, isInProgress) => {
+     
         // Saves the current note and resets localDocumentText before opening the next note.
         this.saveNote(this.state.localDocumentText);
 
@@ -369,6 +383,7 @@ export default class NotesPanel extends Component {
                     noteAssistantMode={this.state.noteAssistantMode}
                     noteClosed={this.props.noteClosed}
                     openNewNote={this.openNewNote}
+                    showTemplateView={this.state.showTemplateView}
                     openExistingNote={this.openExistingNote}
                     patient={this.props.patient}
                     saveNote={this.saveNote}
@@ -392,6 +407,7 @@ export default class NotesPanel extends Component {
                     updateContextTrayItemWithSelectedPickListOptions={this.updateContextTrayItemWithSelectedPickListOptions}
                     updatedEditorNote={this.state.updatedEditorNote}
                     updateErrors={this.props.updateErrors}
+                    updateShowTemplateView={this.updateShowTemplateView}
                 />
             </div>
         );

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -467,8 +467,6 @@ in a structured data insertion and the context panel updates', async t => {
 //     }
 // });
 
-
-// TODO: Nicole
 fixture('Patient Mode - Context Panel')
     .page(startPage);
 
@@ -487,9 +485,9 @@ test('Clicking "#enrollment", "#date" and choosing a date inserts "#enrollment #
     const expectedText = ["#enrollment", `#${today}`];
     const editor = Selector("div[data-slate-editor='true']");
     const structuredField = editor.find("span[class='structured-field']");
-    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
     const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+    const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const clinicalTrialButton = await contextPanelElements.withText(/#enrollment/ig);
 
     // Click on shortcuts
@@ -530,6 +528,12 @@ test('Clicking "#unenrolled", "#date" and choosing a date inserts "#unenrolled #
     const structuredField = editor.find("span[class='structured-field']");
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const clinicalTrialButton = await contextPanelElements.withText(/#unenrolled/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+    // Click on shortcuts
+    await t
+        .click(shortcutsButton);
 
     await t
         .click(clinicalTrialButton);
@@ -564,6 +568,12 @@ test('Clicking "#deceased", "#date" and choosing a date inserts "#deceased #{dat
     const structuredField = editor.find("span[class='structured-field']");
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const deceasedButton = await contextPanelElements.withText(/#deceased/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+    // Click on shortcuts
+    await t
+        .click(shortcutsButton);
 
     await t
         .click(deceasedButton);
@@ -602,6 +612,12 @@ test('Clicking "@condition", "#disease status", "#stable", "#as of", "#date" and
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const optionsForm = Selector("#pickList-options-panel").find(".option-btn");
     const invasiveButton = await optionsForm.withText(/Invasive ductal carcinoma of breast/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+    // Click on shortcuts
+    await t
+        .click(shortcutsButton);
 
     await t
         .click(conditionButton);
@@ -679,6 +695,12 @@ test('Clicking "@condition" and choosing "Invasive ductal carcinoma of breast" c
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const optionsForm = Selector("#pickList-options-panel").find(".option-btn");
     const invasiveButton = await optionsForm.withText(/Invasive ductal carcinoma of breast/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+     // Click on shortcuts
+     await t
+     .click(shortcutsButton);
 
     await t
         .click(conditionButton);
@@ -716,6 +738,12 @@ test('Clicking "@condition" and choosing multiple conditions does not allow user
     const patientButton = await sectionItemElements.withText(/CONTEXT/g);
     const optionsForm = Selector("#pickList-options-panel").find(".option-btn");
     const fractureButton = await optionsForm.withText(/Fracture/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+     // Click on shortcuts
+     await t
+     .click(shortcutsButton);
 
     // Input first condition
     await t
@@ -758,6 +786,12 @@ test('Not choosing an option from a portal still allows user to delete parent sh
     const structuredField = editor.find("span[class='structured-field']");
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const clinicalTrialButton = await contextPanelElements.withText(/#enrollment/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+    // Click on shortcuts
+     await t
+     .click(shortcutsButton);
 
     // Select post-encounter mode
     await t
@@ -948,7 +982,7 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
     const clinicalNotesButton = Selector('#notes-btn');
     // const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
-
+    
     // Enter some text in the editor
     await t
         .typeText(editor, "This is a note.");
@@ -959,7 +993,9 @@ test('Clicking on an in-progress note in post encounter mode loads the note in t
 
     // Click on the new note button to create an in-progress note and toggle back to clinical notes view
     await t
-        .click(newNoteButton)
+        .click(newNoteButton)    
+
+    await t
         .click(clinicalNotesButton);
 
     // Click on the in-progress note
@@ -1003,7 +1039,7 @@ test('Clicking on an in-progress note shows the sign note button', async t => {
     const editor = Selector("div[data-slate-editor='true']");
     const clinicalNotesButton = Selector('#notes-btn');
     const newNoteButton = Selector('.note-new');
-    const signButton = Selector('.btn_finish');
+    const signButton = Selector('.btn_finish');  
 
     // Click on the clinical notes button to switch to clinical notes view
     await t
@@ -1011,7 +1047,9 @@ test('Clicking on an in-progress note shows the sign note button', async t => {
 
     // Click on the new note button to create an in-progress note and toggle back to clinical notes view
     await t
-        .click(newNoteButton)
+        .click(newNoteButton)   
+
+    await t
         .click(clinicalNotesButton);
 
     // Check that the sign button exists
@@ -1029,6 +1067,7 @@ test('Clicking on the sign note button moves the note from in progress notes to 
     const newNoteButton = Selector('.note-new');
     const inProgressNotes = Selector('.in-progress-note');
     const signNoteButton = Selector('.btn_finish');
+   
 
     // Click clinical notes button
     await t
@@ -1036,7 +1075,9 @@ test('Clicking on the sign note button moves the note from in progress notes to 
 
     // Click "New note" button
     await t
-        .click(newNoteButton)
+        .click(newNoteButton)    
+     
+    await t
         .click(clinicalNotesButton);
 
     // Get the current number of in-progress notes
@@ -1063,6 +1104,12 @@ test('Entering disease status information updates the data in the targeted data 
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const unSignedItem = Selector('.list-unsigned');
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+    // Click on shortcuts
+    await t
+        .click(shortcutsButton);
 
     await t
         .click(conditionButton);
@@ -1107,6 +1154,12 @@ test('Clicking on the sign note button changes the unsigned data from a dotted l
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
     const unSignedItem = Selector('.list-unsigned');
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
+
+    // Click on shortcuts
+    await t
+        .click(shortcutsButton);
 
     await t
         .click(conditionButton);

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -733,9 +733,8 @@ test('Clicking "@condition" and choosing multiple conditions does not allow user
 
     const editor = Selector("div[data-slate-editor='true']");
     const contextPanelElements = Selector('.context-options-list').find('.context-option');
-    const sectionItemElements = Selector('.context-tray').find('.section-item');
+    // const sectionItemElements = Selector('.context-tray').find('.section-item');
     const conditionButton = await contextPanelElements.withText(/@condition/ig);
-    const patientButton = await sectionItemElements.withText(/CONTEXT/g);
     const optionsForm = Selector("#pickList-options-panel").find(".option-btn");
     const fractureButton = await optionsForm.withText(/Fracture/ig);
     const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
@@ -749,18 +748,16 @@ test('Clicking "@condition" and choosing multiple conditions does not allow user
     await t
         .click(conditionButton);
 
-    // Click on "Invasive..." button in the option panel
+    // Click on "Fracture" button in the option panel
     await t
         .click(fractureButton);
 
     // Input second condition
     await t
-        .click(patientButton);
-
-    await t
         .click(conditionButton);
 
     const invasiveButton = await optionsForm.withText(/Invasive ductal carcinoma of breast/ig);
+    
     await t
         .click(invasiveButton);
 

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -467,6 +467,8 @@ in a structured data insertion and the context panel updates', async t => {
 //     }
 // });
 
+
+// TODO: Nicole
 fixture('Patient Mode - Context Panel')
     .page(startPage);
 
@@ -486,13 +488,13 @@ test('Clicking "#enrollment", "#date" and choosing a date inserts "#enrollment #
     const editor = Selector("div[data-slate-editor='true']");
     const structuredField = editor.find("span[class='structured-field']");
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
-    const templatesList = Selector(".context-tray").find('.template');
-    const template = await templatesList.withText(/op note/ig);
+    const sectionItemElements = Selector('.context-tray').find('.view-mode-section-item');
+    const shortcutsButton = await sectionItemElements.withText(/SHORTCUTS/g);
     const clinicalTrialButton = await contextPanelElements.withText(/#enrollment/ig);
 
-    // Select a template
+    // Click on shortcuts
     await t
-        .click(template);
+        .click(shortcutsButton);
 
     // In shortcuts, click on #enrollment 
     await t

--- a/test/ui/FullApp.js
+++ b/test/ui/FullApp.js
@@ -9,8 +9,8 @@ const pagePort = "3000";
 const pageRoute = "/demo1"
 const startPage = `${pageDomain}:${pagePort}${pageRoute}`;
 
-fixture('Patient Mode - Patient Control Panel')
-    .page(startPage);
+// fixture('Patient Mode - Patient Control Panel')
+//     .page(startPage);
 
 // test('Clicking event buttons selects corresponding event', async t => {
 //     const clinicalEventSelector = Selector('.clinical-event-select');
@@ -486,8 +486,15 @@ test('Clicking "#enrollment", "#date" and choosing a date inserts "#enrollment #
     const editor = Selector("div[data-slate-editor='true']");
     const structuredField = editor.find("span[class='structured-field']");
     const contextPanelElements = Selector(".context-options-list").find('.context-option');
+    const templatesList = Selector(".context-tray").find('.template');
+    const template = await templatesList.withText(/op note/ig);
     const clinicalTrialButton = await contextPanelElements.withText(/#enrollment/ig);
 
+    // Select a template
+    await t
+        .click(template);
+
+    // In shortcuts, click on #enrollment 
     await t
         .click(clinicalTrialButton);
 


### PR DESCRIPTION
This PR addresses jira 1091. When the user clicks on "New Note" button, the templates view is displayed in the note assistant as opposed to the shortcuts view. 

This fix required passing a property to keep track of when to show the templates view and to make sure shortcuts view is still displayed in other use cases.

In addition, PropTypes were fixed in the files I touched and Full App UI test was updated to handle the new workflow when clicking "New Note" button.

Cases to test:
- On app start, click "New Note" => templates view is displayed
- On app start, click "New Note" => insert from targeted data panel => shortcuts view is displayed
- On app start, click "New Note" => set focus in editor => shortcuts view is displayed
- On app start, click "New Note" => set focus in editor, click clinical notes list, click an existing note, click back on the in progress note => shortcuts view is displayed
- On app start, click "New Note" => click "PLACEHOLDERS", select <staging> => view stays in placeholders view
- on app start, click "New Note" => click  "SHORTCUTS", select @patient => view stays in shortcuts view
- On app start, click "New Note" => insert a template and click ok => shortcuts view is displayed
- On app start, click "New Note" => click on a template, click cancel (don't choose an option) => shortcuts view is displayed



_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added Enzyme-UI tests for slim mode 
- N/A Added Enzyme-UI tests for full mode
- N/A Added backend tests for new functionality added
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
