### PR TITLE
Custom note naming

### DIFF
--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -21,7 +21,7 @@
     margin: 0;
 }
 
-#clinical-notes #note-description p.note-description-detail-value {
+#clinical-notes #note-description p.note-description-detail-value, #note-title-input {
     text-align: left;
     padding-top:0;
     font-size: .8rem;

--- a/src/notes/FluxNotesEditor.css
+++ b/src/notes/FluxNotesEditor.css
@@ -39,6 +39,10 @@
     color: black;
 }
 
+#edit-note-name-btn:hover {
+    cursor: pointer;
+}
+
 .MyEditor-root {
     font-family: 'Georgia', serif;
 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1179,6 +1179,7 @@ class FluxNotesEditor extends React.Component {
                 <TextField
                     id="note-title-input"
                     autoFocus={true}
+                    fullWidth={true}
                     defaultValue={noteTitle}
                     onKeyPress={this.submitNoteNameChange}
                 />

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -76,6 +76,7 @@ class FluxNotesEditor extends React.Component {
 
         this.contextManager.setIsBlock1BeforeBlock2(this.isBlock1BeforeBlock2.bind(this));
 
+        this.editor = null;
         this.didFocusChange = false;
         this.editorHasFocus = false;
         this.lastPosition = { top: 0, left: 0 };
@@ -1277,7 +1278,6 @@ class FluxNotesEditor extends React.Component {
             );
         }
         const callback = {}
-        let editor = null;
         let editorClassName = this.props.inModal ? 'editor-content-modal' : 'editor-content';
         /**
          * Render the editor, toolbar, dropdown and description for note
@@ -1286,7 +1286,7 @@ class FluxNotesEditor extends React.Component {
             <div id="clinical-notes" className="dashboard-panel">
                 {noteDescriptionContent}
                 <div className="MyEditor-root" onClick={(event) => {
-                    editor.focus();
+                    this.editor.focus();
                 }}>
                     { !this.props.inModal &&
                         <EditorToolbar
@@ -1306,8 +1306,8 @@ class FluxNotesEditor extends React.Component {
                             plugins={this.plugins}
                             readOnly={!this.props.isNoteViewerEditable}
                             state={this.state.state}
-                            ref={function (c) {
-                                editor = c;
+                            ref={(c) => {
+                                this.editor = c;
                             }}
                             onChange={this.onChange}
                             onInput={this.onInput}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1241,11 +1241,11 @@ class FluxNotesEditor extends React.Component {
          * Render the editor, toolbar, dropdown and description for note
          */
         return (
-            <div id="clinical-notes" className="dashboard-panel" onClick={(event) => {
-                editor.focus();
-            }}>
+            <div id="clinical-notes" className="dashboard-panel">
                 {noteDescriptionContent}
-                <div className="MyEditor-root">
+                <div className="MyEditor-root" onClick={(event) => {
+                    editor.focus();
+                }}>
                     { !this.props.inModal &&
                         <EditorToolbar
                             contextManager={this.props.contextManager}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1166,6 +1166,7 @@ class FluxNotesEditor extends React.Component {
             this.setState({
                 isEditingNoteName: false
             });
+            this.editor.focus();
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1178,7 +1178,7 @@ class FluxNotesEditor extends React.Component {
         if(this.props.selectedNote.signed) {
             noteTag = <p className="note-description-detail-value" id="note-title">{noteTitle}</p>;
         } else {
-            noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
+            noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
         }
         if(this.state.isEditingNoteName) {
             return (

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -13,7 +13,7 @@ import ContextPortal from '../context/ContextPortal';
 import {Row, Col} from 'react-flexbox-grid';
 import EditorToolbar from './EditorToolbar';
 import Button from '../elements/Button';
-import Divider from 'material-ui/Divider';
+import {TextField, Divider} from 'material-ui';
 import AutoReplace from 'slate-auto-replace'
 import SuggestionsPlugin from '../lib/slate-suggestions-dist'
 import position from '../lib/slate-suggestions-dist/caret-position';
@@ -198,6 +198,7 @@ class FluxNotesEditor extends React.Component {
             state: initialState,
             openedPortal: null,
             portalOptions: null,
+            isEditingNoteName: false
         };
     }
 
@@ -1146,6 +1147,47 @@ class FluxNotesEditor extends React.Component {
         this.setState({ openedPortal });
     }
 
+    /**
+     * Enable edit mode for a note name
+     */
+    enableNoteNameEditing = () => {
+        this.setState({
+            isEditingNoteName: true
+        });
+    }
+
+    /**
+     * Handle the user submitting a new name for a note
+     */
+    submitNoteNameChange = (e) => {
+        if(e.key === "Enter") {
+            this.props.selectedNote.subject = e.target.value;
+            this.setState({
+                isEditingNoteName: false
+            });
+        }
+    }
+
+    /**
+     * Render a TextField if the user wishes to edit the note name, otherwise render the note name as plain text
+     */
+    renderNoteNameEditor = (noteTitle) => {
+        if(this.state.isEditingNoteName) {
+            return (
+                <TextField
+                    id="note-title-input"
+                    autoFocus={true}
+                    defaultValue={noteTitle}
+                    onKeyPress={this.submitNoteNameChange}
+                />
+            );
+        } else {
+            return (
+                <p className="note-description-detail-value" id="note-title">{noteTitle}</p>
+            );
+        }
+    }
+
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
         const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
@@ -1178,8 +1220,8 @@ class FluxNotesEditor extends React.Component {
                 <div id="note-description">
                     <Row end="xs">
                         <Col xs={2}>
-                            <p className="note-description-detail-name">Name</p>
-                            <p className="note-description-detail-value" id="note-title">{noteTitle}</p>
+                            <p className="note-description-detail-name">Name <FontAwesome name="pencil" onClick={this.enableNoteNameEditing} /></p>
+                            {this.renderNoteNameEditor(noteTitle)}
                         </Col>
                         <Col xs={2}>
                             <p className="note-description-detail-name">Date</p>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1174,6 +1174,12 @@ class FluxNotesEditor extends React.Component {
      * Render a TextField if the user wishes to edit the note name, otherwise render the note name as plain text
      */
     renderNoteNameEditor = (noteTitle) => {
+        let noteTag;
+        if(this.props.selectedNote.signed) {
+            noteTag = <p className="note-description-detail-value" id="note-title">{noteTitle}</p>;
+        } else {
+            noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
+        }
         if(this.state.isEditingNoteName) {
             return (
                 <TextField
@@ -1185,9 +1191,7 @@ class FluxNotesEditor extends React.Component {
                 />
             );
         } else {
-            return (
-                <p className="note-description-detail-value" id="note-title">{noteTitle}</p>
-            );
+            return noteTag;
         }
     }
 
@@ -1223,7 +1227,7 @@ class FluxNotesEditor extends React.Component {
                 <div id="note-description">
                     <Row end="xs">
                         <Col xs={2}>
-                            <p className="note-description-detail-name">Name <FontAwesome name="pencil" onClick={this.enableNoteNameEditing} /></p>
+                            <p className="note-description-detail-name">Name</p>
                             {this.renderNoteNameEditor(noteTitle)}
                         </Col>
                         <Col xs={2}>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1161,7 +1161,7 @@ class FluxNotesEditor extends React.Component {
      * Handle the user submitting a new name for a note
      */
     submitNoteNameChange = (e) => {
-        if(e.key === "Enter") {
+        if (e.key === "Enter") {
             this.props.selectedNote.subject = e.target.value;
             this.setState({
                 isEditingNoteName: false
@@ -1175,12 +1175,12 @@ class FluxNotesEditor extends React.Component {
      */
     renderNoteNameEditor = (noteTitle, signed) => {
         let noteTag;
-        if(signed) {
+        if (signed) {
             noteTag = <p className="note-description-detail-value" id="note-title">{noteTitle}</p>;
         } else {
             noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
         }
-        if(this.state.isEditingNoteName) {
+        if (this.state.isEditingNoteName) {
             return (
                 <TextField
                     id="note-title-input"

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1173,9 +1173,9 @@ class FluxNotesEditor extends React.Component {
     /**
      * Render a TextField if the user wishes to edit the note name, otherwise render the note name as plain text
      */
-    renderNoteNameEditor = (noteTitle) => {
+    renderNoteNameEditor = (noteTitle, signed) => {
         let noteTag;
-        if(this.props.selectedNote.signed) {
+        if(signed) {
             noteTag = <p className="note-description-detail-value" id="note-title">{noteTitle}</p>;
         } else {
             noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
@@ -1205,6 +1205,7 @@ class FluxNotesEditor extends React.Component {
         let date = Moment(new Date()).format('DD MMM YYYY');
         let signedString = "not signed";
         let source = "Dana Farber";
+        let signed = false;
 
         // If a note is selected, update the note header with information from the selected note
         if (this.props.selectedNote) {
@@ -1213,6 +1214,7 @@ class FluxNotesEditor extends React.Component {
             source = this.props.selectedNote.hospital;
 
             if(this.props.selectedNote.signed) {
+                signed = true;
                 signedString = this.props.selectedNote.clinician;
             } else {
                 signedString = "not signed";
@@ -1228,7 +1230,7 @@ class FluxNotesEditor extends React.Component {
                     <Row end="xs">
                         <Col xs={2}>
                             <p className="note-description-detail-name">Name</p>
-                            {this.renderNoteNameEditor(noteTitle)}
+                            {this.renderNoteNameEditor(noteTitle, signed)}
                         </Col>
                         <Col xs={2}>
                             <p className="note-description-detail-name">Date</p>

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -163,9 +163,9 @@ export default class NotesPanel extends Component {
     openNewNote = () => {
         // Create info to be set for new note
         const date = new moment().format("D MMM YYYY");
-        const subject = "New Note";
         const hospital = "Dana Farber";
         const clinician = this.props.loginUser;
+        const subject = `${clinician}-${new moment().format("YYYYDDMM-hhmm")}`;
         const content = "";
         const signed = false;
 


### PR DESCRIPTION
This PR is for Jira 208, which allows the user to edit the names of unsigned notes, and adds a default name other than just "New Note" which was the previous default.

Added Functionality:
- When the new note button is clicked, the default note name will now be based off of the clinician's name, the date, and current time, e.g. "Dr. X123 Y987-20183007-1106."
- In the note viewer, there is now a button with a pencil icon that will enable editing of the note name
    - When clicked, the note name field will change into a text box where the user can make changes to them.
    - Hitting enter will confirm the edits and the name change will be saved.
    - Signed notes will not have the pencil button, as their names cannot be changed.

**Note**: We discussed enforcing uniqueness of note names, but we are not quite sure if this is actually what is desired based on how the names are created, so this functionality was not implemented on this branch. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added Enzyme-UI tests for slim mode 
- N/A Added Enzyme-UI tests for full mode
- N/A Added backend tests for new functionality added
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
