### PR TITLE
Updated patient entry dates

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -1,22 +1,7 @@
 [
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
         "Value": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "2",
@@ -24,34 +9,31 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
             }
         },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        },
+        "FathersName": {
+            "Value": "Jose Hernandez672",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/FathersName"
+            }
+        },
+        "LastUpdated": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
         "PlaceOfBirth": {
+            "Value": "US",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/PlaceOfBirth"
-            },
-            "Value": "US"
+            }
         },
-        "BirthSex": {
+        "CreationTime": {
+            "Value": "01 Jun 2012",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/BirthSex"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "F",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Female"
-                        }
-                    }
-                ]
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             }
         },
         "Race": {
@@ -59,17 +41,47 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Race"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "white",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "MothersMaidenName": {
+            "Value": "Himinez221",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MothersMaidenName"
+            }
+        },
+        "BirthSex": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/BirthSex"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "F",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "white"
+                        "DisplayText": {
+                            "Value": "Female",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         },
         "Ethnicity": {
@@ -77,18 +89,18 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Ethnicity"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "2186-5",
+                        "DisplayText": "Non Hispanic or Latino",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "2186-5",
-                        "DisplayText": "Non Hispanic or Latino"
+                        }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         },
         "MaritalStatus": {
@@ -96,120 +108,108 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/MaritalStatus"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "M",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "M",
                         "CodeSystem": {
+                            "Value": "http://hl7.org/fhir/v3/MaritalStatus",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://hl7.org/fhir/v3/MaritalStatus"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Married",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Married"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "MothersMaidenName": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MothersMaidenName"
-            },
-            "Value": "Himinez221"
-        },
-        "FathersName": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/FathersName"
-            },
-            "Value": "Jose Hernandez672"
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "2",
+        "DateOfBirth": "23 Aug 1966",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "2",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
         "HumanName": [
             {
+                "Value": "Debra Hernandez672",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/HumanName"
-                },
-                "Value": "Debra Hernandez672"
+                }
             }
         ],
-        "DateOfBirth": "5 APR 1966",
+        "LastUpdated": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "AdministrativeGender": "female",
         "Address": [
             {
+                "City": {
+                    "Value": "Boston",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/City"
+                    }
+                },
+                "State": {
+                    "Value": "MA",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/State"
+                    }
+                },
+                "Country": {
+                    "Value": "US",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Country"
+                    }
+                },
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Address"
                 },
+                "AddressLine": [
+                    {
+                        "Value": "123 Main Street",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/AddressLine"
+                        }
+                    }
+                ],
                 "Purpose": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Purpose"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "primary_residence",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "primary_residence"
+                                }
                             }
-                        ]
-                    }
-                },
-                "AddressLine": [
-                    {
+                        ],
                         "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/AddressLine"
-                        },
-                        "Value": "123 Main Street"
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
-                ],
-                "City": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/City"
-                    },
-                    "Value": "Boston"
-                },
-                "State": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/State"
-                    },
-                    "Value": "MA"
-                },
-                "Country": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Country"
-                    },
-                    "Value": "US"
                 }
             }
         ],
@@ -222,10 +222,10 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Attachment"
                 },
                 "ResourceLocation": {
+                    "Value": "./DebraHernandez672.png",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/ResourceLocation"
-                    },
-                    "Value": "./DebraHernandez672.png"
+                    }
                 }
             }
         },
@@ -234,28 +234,22 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/ContactPoint"
                 },
-                "TelecomNumberOrAddress": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
-                    },
-                    "Value": "999-555-5555"
-                },
                 "Type": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "phone",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "phone"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 },
                 "Purpose": {
@@ -263,17 +257,23 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Purpose"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "home",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "home"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "TelecomNumberOrAddress": {
+                    "Value": "999-555-5555",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
                     }
                 }
             },
@@ -281,28 +281,22 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/ContactPoint"
                 },
-                "TelecomNumberOrAddress": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
-                    },
-                    "Value": "999-555-4444"
-                },
                 "Type": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "phone",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "phone"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 },
                 "Purpose": {
@@ -310,17 +304,23 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Purpose"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "mobile",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "mobile"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "TelecomNumberOrAddress": {
+                    "Value": "999-555-4444",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
                     }
                 }
             }
@@ -335,267 +335,223 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/base/Language"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "en-US",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "en-US",
                                 "DisplayText": {
+                                    "Value": "English (United States)",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "English (United States)"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 }
             }
         ]
     },
     {
-        "identifierType": "MRN",
-        "organization": "MITRE",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
+        "value": "026-DH-678944",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "3",
+        "organization": "MITRE",
+        "identifierType": "MRN",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/base/PatientIdentifier"
         },
+        "fictionalPerson": "026-DH-678944",
         "LastUpdated": {
+            "Value": "17 Sep 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "PersonOfRecord": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                "EntryId": "1"
             }
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "value": "026-DH-678944",
-        "fictionalPerson": "026-DH-678944"
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "4",
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-        },
-        "PersonOfRecord": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                "EntryId": "1"
-            }
-        },
-        "date": "02 AUG 2015",
-        "subject": "Clinical follow-up",
-        "hospital": "Dana Farber",
-        "clinician": "Dr. Smith",
-        "content": "@name[[Debra Hernandez672]] is a @age[[49]] year old @gender[[Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
         "CreationTime": {
+            "Value": "17 Sep 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
+            }
         },
-        "LastUpdated": {
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
     },
     {
+        "date": "20 Dec 2015",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "5",
+        "signed": true,
+        "subject": "Clinical follow-up",
+        "content": "@name[[Debra Hernandez672]] is a @age[[49]] year old @gender[[Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
+        "EntryId": "4",
+        "hospital": "Dana Farber",
+        "clinician": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "17 Sep 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                "EntryId": "1"
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
-        "date": "12 JUL 2012",
+        "CreationTime": {
+            "Value": "17 Sep 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "date": "29 Nov 2012",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "signed": true,
         "subject": "Consult",
+        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name[[Debra Hernandez672]] has staging values T1 N1 and M0, corresponding to stage IIA.",
+        "EntryId": "5",
         "hospital": "Dana Farber",
         "clinician": "Dr. Zheng",
-        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name[[Debra Hernandez672]] has staging values T1 N1 and M0, corresponding to stage IIA.",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "6",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "17 Sep 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                "EntryId": "1"
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
-        "date": "20 JUN 2012",
+        "CreationTime": {
+            "Value": "17 Sep 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "date": "07 Nov 2012",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "signed": true,
         "subject": "Clinical post-op",
+        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
+        "EntryId": "6",
         "hospital": "Brigham and Women's",
         "clinician": "Dr. Smith",
-        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "7",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "17 Sep 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "17 Sep 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
             "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                "EntryId": "1"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
             }
-        },
-        "date": "16 MAY 2012",
-        "subject": "Clinical follow-up",
-        "hospital": "Dana Farber",
-        "clinician": "Dr. Strauss",
-        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name[[Debra Hernandez672]] is enrolled in the clinical trial PATINA on 12/24/2017.",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
+        }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
-        },
+        "date": "03 Oct 2012",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "8",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "signed": true,
+        "subject": "Clinical follow-up",
+        "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name[[Debra Hernandez672]] is enrolled in the clinical trial PATINA on 12/24/2017.",
+        "EntryId": "7",
+        "hospital": "Dana Farber",
+        "clinician": "Dr. Strauss",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "17 Sep 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "17 Sep 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
+            }
         },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 FEB 2012"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "408643008",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Invasive ductal carcinoma of breast"
-                    }
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
                 }
-            ]
-        },
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "8",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
         },
         "Evidence": [
             {
@@ -718,27 +674,71 @@
                 }
             }
         ],
-        "Category": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "#disease"
-                    }
-                ]
+        "LastUpdated": {
+            "Value": "20 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
-        ],
+        },
+        "CreationTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "ClinicalStatus": {
+            "Value": "active",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/condition/ClinicalStatus"
-            },
-            "Value": "active"
+            }
         },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "408643008",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Invasive ductal carcinoma of breast",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "Category": [
+            {
+                "Coding": [
+                    {
+                        "Value": "#disease",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        ],
         "BodySiteOrCode": [
             {
                 "EntryType": {
@@ -749,81 +749,99 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/BodySite"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "73056007",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "73056007",
                                 "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "Right breast structure",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Right breast structure"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     },
                     "Laterality": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/entity/Laterality"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "C25228",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "C25228",
                                     "CodeSystem": {
+                                        "Value": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "Right",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "Right"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         }
                     }
                 }
             }
         ],
         "WhenClinicallyRecognized": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
-            },
             "Value": {
+                "Value": "01 Jun 2012",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedDateTime"
-                },
-                "Value": "13 JAN 2012"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "9",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "20 Apr 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "20 Apr 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -831,119 +849,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 DEC 2013"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 DEC 2013"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "10 FEB 2012"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "20 AUG 2012"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "42512",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Adriamycin"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 6,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 6,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "10^9/L",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "10^9/L"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -955,68 +890,151 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 6,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 6
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "07 Jan 2013",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "29 Jun 2012",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
                 }
             }
         },
         "NumberOfRefillsAllowed": {
+            "Value": 5,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
             },
-            "Value": 5
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "42512",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Adriamycin",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "10",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "20 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "20 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -1024,119 +1042,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 FEB 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 FEB 2012"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "10 FEB 2012"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "20 AUG 2012"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "3002",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Cyclophosphamide"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 10,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 10,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg/kg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg/kg"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1148,68 +1083,151 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 6,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 6
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "07 Jan 2013",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "29 Jun 2012",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
                 }
             }
         },
         "NumberOfRefillsAllowed": {
+            "Value": 2,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
             },
-            "Value": 2
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "3002",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Cyclophosphamide",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "11",
+        "Author": {
+            "Value": "Dr. XYZ987",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "21 Mar 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 Mar 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -1217,119 +1235,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 NOV 2013"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 NOV 2013"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. XYZ987"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "01 NOV 2013"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "13 AUG 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "10324",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Tamoxifen"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 20,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 20,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1345,80 +1280,163 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrencePattern"
                         },
                         "RecurrenceInterval": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
-                            },
                             "Value": {
+                                "Value": 1,
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Duration"
                                 },
-                                "Value": 1,
                                 "Units": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                                    },
                                     "Value": {
+                                        "Value": "d",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                        },
-                                        "Value": "d"
+                                        }
+                                    },
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                                     }
                                 }
+                            },
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
                             }
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "31 Dec 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "21 Mar 2014",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
                 }
             }
         },
         "NumberOfRefillsAllowed": {
+            "Value": 0,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
             },
-            "Value": 0
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "10324",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Tamoxifen",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "12",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "29 May 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 May 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -1426,119 +1444,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "09 JAN 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "09 JAN 2015"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "10 JAN 2015"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "10 JAN 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "72965",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Letrozole"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 2.5,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 2.5,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1554,289 +1489,163 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrencePattern"
                         },
                         "RecurrenceInterval": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
-                            },
                             "Value": {
+                                "Value": 1,
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Duration"
                                 },
-                                "Value": 1,
                                 "Units": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                                    },
                                     "Value": {
+                                        "Value": "d",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                        },
-                                        "Value": "d"
+                                        }
+                                    },
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                                     }
                                 }
+                            },
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
                             }
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "29 May 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "30 May 2015",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
                 }
             }
         },
         "NumberOfRefillsAllowed": {
+            "Value": 2,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
             },
-            "Value": 2
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "72965",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Letrozole",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "13",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "05 SEP 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "05 SEP 2015"
-        },
         "Author": {
+            "Value": "Dr. XYZ987",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. XYZ987"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "05 SEP 2015"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "01 JUN 2017"
-                    }
-                }
             }
         },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "202421",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Coumadin"
-                        }
-                    }
-                ]
-            }
-        },
-        "Dosage": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
-            },
-            "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
-                    },
-                    "Value": 2,
-                    "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg"
-                        }
-                    }
-                }
-            },
-            "TimingOfDoses": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
-                    },
-                    "RecurrencePattern": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrencePattern"
-                        },
-                        "RecurrenceInterval": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
-                            },
-                            "Value": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Duration"
-                                },
-                                "Value": 1,
-                                "Units": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                                    },
-                                    "Value": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                        },
-                                        "Value": "d"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
-            },
-            "RouteIntoBody": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "26643006",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
-                            }
-                        }
-                    ]
-                }
-            }
-        },
-        "NumberOfRefillsAllowed": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
-            },
-            "Value": 5
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "14",
+        "LastUpdated": {
+            "Value": "23 Jan 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "23 Jan 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -1844,119 +1653,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "05 JUN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "05 JUN 2017"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "active"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "05 OCT 2017"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "01 MAY 2018"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "262105",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Aromasin"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 2,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 25,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1972,247 +1698,85 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrencePattern"
                         },
                         "RecurrenceInterval": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
-                            },
                             "Value": {
+                                "Value": 1,
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Duration"
                                 },
-                                "Value": 1,
                                 "Units": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                                    },
                                     "Value": {
+                                        "Value": "d",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                        },
-                                        "Value": "d"
+                                        }
+                                    },
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                                     }
                                 }
+                            },
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
                             }
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         },
-        "NumberOfRefillsAllowed": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
-            },
-            "Value": 3
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "15",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0024671",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Mammography"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "13 JAN 2012"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "16",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 JUL 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 JUL 2012"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0454059",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Radiation therapy procedure or service"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
+                    },
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
@@ -2221,35 +1785,520 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
                     },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "12 JUL 2012"
-                    },
                     "TimePeriodEnd": {
+                        "Value": "19 Oct 2017",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "16 AUG 2012"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "23 Jan 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
                     }
                 }
             }
         },
+        "NumberOfRefillsAllowed": {
+            "Value": 5,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "202421",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Coumadin",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "14",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "23 Oct 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "23 Oct 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "Dosage": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
+            },
+            "DoseAmount": {
+                "Value": {
+                    "Value": 25,
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
+                    },
+                    "Units": {
+                        "Value": {
+                            "Value": "mg",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        }
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                }
+            },
+            "TimingOfDoses": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
+                    },
+                    "RecurrencePattern": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrencePattern"
+                        },
+                        "RecurrenceInterval": {
+                            "Value": {
+                                "Value": 1,
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Duration"
+                                },
+                                "Units": {
+                                    "Value": {
+                                        "Value": "d",
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                        }
+                                    },
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                                    }
+                                }
+                            },
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceInterval"
+                            }
+                        }
+                    }
+                }
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "26643006",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "Oral route",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "active",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "18 Sep 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "22 Feb 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "NumberOfRefillsAllowed": {
+            "Value": 3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/NumberOfRefillsAllowed"
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "262105",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Aromasin",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "15",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
-        }
-    },
-    {
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0024671",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Mammography",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "01 Jun 2012",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "16",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "19 Nov 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Nov 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0454059",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Radiation therapy procedure or service",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "03 Jan 2013",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "29 Nov 2012",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "17",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "07 Feb 2013",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "07 Feb 2013",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0851238",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Lumpectomy",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -2257,323 +2306,312 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 SEP 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 SEP 2012"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0851238",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Lumpectomy"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "07 Feb 2013",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "20 SEP 2012"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "18",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 SEP 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 SEP 2012"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0796693",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Sentinel Lymph Node Biopsy"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "20 SEP 2012"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
-        }
-    },
-    {
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "19",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "LastUpdated": {
+            "Value": "07 Feb 2013",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "07 Feb 2013",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "04 OCT 2013"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "04 OCT 2013"
+            }
         },
         "Type": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0796693",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0024671",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Sentinel Lymph Node Biopsy",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Mammography"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "07 Feb 2013",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "04 OCT 2013"
+                }
             }
-        },
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "19",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "21 Feb 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 Feb 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0024671",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Mammography",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "21 Feb 2014",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "20",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JUN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2012"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1272745",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Improving, responding to treatment"
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "LastUpdated": {
+            "Value": "31 Oct 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "31 Oct 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C1272745",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Improving, responding to treatment",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "Evidence": [
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "C0031809",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "physical examination",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        ],
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FocalSubjectReference": {
@@ -2582,149 +2620,64 @@
             "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
-        },
-        "Evidence": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "C0031809",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "physical examination"
-                            }
-                        }
-                    ]
-                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
             }
-        ],
+        },
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "21",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 NOV 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 NOV 2012"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0677874",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Complete response or remission; no measurable or observable evidence of cancer."
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -2732,35 +2685,52 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "8",
-            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "FindingStatus": {
+        "LastUpdated": {
+            "Value": "21 Mar 2013",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 Mar 2013",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
             "Coding": [
                 {
+                    "Value": "C0677874",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Complete response or remission; no measurable or observable evidence of cancer.",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         },
         "Evidence": [
             {
@@ -2768,29 +2738,29 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0011923",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0011923",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "imaging",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "imaging"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             },
             {
@@ -2798,119 +2768,102 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0031809",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0031809",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "physical examination",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "physical examination"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "8",
+            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "22",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "17 APR 2014"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "17 APR 2014"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1546960",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Worsening, disease progressing"
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -2918,35 +2871,52 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "8",
-            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "FindingStatus": {
+        "LastUpdated": {
+            "Value": "04 Sep 2014",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "04 Sep 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
             "Coding": [
                 {
+                    "Value": "C1546960",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Worsening, disease progressing",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         },
         "Evidence": [
             {
@@ -2954,119 +2924,102 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0011923",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0011923",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "imaging",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "imaging"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "8",
+            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "23",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "03 JUL 2014"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "03 JUL 2014"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1272745",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Improving, responding to treatment"
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -3074,35 +3027,52 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "8",
-            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "FindingStatus": {
+        "LastUpdated": {
+            "Value": "20 Nov 2014",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "20 Nov 2014",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
             "Coding": [
                 {
+                    "Value": "C1272745",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Improving, responding to treatment",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         },
         "Evidence": [
             {
@@ -3110,119 +3080,102 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0030664",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0030664",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "pathology",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "pathology"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "8",
+            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "24",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "2 AUG 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "2 AUG 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205360",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Stable, neither improving nor worsening"
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -3230,35 +3183,52 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "8",
-            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "FindingStatus": {
+        "LastUpdated": {
+            "Value": "20 Dec 2015",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "20 Dec 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
             "Coding": [
                 {
+                    "Value": "C0205360",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Stable, neither improving nor worsening",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         },
         "Evidence": [
             {
@@ -3266,29 +3236,29 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0030664",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0030664",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "pathology",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "pathology"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             },
             {
@@ -3296,119 +3266,102 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C1457887",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C1457887",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "symptoms",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "symptoms"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "8",
+            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "25",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "11 AUG 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "11 AUG 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205360",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Stable, neither improving nor worsening"
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -3416,141 +3369,46 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "8",
-            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "C0031809",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "physical examination"
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "C1457887",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "symptoms"
-                            }
-                        }
-                    ]
-                }
-            }
-        ],
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0421176",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
-                        }
-                    }
-                ]
-            }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "26",
+        "LastUpdated": {
+            "Value": "29 Dec 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 Dec 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C0205360",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Stable, neither improving nor worsening",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -3558,43 +3416,138 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+        "Evidence": [
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "C0031809",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "physical examination",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
             },
-            "Value": "15 MAY 2017"
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "C1457887",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "symptoms",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        ],
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "8",
+            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
         },
-        "LastUpdated": {
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 MAY 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
         },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+        "FindingStatus": {
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C1546960",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Worsening, disease progressing"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0421176",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Progression",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "26",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -3602,35 +3555,52 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "8",
-            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "FindingStatus": {
+        "LastUpdated": {
+            "Value": "02 Oct 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "02 Oct 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
             "Coding": [
                 {
+                    "Value": "C1546960",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Worsening, disease progressing",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         },
         "Evidence": [
             {
@@ -3638,29 +3608,29 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
                             "Value": "C0030664",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "pathology",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "pathology"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             },
             {
@@ -3668,29 +3638,29 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0421176",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0421176",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "imaging",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "imaging"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             },
             {
@@ -3698,120 +3668,156 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Evidence"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "C0421176",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "C0421176",
                             "CodeSystem": {
+                                "Value": "http://ncimeta.nci.nih.gov",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://ncimeta.nci.nih.gov"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "symptoms",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "symptoms"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "8",
+            "_EntryType": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "27",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/condition/Injury"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "27",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "LastUpdated": {
+            "Value": "31 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "02 Jun 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2018"
+            }
         },
-        "LastUpdated": {
+        "ClinicalStatus": {
+            "Value": "active",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2018"
+                "Value": "http://standardhealthrecord.org/spec/shr/condition/ClinicalStatus"
+            }
         },
         "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0016658",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0016658",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Fracture",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Fracture"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
-        "Subject": {
+        "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
@@ -3820,367 +3826,195 @@
         },
         "Category": [
             {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "#structural_abnormality",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "#structural_abnormality"
+                        }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         ],
-        "ClinicalStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/condition/ClinicalStatus"
-            },
-            "Value": "active"
-        },
         "BodySiteOrCode": [
             {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/entity/BodySiteOrCode"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "724231006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "724231006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Bone structure of left fibula",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Bone structure of left fibula"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
         "WhenClinicallyRecognized": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
-            },
             "Value": {
+                "Value": "02 Jun 2018",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedDateTime"
-                },
-                "Value": "13 JAN 2018"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "28",
-        "PersonOfRecord": {
+        "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2018"
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
         "LastUpdated": {
+            "Value": "02 Jun 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2018"
+            }
+        },
+        "CreationTime": {
+            "Value": "02 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
         },
         "Type": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "433341001",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "433341001",
                         "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Application of long leg splint",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Application of long leg splint"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
                         "_EntryId": "27",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Injury"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "02 Jun 2018",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "13 JAN 2018"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/allergy/AllergyIntolerance"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "29",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "412533000",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": "Wheat Bran"
-                }
-            ]
-        },
-        "SubstanceCategory": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/allergy/SubstanceCategory"
-                },
-                "Value": "food"
-            }
-        ],
-        "AdverseReaction": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction"
-                },
-                "Manifestation": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "272027003",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Headache"
-                                }
-                            }
-                        ]
-                    }
-                },
-                "OccurrenceTime": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrenceTime"
-                    },
-                    "Value": "13 JAN 2015"
-                },
-                "Severity": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/condition/Severity"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "mild",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://hl7.org/fhir/reaction-event-severity"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Mild"
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction"
-                },
-                "Manifestation": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "249497008",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Vomiting"
-                                }
-                            }
-                        ]
-                    }
-                },
-                "OccurrenceTime": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrenceTime"
-                    },
-                    "Value": "13 JAN 2015"
-                },
-                "Severity": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/condition/Severity"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "severe",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://hl7.org/fhir/reaction-event-severity"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Severe"
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/allergy/AllergyIntolerance"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "30",
+        "LastUpdated": {
+            "Value": "31 Oct 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "02 Jun 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "412533000",
+                    "DisplayText": "Wheat Bran",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4188,44 +4022,12 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "410942007",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": "Milk - dietary"
-                }
-            ]
-        },
         "SubstanceCategory": [
             {
+                "Value": "food",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/allergy/SubstanceCategory"
-                },
-                "Value": "food"
+                }
             }
         ],
         "AdverseReaction": [
@@ -4233,70 +4035,70 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction"
                 },
-                "Manifestation": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "267060006",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Diarrhea"
-                                }
-                            }
-                        ]
-                    }
-                },
                 "OccurrenceTime": {
+                    "Value": "02 Jun 2015",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrenceTime"
-                    },
-                    "Value": "13 JAN 2015"
+                    }
                 },
                 "Severity": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/condition/Severity"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "mild",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "moderate",
                                 "CodeSystem": {
+                                    "Value": "http://hl7.org/fhir/reaction-event-severity",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://hl7.org/fhir/reaction-event-severity"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "Mild",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Moderate"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "Manifestation": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "272027003",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "Headache",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 }
             },
@@ -4304,177 +4106,322 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction"
                 },
-                "Manifestation": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "267105001",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Itching"
-                                }
-                            }
-                        ]
-                    }
-                },
                 "OccurrenceTime": {
+                    "Value": "02 Jun 2015",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrenceTime"
-                    },
-                    "Value": "13 JAN 2015"
+                    }
                 },
                 "Severity": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/condition/Severity"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "severe",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "mild",
                                 "CodeSystem": {
+                                    "Value": "http://hl7.org/fhir/reaction-event-severity",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://hl7.org/fhir/reaction-event-severity"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "Severe",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Mild"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "Manifestation": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "249497008",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "Vomiting",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 }
             }
         ]
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "30",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/allergy/AllergyIntolerance"
+        },
+        "LastUpdated": {
+            "Value": "31 Oct 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "02 Jun 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "410942007",
+                    "DisplayText": "Milk - dietary",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "SubstanceCategory": [
+            {
+                "Value": "food",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/allergy/SubstanceCategory"
+                }
+            }
+        ],
+        "AdverseReaction": [
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction"
+                },
+                "OccurrenceTime": {
+                    "Value": "02 Jun 2015",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrenceTime"
+                    }
+                },
+                "Severity": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/condition/Severity"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "moderate",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://hl7.org/fhir/reaction-event-severity",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "Moderate",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "Manifestation": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "267060006",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "Diarrhea",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                }
+            },
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/allergy/AdverseReaction"
+                },
+                "OccurrenceTime": {
+                    "Value": "02 Jun 2015",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrenceTime"
+                    }
+                },
+                "Severity": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/condition/Severity"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "mild",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://hl7.org/fhir/reaction-event-severity",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "Mild",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "Manifestation": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/allergy/Manifestation"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "267105001",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "Itching",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "31",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/allergy/NoKnownAllergy"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "31",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "LastUpdated": {
+            "Value": "31 Oct 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "02 Jun 2015",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2015"
+            }
         },
         "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "409137002",
+                    "DisplayText": "No known drug allergy",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "409137002",
                     "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": "No known drug allergy"
+                        }
+                    }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "32",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "Debra Hernandez672 is coming in to see Dr. X123 Y987 for a regular check up on the progress of her treatment for Invasive ductal carcinoma of the breast"
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "active"
-            },
-            "RequestIntent": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
-                },
-                "Value": "plan"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "12 MAR 2018 15:00 -0500"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4482,19 +4429,27 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "ReferralDate": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
-            },
-            "Value": "01 JAN 2018"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "33",
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "ReferralDate": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4502,49 +4457,41 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
         "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            "Status": {
+                "Value": "active",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
             "Reason": [
                 {
+                    "Value": "Debra Hernandez672 is coming in to see Dr. X123 Y987 for a regular check up on the progress of her treatment for Invasive ductal carcinoma of the breast",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "Debra Hernandez672 saw Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast"
+                    }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "active"
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "RequestIntent": {
+                "Value": "plan",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
-                },
-                "Value": "plan"
+                }
             },
             "ExpectedPerformanceTime": {
+                "Value": "31 Jul 2018 16:00 -0400",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "12 FEB 2018 16:00 -0500"
+                }
             }
-        },
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "33",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4552,19 +4499,27 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "ReferralDate": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
-            },
-            "Value": "02 JAN 2018"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "33",
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "ReferralDate": {
+            "Value": "22 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4572,49 +4527,41 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
         "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            "Status": {
+                "Value": "active",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
             "Reason": [
                 {
+                    "Value": "Debra Hernandez672 saw Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "Debra Hernandez672 is coming in to see Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast"
+                    }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "active"
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "RequestIntent": {
+                "Value": "plan",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
-                },
-                "Value": "plan"
+                }
             },
             "ExpectedPerformanceTime": {
+                "Value": "3 Jul 2018 16:00 -0400",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "28 FEB 2018 18:00 -0500"
+                }
             }
-        },
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "33",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4622,19 +4569,84 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
         "ReferralDate": {
+            "Value": "22 May 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "active",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
-            "Value": "02 JAN 2018"
+            "Reason": [
+                {
+                    "Value": "Debra Hernandez672 is coming in to see Dr. X123 Y987 for a check up on the progress of her treatment for Invasive ductal carcinoma of the breast",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "RequestIntent": {
+                "Value": "plan",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                }
+            },
+            "ExpectedPerformanceTime": {
+                "Value": "19 Jul 2018 18:00 -0400",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "34",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "34",
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4642,47 +4654,7 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C95618",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Review of systems"
-                    }
-                }
-            ]
-        },
         "Members": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/Members"
-            },
             "Value": [
                 {
                     "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
@@ -4789,15 +4761,56 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/Members"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C95618",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Review of systems",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": true,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "35",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4805,51 +4818,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": true,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C50575",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C50575",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "alopecia",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "alopecia"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": true,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "36",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4857,51 +4870,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": true,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C61443",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C61443",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "amenorrhea",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "amenorrhea"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": true,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "37",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4909,51 +4922,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": true,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C118263",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C118263",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "numbness or tingling in hands and feet",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "numbness or tingling in hands and feet"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "38",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -4961,51 +4974,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 4",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 4"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "39",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5013,51 +5026,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 5",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 5"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "40",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5065,51 +5078,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 6",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 6"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "41",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5117,51 +5130,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 7",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 7"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "42",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5169,51 +5182,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 8",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 8"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "43",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5221,51 +5234,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 9",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 9"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "44",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5273,51 +5286,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 10",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 10"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "45",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5325,51 +5338,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 11",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 11"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "46",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5377,51 +5390,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 12",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 12"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "47",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5429,103 +5442,103 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 13",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 13"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "48",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "foo",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 14"
-                    }
-                }
-            ]
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
         },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "foo",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Question 14",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        }
+    },
+    {
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "49",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5533,51 +5546,67 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 15",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 15"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1000",
+        "Value": {
+            "Value": 15,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "%",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5585,98 +5614,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "21 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 15,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "%"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0019046",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0019046",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Hemoglobin",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Hemoglobin"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "01 JAN 2018"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1010",
+        "Value": {
+            "Value": 10.3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "%",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "08 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "08 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5684,98 +5713,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "08 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "19 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "19 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 10.3,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "%"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0019046",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0019046",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Hemoglobin",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Hemoglobin"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "19 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1020",
+        "Value": {
+            "Value": 14.5,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "%",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "30 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "30 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5783,98 +5812,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "30 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "10 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "10 JAN 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 14.5,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "%"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0019046",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0019046",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Hemoglobin",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Hemoglobin"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "10 JAN 2018"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1030",
+        "Value": {
+            "Value": 6.74,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "14 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "14 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5882,98 +5911,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "14 Apr 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "25 NOV 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "25 NOV 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 6.74,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "25 NOV 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1040",
+        "Value": {
+            "Value": 3.37,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "24 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "24 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -5981,98 +6010,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "24 Apr 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "5 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "5 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 3.37,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "5 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1050",
+        "Value": {
+            "Value": 1.86,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "01 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6080,98 +6109,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "01 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "12 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 1.86,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "12 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1060",
+        "Value": {
+            "Value": 4.72,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "08 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "08 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6179,98 +6208,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "08 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "19 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "19 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 4.72,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "19 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1070",
+        "Value": {
+            "Value": 6.75,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "16 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "16 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6278,93 +6307,93 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "16 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "27 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "27 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 6.75,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
                     "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": "Final"
-                }
-            ]
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
+                    "DisplayText": "Final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "27 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C0023508",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "White blood cell",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1080",
+        "Value": {
+            "Value": 8.12,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "22 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6372,98 +6401,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "22 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 JAN 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 8.12,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "02 JAN 2018"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1090",
+        "Value": {
+            "Value": 4.2,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "14 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "14 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6471,98 +6500,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "14 Apr 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "25 NOV 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "25 NOV 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 4.2,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "25 NOV 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1100",
+        "Value": {
+            "Value": 2.3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "24 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "24 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6570,98 +6599,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "24 Apr 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "5 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "5 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 2.3,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "5 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1110",
+        "Value": {
+            "Value": 1.2,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "01 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6669,98 +6698,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "01 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "12 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 1.2,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "12 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1120",
+        "Value": {
+            "Value": 1.9,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "08 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "08 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6768,197 +6797,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "08 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "19 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "19 DEC 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 1.9,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "19 DEC 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "EntryId": "1130",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "27 DEC 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "27 DEC 2017"
-        },
         "Value": {
+            "Value": 2.6,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
             },
-            "Value": 2.6,
             "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
                 "Value": {
+                    "Value": "10^9/L",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                 }
             }
         },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0027950",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
-                    }
-                }
-            ]
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "27 DEC 2017"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "1140",
+        "LastUpdated": {
+            "Value": "16 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "16 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -6966,98 +6896,205 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "16 May 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 JAN 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 4.3,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "02 JAN 2018"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "1140",
+        "Value": {
+            "Value": 4.3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "22 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "22 May 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C0027950",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Neutrophil",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "1150",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "1150",
+        "LastUpdated": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "369792005",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "High grade or poorly differentiated",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -7065,81 +7102,73 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "369792005",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "High grade or poorly differentiated"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
+        "EntryId": "1160",
+        "Value": {
+            "Value": 30,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "mm",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
-        "EntryId": "1160",
+        "LastUpdated": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
             "_EntryId": "1",
@@ -7147,90 +7176,61 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "01 Jun 2012",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 30,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "mm"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0475440",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0475440",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Tumor Size",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Tumor Size"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "13 JAN 2012"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     }
 ]

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -1,22 +1,7 @@
 [
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "1",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
         "Value": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "2",
@@ -24,34 +9,31 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
             }
         },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        },
+        "FathersName": {
+            "Value": "Jose Ortiz111",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/FathersName"
+            }
+        },
+        "LastUpdated": {
+            "Value": "29 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
         "PlaceOfBirth": {
+            "Value": "US",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/PlaceOfBirth"
-            },
-            "Value": "US"
+            }
         },
-        "BirthSex": {
+        "CreationTime": {
+            "Value": "29 Jun 2012",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/BirthSex"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "F",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Female"
-                        }
-                    }
-                ]
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             }
         },
         "Race": {
@@ -59,17 +41,47 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Race"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "white",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "MothersMaidenName": {
+            "Value": "Himinez221",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MothersMaidenName"
+            }
+        },
+        "BirthSex": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/BirthSex"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "F",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "white"
+                        "DisplayText": {
+                            "Value": "Female",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         },
         "Ethnicity": {
@@ -77,18 +89,18 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Ethnicity"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "2135-2",
+                        "DisplayText": "Hispanic or Latino",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "2135-2",
-                        "DisplayText": "Hispanic or Latino"
+                        }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         },
         "MaritalStatus": {
@@ -96,120 +108,108 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/MaritalStatus"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "M",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "M",
                         "CodeSystem": {
+                            "Value": "http://hl7.org/fhir/v3/MaritalStatus",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://hl7.org/fhir/v3/MaritalStatus"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Married",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Married"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "MothersMaidenName": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MothersMaidenName"
-            },
-            "Value": "Himinez221"
-        },
-        "FathersName": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/FathersName"
-            },
-            "Value": "Jose Ortiz111"
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2",
+        "DateOfBirth": "01 Jun 1975",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/entity/Person"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2012"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2012"
-        },
         "HumanName": [
             {
+                "Value": "Ella Ortiz111",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/HumanName"
-                },
-                "Value": "Ella Ortiz111"
+                }
             }
         ],
-        "DateOfBirth": "15 DEC 1974",
+        "LastUpdated": {
+            "Value": "29 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 Jun 2012",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "AdministrativeGender": "female",
         "Address": [
             {
+                "City": {
+                    "Value": "Boston",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/City"
+                    }
+                },
+                "State": {
+                    "Value": "MA",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/State"
+                    }
+                },
+                "Country": {
+                    "Value": "US",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Country"
+                    }
+                },
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Address"
                 },
+                "AddressLine": [
+                    {
+                        "Value": "123 Other Street",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/AddressLine"
+                        }
+                    }
+                ],
                 "Purpose": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Purpose"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "primary_residence",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "primary_residence"
+                                }
                             }
-                        ]
-                    }
-                },
-                "AddressLine": [
-                    {
+                        ],
                         "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/AddressLine"
-                        },
-                        "Value": "123 Other Street"
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
-                ],
-                "City": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/City"
-                    },
-                    "Value": "Boston"
-                },
-                "State": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/State"
-                    },
-                    "Value": "MA"
-                },
-                "Country": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Country"
-                    },
-                    "Value": "US"
                 }
             }
         ],
@@ -222,10 +222,10 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Attachment"
                 },
                 "ResourceLocation": {
+                    "Value": "./EllaOrtiz111.png",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/ResourceLocation"
-                    },
-                    "Value": "./EllaOrtiz111.png"
+                    }
                 }
             }
         },
@@ -234,28 +234,22 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/ContactPoint"
                 },
-                "TelecomNumberOrAddress": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
-                    },
-                    "Value": "999-555-5555"
-                },
                 "Type": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "phone",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "phone"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 },
                 "Purpose": {
@@ -263,17 +257,23 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Purpose"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "home",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "home"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "TelecomNumberOrAddress": {
+                    "Value": "999-555-5555",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
                     }
                 }
             },
@@ -281,28 +281,22 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/ContactPoint"
                 },
-                "TelecomNumberOrAddress": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
-                    },
-                    "Value": "999-555-4444"
-                },
                 "Type": {
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "phone",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "phone"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 },
                 "Purpose": {
@@ -310,17 +304,23 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/Purpose"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "mobile",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "mobile"
+                                }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                },
+                "TelecomNumberOrAddress": {
+                    "Value": "999-555-4444",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TelecomNumberOrAddress"
                     }
                 }
             }
@@ -335,341 +335,297 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/base/Language"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "en-US",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "en-US",
                                 "DisplayText": {
+                                    "Value": "English (United States)",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "English (United States)"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 }
             }
         ]
     },
     {
-        "identifierType": "MRN",
-        "organization": "MITRE",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
+        "value": "022-EO-671974",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "3",
+        "organization": "MITRE",
+        "identifierType": "MRN",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/base/PatientIdentifier"
         },
+        "fictionalPerson": "022-EO-671974",
         "LastUpdated": {
+            "Value": "15 Oct 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "PersonOfRecord": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
             }
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "value": "022-EO-671974",
-        "fictionalPerson": "022-EO-671974"
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "1000",
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-        },
-        "PersonOfRecord": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
-            }
-        },
-        "date": "09 NOV 2015",
-        "subject": "Experienced pain in breast and felt lump in right breast during self-examination",
-        "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
-        "content": "@name[[Ella Ortiz111]] is a @age[[40]] year old @gender[[Female]] presenting with pain in her right breast. She felt a lump during a self-examination.\nOrdering mammography.",
         "CreationTime": {
+            "Value": "15 Oct 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
+            }
         },
-        "LastUpdated": {
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
     },
     {
+        "date": "25 Apr 2016",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "1005",
+        "signed": true,
+        "subject": "Experienced pain in breast and felt lump in right breast during self-examination",
+        "content": "@name[[Ella Ortiz111]] is a @age[[40]] year old @gender[[Female]] presenting with pain in her right breast. She felt a lump during a self-examination.\nOrdering mammography.",
+        "EntryId": "1000",
+        "hospital": "Hospital X",
+        "clinician": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "15 Oct 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
-        "date": "13 NOV 2015",
+        "CreationTime": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "date": "29 Apr 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "signed": true,
         "subject": "Mammography",
+        "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given mammography.\nshowed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. Order a right targeted spot compression breast ultrasound.",
+        "EntryId": "1005",
         "hospital": "Hospital X",
         "clinician": "Dr. Zheng",
-        "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given mammography.\nshowed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. Order a right targeted spot compression breast ultrasound.",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "1010",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "15 Oct 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
-        "date": "29 NOV 2015",
+        "CreationTime": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "date": "15 May 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "signed": true,
         "subject": "Ultrasound Report",
+        "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given a right targeted spot compression breast ultrasound of a palpable lump. Image revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate",
+        "EntryId": "1010",
         "hospital": "Hospital X",
         "clinician": "Dr. Strauss",
-        "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given a right targeted spot compression breast ultrasound of a palpable lump. Image revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "1070",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "15 Oct 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
-        "date": "27 SEP 2017",
+        "CreationTime": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "date": "14 Mar 2018",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "signed": true,
         "subject": "Treatment Progress",
-        "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
         "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 42-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\n\nASSESSMENT:\nStop Tamoxifen.",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "1080",
+        "EntryId": "1070",
+        "hospital": "Hospital X",
+        "clinician": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
+        "LastUpdated": {
+            "Value": "15 Oct 2018",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
-        "date": "10 OCT 2017",
+        "CreationTime": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "date": "27 Mar 2018",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "signed": true,
         "subject": "Pre-chemotherapy",
+        "content": "REASON FOR VISIT:\nReplace Port-A-Cath\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 42-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\nTamoxifen was stopped September 27, 2017.\n\n\nASSESSMENT:\nA Port-A-Cath was replaced today.\nShe will start induction chemotherapy with trastuzumab and paclitaxel due to low volume of metastatic disease, beginning on October 17, 2017.",
+        "EntryId": "1080",
         "hospital": "Hospital X",
         "clinician": "Dr. Smith",
-        "content": "REASON FOR VISIT:\nReplace Port-A-Cath\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 42-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\nTamoxifen was stopped September 27, 2017.\n\n\nASSESSMENT:\nA Port-A-Cath was replaced today.\nShe will start induction chemotherapy with trastuzumab and paclitaxel due to low volume of metastatic disease, beginning on October 17, 2017.",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
-        },
-        "signed": true
-    },
-    {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "1085",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
-        "PersonOfRecord": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "1"
-            }
-        },
-        "date": "30 JAN 2018",
-        "subject": "Treatment Check-in",
-        "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
-        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 43-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\nTamoxifen was stopped September 27, 2017.\n\nA Port-A-Cath was replaced on October 10, 2017.\nShe underwent induction chemotherapy with trastuzumab and paclitaxel due to low volume of metastatic disease, beginning on October 17, 2017.\n\nASSESSMENT:\nAlthough her #disease status is #stable #as of #1/30/2018, recommending to halt after 5 cycles due to #toxicity #Grade 3 #myalgia and #toxicity #Grade 3 #peripheral motor neuropathy attributed to paclitaxel.",
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 Apr 2018"
-        },
         "LastUpdated": {
+            "Value": "15 Oct 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 Apr 2018"
+            }
         },
-        "signed": true
+        "CreationTime": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
     },
     {
+        "date": "17 Jul 2018",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "signed": true,
+        "subject": "Treatment Check-in",
+        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 43-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\nTamoxifen was stopped September 27, 2017.\n\nA Port-A-Cath was replaced on October 10, 2017.\nShe underwent induction chemotherapy with trastuzumab and paclitaxel due to low volume of metastatic disease, beginning on October 17, 2017.\n\nASSESSMENT:\nAlthough her #disease status is #stable #as of #1/30/2018, recommending to halt after 5 cycles due to #toxicity #Grade 3 #myalgia and #toxicity #Grade 3 #peripheral motor neuropathy attributed to paclitaxel.",
+        "EntryId": "1085",
+        "hospital": "Hospital X",
+        "clinician": "Dr. Smith",
         "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
+        "LastUpdated": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 Oct 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "8",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "408643008",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Invasive ductal carcinoma of breast"
-                    }
-                }
-            ]
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
         },
         "Evidence": [
             {
@@ -841,27 +797,71 @@
                 }
             }
         ],
-        "Category": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "#disease"
-                    }
-                ]
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
-        ],
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "408643008",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Invasive ductal carcinoma of breast",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "ClinicalStatus": {
+            "Value": "active",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/condition/ClinicalStatus"
-            },
-            "Value": "active"
+            }
         },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "Category": [
+            {
+                "Coding": [
+                    {
+                        "Value": "#disease",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        ],
         "BodySiteOrCode": [
             {
                 "EntryType": {
@@ -872,58 +872,58 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/entity/BodySite"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "73056007",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "73056007",
                                 "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "Right breast structure",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Right breast structure"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     },
                     "Laterality": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/entity/Laterality"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "C25228",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "C25228",
                                     "CodeSystem": {
+                                        "Value": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "Right",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "Right"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         }
                     },
                     "ClockDirection": {
@@ -931,58 +931,58 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/ClockDirection"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "C0442323",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "C0442323",
                                     "CodeSystem": {
+                                        "Value": "http://ncimeta.nci.nih.gov",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://ncimeta.nci.nih.gov"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "7 o'clock position",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "7 o'clock position"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         },
                         "ObservationCode": {
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
                             },
                             "Value": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                                },
                                 "Coding": [
                                     {
+                                        "Value": "assertion",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                         },
-                                        "Value": "assertion",
                                         "CodeSystem": {
+                                            "Value": "",
                                             "EntryType": {
                                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                            },
-                                            "Value": ""
+                                            }
                                         },
                                         "DisplayText": {
+                                            "Value": "",
                                             "EntryType": {
                                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                            },
-                                            "Value": ""
+                                            }
                                         }
                                     }
-                                ]
+                                ],
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                                }
                             }
                         }
                     }
@@ -990,210 +990,41 @@
             }
         ],
         "WhenClinicallyRecognized": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
-            },
             "Value": {
+                "Value": "15 May 2016",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedDateTime"
-                },
-                "Value": "29 NOV 2015"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "9",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 JAN 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "23 MAY 2016"
-        },
         "Author": {
+            "Value": "Dr. ABC123",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "20 JAN 2016"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "23 MAY 2016"
-                    }
-                }
             }
         },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "3002",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Cyclophosphamide"
-                        }
-                    }
-                ]
-            }
-        },
-        "Dosage": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
-            },
-            "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
-                    },
-                    "Value": 10,
-                    "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg/kg"
-                        }
-                    }
-                }
-            },
-            "TimingOfDoses": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
-                    },
-                    "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 11
-                        }
-                    }
-                }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
-            },
-            "RouteIntoBody": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "26643006",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "10",
+        "LastUpdated": {
+            "Value": "07 Nov 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "06 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -1201,119 +1032,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 JAN 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 JAN 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "20 JAN 2016"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "23 MAY 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "56946",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "PACLitaxel"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 10,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 205,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg/kg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg/m2"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1325,136 +1073,370 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 11,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 11
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "07 Nov 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "06 Jul 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "3002",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Cyclophosphamide",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                 }
             }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "10",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "06 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "06 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "Dosage": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
+            },
+            "DoseAmount": {
+                "Value": {
+                    "Value": 205,
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
+                    },
+                    "Units": {
+                        "Value": {
+                            "Value": "mg/m2",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        }
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                }
+            },
+            "TimingOfDoses": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
+                    },
+                    "RecurrenceRange": {
+                        "Value": {
+                            "Value": 11,
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
+                        }
+                    }
+                }
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "26643006",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "Oral route",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "07 Nov 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "06 Jul 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "56946",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "PACLitaxel",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "11",
+        "Author": {
+            "Value": "Dr. XYZ987",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationChange"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "11",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "LastUpdated": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "17 Jul 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. XYZ987"
+            }
         },
         "Type": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "reduced",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "reduced",
                         "DisplayText": {
+                            "Value": "Dose Reduced",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Dose Reduced"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         },
-        "MedicationBeforeChange": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationBeforeChange"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "14"
-            }
-        },
-        "MedicationAfterChange": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationAfterChange"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                "EntryId": "19"
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/PerformedContext"
             },
@@ -1464,40 +1446,76 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "side_effect",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "side_effect",
                                 "DisplayText": {
+                                    "Value": "Side Effect",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Side Effect"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 }
-            ],
-            "Status": {
+            ]
+        },
+        "MedicationAfterChange": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "19",
                 "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationAfterChange"
+            }
+        },
+        "MedicationBeforeChange": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                "EntryId": "14",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationBeforeChange"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "12",
+        "Author": {
+            "Value": "Dr. XYZ987",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "23 Mar 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "23 Mar 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -1505,119 +1523,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "06 OCT 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "06 OCT 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. XYZ987"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "06 OCT 2016"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "27 SEP 2017"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "10324",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Tamoxifen"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 4,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 4,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1629,62 +1564,145 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 6,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 6
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "14 Mar 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "23 Mar 2017",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "10324",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Tamoxifen",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                 }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "13",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "03 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -1692,119 +1710,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "17 OCT 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "17 OCT 2017"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "30 JAN 2018"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "224905",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Trastuzumab"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 9,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 9,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg/kg",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg/kg"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -1816,62 +1751,145 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 5,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 5
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "17 Jul 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "03 Apr 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "224905",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Trastuzumab",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                 }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "14",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "03 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -1879,119 +1897,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "17 OCT 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "17 OCT 2017"
-                    },
-                    "TimePeriodEnd": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "30 JAN 2018"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "56946",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "PACLitaxel"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 200,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 200,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "mg/m2",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "mg/m2"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
                 }
             },
             "TimingOfDoses": {
@@ -2003,62 +1938,145 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 5,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 5
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodEnd": {
+                        "Value": "17 Jul 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "03 Apr 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "56946",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "PACLitaxel",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                 }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "15",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -2066,312 +2084,65 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "15 FEB 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "29046",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Lisinopril 20mg tablet"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 1,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 1,
                     "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
                         "Value": {
+                            "Value": "tablet",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "tablet"
-                        }
-                    }
-                }
-            },
-            "TimingOfDoses": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
-                    },
-                    "TimingCode": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
+                            }
                         },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
-                            "Coding": [
-                                {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                    },
-                                    "Value": "QD",
-                                    "CodeSystem": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation"
-                                    },
-                                    "DisplayText": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "QD"
-                                    }
-                                }
-                            ]
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                         }
                     }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
                 }
             },
             "AsNeededIndicator": {
+                "Value": false,
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
+                }
             },
             "RouteIntoBody": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "26643006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Oral route",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                }
                             }
                         }
-                    ]
-                }
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "16",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
+                    ],
                     "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "15 FEB 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "316077",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "ibuprofen 600mg tablet"
-                        }
-                    }
-                ]
-            }
-        },
-        "Dosage": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
-            },
-            "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
-                    },
-                    "Value": 1,
-                    "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "tablet"
-                        }
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                     }
                 }
             },
@@ -2388,38 +2159,232 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "QD",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "TID",
                                     "CodeSystem": {
+                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "QD",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "TID"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         }
                     }
                 }
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodStart": {
+                        "Value": "01 Aug 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "29046",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "Lisinopril 20mg tablet",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "16",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "Dosage": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
+            },
+            "DoseAmount": {
+                "Value": {
+                    "Value": 1,
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
+                    },
+                    "Units": {
+                        "Value": {
+                            "Value": "tablet",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        }
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
             },
             "AsNeededIndicator": {
+                "Value": true,
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                }
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
                 },
-                "Value": true
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "26643006",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "Oral route",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            },
+            "TimingOfDoses": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
+                    },
+                    "TimingCode": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
+                        },
+                        "Value": {
+                            "Coding": [
+                                {
+                                    "Value": "TID",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                    },
+                                    "CodeSystem": {
+                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation",
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                        }
+                                    },
+                                    "DisplayText": {
+                                        "Value": "TID",
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                        }
+                                    }
+                                }
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
+                        }
+                    }
+                }
             },
             "AdditionalDoseInstruction": [
                 {
@@ -2427,119 +2392,57 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/medication/AdditionalDoseInstruction"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "311504000",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "311504000",
                                 "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "With or after food",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "With or after food"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     }
                 }
-            ],
-            "RouteIntoBody": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "26643006",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "17",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
+            ]
         },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
@@ -2549,10 +2452,10 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
                     },
                     "TimePeriodStart": {
+                        "Value": "01 Aug 2016",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "15 FEB 2016"
+                        }
                     }
                 }
             }
@@ -2562,23 +2465,55 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "316077",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "310891",
                         "DisplayText": {
+                            "Value": "ibuprofen 600mg tablet",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "hydrocortisone 2.5% ointment"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "17",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
         "Dosage": {
@@ -2586,24 +2521,60 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 1,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 1,
                     "Units": {
+                        "Value": {
+                            "Value": "g",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            }
+                        },
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
+                        }
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": true,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                }
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "6064005",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "g"
+                            "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "Topical route",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
                         }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                     }
                 }
             },
@@ -2620,107 +2591,130 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "BID",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "BID",
                                     "CodeSystem": {
+                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "BID",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "BID"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
                 "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": true
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
-            "RouteIntoBody": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
                 "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
                 },
                 "Value": {
                     "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
                     },
-                    "Coding": [
-                        {
+                    "TimePeriodStart": {
+                        "Value": "01 Aug 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "310891",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "hydrocortisone 2.5% ointment",
                             "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "6064005",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Topical route"
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                             }
                         }
-                    ]
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                 }
             }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "18",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancerGeneticAnalysisPanel"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "18",
+        "LastUpdated": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "01 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "15 OCT 2015"
         },
         "Members": {
             "EntryType": {
@@ -2732,58 +2726,58 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/oncology/BRCA1Variant"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "C0205160",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "C0205160",
                                 "CodeSystem": {
+                                    "Value": "http://ncimeta.nci.nih.gov",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://ncimeta.nci.nih.gov"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "Negative",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Negative"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     },
                     "FocalSubject": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/finding/FocalSubject"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "405827002",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "405827002",
                                     "CodeSystem": {
+                                        "Value": "http://snomed.info/sct",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://snomed.info/sct"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "Breast cancer type 1 susceptibility protein",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "Breast cancer type 1 susceptibility protein"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         }
                     }
                 },
@@ -2792,70 +2786,94 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/oncology/BRCA2Variant"
                     },
                     "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
                         "Coding": [
                             {
+                                "Value": "C0205160",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                 },
-                                "Value": "C0205160",
                                 "CodeSystem": {
+                                    "Value": "http://ncimeta.nci.nih.gov",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://ncimeta.nci.nih.gov"
+                                    }
                                 },
                                 "DisplayText": {
+                                    "Value": "Negative",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Negative"
+                                    }
                                 }
                             }
-                        ]
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
                     },
                     "FocalSubject": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/finding/FocalSubject"
                         },
                         "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
                             "Coding": [
                                 {
+                                    "Value": "405828007",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
-                                    "Value": "405828007",
                                     "CodeSystem": {
+                                        "Value": "http://snomed.info/sct",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://snomed.info/sct"
+                                        }
                                     },
                                     "DisplayText": {
+                                        "Value": "Breast cancer type 2 susceptibility protein",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "Breast cancer type 2 susceptibility protein"
+                                        }
                                     }
                                 }
-                            ]
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
                         }
                     }
                 }
             ]
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "31 Mar 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "19",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "19",
+        "LastUpdated": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -2863,112 +2881,65 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "30 JAN 2018"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "56946",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "PACLitaxel"
-                        }
-                    }
-                ]
-            }
-        },
         "Dosage": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
             },
             "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
                 "Value": {
+                    "Value": 180,
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
                     },
-                    "Value": 180,
                     "Units": {
+                        "Value": {
+                            "Value": "mg/m2",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            }
+                        },
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
+                        }
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": false,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                }
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "26643006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "mg/m2"
+                            "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "Oral route",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
                         }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                     }
                 }
             },
@@ -2981,118 +2952,93 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
                     },
                     "RecurrenceRange": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
-                        },
                         "Value": {
+                            "Value": 5,
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/NumberOfRepeats"
-                            },
-                            "Value": 5
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/RecurrenceRange"
                         }
                     }
                 }
-            },
-            "AsNeededIndicator": {
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
                 "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": false
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
-            "RouteIntoBody": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
                 "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
                 },
                 "Value": {
                     "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
                     },
-                    "Coding": [
-                        {
+                    "TimePeriodStart": {
+                        "Value": "17 Jul 2018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "56946",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "PACLitaxel",
                             "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "26643006",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                             }
                         }
-                    ]
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                 }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
-            }
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "25",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "23 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "23 FEB 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10034580",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://www.meddra.org"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Peripheral motor neuropathy"
-                    }
-                }
-            ]
-        },
         "Author": {
+            "Value": "Dr. ABC123",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
+            }
         },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
@@ -3101,34 +3047,58 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "AdverseEventGrade": {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "LastUpdated": {
+            "Value": "09 Aug 2016",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "09 Aug 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "10034580",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://www.meddra.org",
                         "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C1519275",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Grade 3"
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Peripheral motor neuropathy",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         }
                     }
-                ]
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
             }
         },
         "CauseCategory": {
@@ -3136,38 +3106,117 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "treatment",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "treatment",
                         "CodeSystem": {
+                            "Value": "AttributionCategoryCS",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "AttributionCategoryCS"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "treatment",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "treatment"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C1519275",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Grade 3",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "30",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "18 Aug 2013",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "16 Aug 2013",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0024671",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Mammography",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3175,167 +3224,35 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "1 MAR 2013"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "3 MAR 2013"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0024671",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Mammography"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
             "Reason": [
                 {
+                    "Value": "proactive",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "proactive"
+                    }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "ExpectedPerformanceTime": {
+                "Value": "18 Aug 2013",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "3 MAR 2013"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "35",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 NOV 2015"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0024671",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Mammography"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "13 NOV 2015"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3343,101 +3260,101 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "29 Apr 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "29 Apr 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0024671",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Mammography",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "29 Apr 2016",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "40",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "16310003",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Diagnostic ultrasonography"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "29 NOV 2015"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3445,101 +3362,101 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "16310003",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Diagnostic ultrasonography",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "15 May 2016",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "45",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "44578009",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Core needle biopsy of breast"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "29 NOV 2015"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3547,101 +3464,101 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "44578009",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Core needle biopsy of breast",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "15 May 2016",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "50",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "432313008",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Core needle biopsy of axilla using ultrasound guidance"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "29 NOV 2015"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3649,21 +3566,153 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "showed right axillary lymph node was negative for malignancy"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "showed right axillary lymph node was negative for malignancy",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "432313008",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Core needle biopsy of axilla using ultrasound guidance",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "15 May 2016",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "55",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "29 Jun 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 Jun 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "312376000",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Insertion of Port-a-cath",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3671,173 +3720,41 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2016"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "312376000",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Insertion of Port-a-cath"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "29 Jun 2016",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "13 JAN 2016"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "60",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 JAN 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 JAN 2016"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "2768625017",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Transthoracic three dimensional echocardiogram of heart"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "15 JAN 2016"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3845,21 +3762,153 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "01 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "01 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "2768625017",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Transthoracic three dimensional echocardiogram of heart",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "01 Jul 2016",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "65",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "27 Nov 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "27 Nov 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0851238",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Lumpectomy",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3867,93 +3916,93 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 JUN 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "12 JUN 2016"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0851238",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Lumpectomy"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "27 Nov 2016",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "12 JUN 2016"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "69",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "16 Mar 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "02 Feb 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C51987",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Adjuvant Radiation Therapy",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -3961,72 +4010,30 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "18 AUG 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 SEP 2016"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C51987",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Adjuvant Radiation Therapy"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
@@ -4035,35 +4042,77 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
                     },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "18 AUG 2016"
-                    },
                     "TimePeriodEnd": {
+                        "Value": "16 Mar 2017",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "29 SEP 2016"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "02 Feb 2017",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
                     }
                 }
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "70",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "07 Nov 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "06 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C51987",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Adjuvant Radiation Therapy",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4071,72 +4120,30 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 JAN 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "23 MAY 2016"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C51987",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Adjuvant Radiation Therapy"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
@@ -4145,115 +4152,25 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
                     },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "20 JAN 2016"
-                    },
                     "TimePeriodEnd": {
+                        "Value": "07 Nov 2016",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
-                        },
-                        "Value": "23 MAY 2016"
+                        }
+                    },
+                    "TimePeriodStart": {
+                        "Value": "06 Jul 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
                     }
                 }
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "71",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 DEC 2016"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "3428724016",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Digital tomosynthesis of bilateral breasts"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "15 DEC 2016"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4261,21 +4178,153 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "showed benign findings"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "01 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "showed benign findings",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "01 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "3428724016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Digital tomosynthesis of bilateral breasts",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "01 Jun 2017",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "72",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "21 Sep 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "21 Sep 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "3005131018",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Routine gynecologic examination",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4283,159 +4332,27 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "06 APR 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "06 APR 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "3005131018",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Routine gynecologic examination"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "21 Sep 2017",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "06 APR 2017"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "73",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "3 SEP 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "10 SEP 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "432634008",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "MRI of breast with contrast"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "10 SEP 2017"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4443,101 +4360,101 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "revealed stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "25 Feb 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "revealed stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "18 Feb 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "432634008",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "MRI of breast with contrast",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "25 Feb 2018",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "74",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 SEP 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "433761009",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "CT of thorax, abdomen and pelvis with contrast"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "20 SEP 2017"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4545,101 +4462,101 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla and two hypodensities in the left lobe of the liver that were consistent with benign cysts"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla and two hypodensities in the left lobe of the liver that were consistent with benign cysts",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "17 Feb 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "433761009",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "CT of thorax, abdomen and pelvis with contrast",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "07 Mar 2018",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "75",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 SEP 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "28 SEP 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "69647011",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Bone scan"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "28 SEP 2017"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4647,21 +4564,153 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "Annotation": [
-            {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "was negative for skeletal metastases"
-            }
-        ]
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
+        "LastUpdated": {
+            "Value": "15 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "was negative for skeletal metastases",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "17 Feb 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "69647011",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Bone scan",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "15 Mar 2018",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "76",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "27 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "27 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "312379007",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Removal of Port-a-cath",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4669,93 +4718,93 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "10 OCT 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "10 OCT 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "312379007",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Removal of Port-a-cath"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "27 Mar 2018",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "10 OCT 2017"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "77",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "27 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "27 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "312376000",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Insertion of Port-a-cath",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -4763,244 +4812,41 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "10 OCT 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "10 OCT 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "312376000",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Insertion of Port-a-cath"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "27 Mar 2018",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "10 OCT 2017"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "78",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "17 OCT 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "17 OCT 2017"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "450827009",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Induction chemotherapy"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "17 OCT 2017"
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
-            }
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "79",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10028411",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://www.meddra.org"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Myalgia"
-                    }
-                }
-            ]
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5008,204 +4854,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "AdverseEventGrade": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C1519275",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Grade 3"
-                        }
-                    }
-                ]
-            }
-        },
-        "CauseCategory": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "treatment",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "AttributionCategoryCS"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "treatment"
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
-            }
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "80",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10034580",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://www.meddra.org"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Peripheral motor neuropathy"
-                    }
-                }
-            ]
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "AdverseEventGrade": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C1519275",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Grade 3"
-                        }
-                    }
-                ]
-            }
-        },
-        "CauseCategory": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "treatment",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "AttributionCategoryCS"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "treatment"
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "81",
+        "LastUpdated": {
+            "Value": "03 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "03 Apr 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "450827009",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Induction chemotherapy",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5213,77 +4906,45 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 FEB 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "22 FEB 2018"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "75385009",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "CT of thorax with contrast"
-                        }
-                    }
-                ]
-            }
-        },
         "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "Reason": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
                     "Value": {
                         "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
                         }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
             "ExpectedPerformanceTime": {
+                "Value": "03 Apr 2018",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "22 FEB 2018"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "79",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
             }
         },
         "Subject": {
@@ -5291,23 +4952,407 @@
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "LastUpdated": {
+            "Value": "17 Jul 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "17 Jul 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "10028411",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://www.meddra.org",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Myalgia",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "treatment",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "AttributionCategoryCS",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "treatment",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C1519275",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Grade 3",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "80",
+        "Author": {
+            "Value": "Dr. ABC123",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "LastUpdated": {
+            "Value": "17 Jul 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "17 Jul 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "10034580",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://www.meddra.org",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Peripheral motor neuropathy",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "treatment",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "AttributionCategoryCS",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "treatment",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C1519275",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Grade 3",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "81",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "09 Aug 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "Annotation": [
             {
+                "Value": "revealed pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
-                },
-                "Value": "revealed pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla"
+                }
             }
-        ]
+        ],
+        "CreationTime": {
+            "Value": "30 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "75385009",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "CT of thorax with contrast",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "09 Aug 2018",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "90",
+        "Evidence": [],
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "LastUpdated": {
+            "Value": "19 Mar 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Mar 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C1546960",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Worsening, disease progressing",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5315,48 +5360,35 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 OCT 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 OCT 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+        "FindingStatus": {
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C1546960",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Worsening, disease progressing"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "ClinicallyRelevantTime": {
+            "Value": "19 Mar 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FocalSubjectReference": {
@@ -5366,119 +5398,41 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
             }
         },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [],
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "02 OCT 2016"
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "91",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "27 JUN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "27 JUN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205360",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Stable, neither improving nor worsening"
-                    }
-                }
-            ]
-        },
+        "Evidence": [],
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5486,82 +5440,46 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
-            }
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [],
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0421176",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
-                        }
-                    }
-                ]
-            }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "27 JUN 2017"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "92",
+        "LastUpdated": {
+            "Value": "12 Dec 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "12 Dec 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C0205360",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Stable, neither improving nor worsening",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5569,55 +5487,35 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+        "FindingStatus": {
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0205360",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Stable, neither improving nor worsening"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
-        "SourceClinicalNote": {
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-            },
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1085"
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "ClinicallyRelevantTime": {
+            "Value": "12 Dec 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FocalSubjectReference": {
@@ -5627,171 +5525,220 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
             }
         },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [],
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "C0421176",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "C0421176",
                         "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
+                            }
                         },
                         "DisplayText": {
+                            "Value": "Progression",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "30 JAN 2018"
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "92",
+        "Evidence": [],
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "LastUpdated": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C0205360",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Stable, neither improving nor worsening",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1085",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/BreastCancer"
+            }
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "C0421176",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://ncimeta.nci.nih.gov",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Progression",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "99",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/allergy/NoKnownAllergy"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "99",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "LastUpdated": {
+            "Value": "28 Nov 2015",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "30 Jun 2015",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2015"
+            }
         },
         "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "409137002",
+                    "DisplayText": "No known drug allergy",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "409137002",
                     "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": "No known drug allergy"
+                        }
+                    }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "100",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "12 FEB 2018"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "Ms. Ortiz111 had a breast cancer follow up"
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "active"
-            },
-            "RequestIntent": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
-                },
-                "Value": "plan"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "12 FEB 2018 15:00 -0500"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5799,19 +5746,27 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "ReferralDate": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
-            },
-            "Value": "01 JAN 2018"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "110",
+        "LastUpdated": {
+            "Value": "30 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "ReferralDate": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5819,49 +5774,41 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "7 MAR 2018"
-        },
         "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            "Status": {
+                "Value": "active",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
             "Reason": [
                 {
+                    "Value": "Ms. Ortiz111 had a breast cancer follow up",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "Ms. Ortiz111 has a breast cancer follow up"
+                    }
                 }
             ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "active"
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
             },
             "RequestIntent": {
+                "Value": "plan",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
-                },
-                "Value": "plan"
+                }
             },
             "ExpectedPerformanceTime": {
+                "Value": "31 Jul 2018 15:00 -0400",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "7 MAR 2018 18:00 -0500"
+                }
             }
-        },
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "110",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5869,19 +5816,84 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "LastUpdated": {
+            "Value": "22 Aug 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
         "ReferralDate": {
+            "Value": "19 Jun 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "active",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
             },
-            "Value": "02 JAN 2018"
+            "Reason": [
+                {
+                    "Value": "Ms. Ortiz111 has a breast cancer follow up",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "RequestIntent": {
+                "Value": "plan",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                }
+            },
+            "ExpectedPerformanceTime": {
+                "Value": "23 Aug 2018 18:00 -0400",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "234",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "234",
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -5889,47 +5901,7 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C95618",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Review of systems"
-                    }
-                }
-            ]
-        },
         "Members": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/Members"
-            },
             "Value": [
                 {
                     "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
@@ -6036,15 +6008,56 @@
                         "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/Members"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C95618",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Review of systems",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": true,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "235",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6052,51 +6065,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": true,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C50575",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C50575",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "alopecia",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "alopecia"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": true,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "236",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6104,51 +6117,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": true,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C61443",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C61443",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "amenorrhea",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "amenorrhea"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": true,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "237",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6156,51 +6169,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": true,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C118263",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C118263",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "numbness or tingling in hands and feet",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "numbness or tingling in hands and feet"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "238",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6208,51 +6221,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 4",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 4"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "239",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6260,51 +6273,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 5",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 5"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "240",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6312,51 +6325,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 6",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 6"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "241",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6364,51 +6377,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 7",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 7"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "242",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6416,51 +6429,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 8",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 8"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "243",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6468,51 +6481,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 9",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 9"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "244",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6520,51 +6533,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 10",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 10"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "245",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6572,51 +6585,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 11",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 11"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "246",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6624,51 +6637,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 12",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 12"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "247",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6676,103 +6689,51 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 13",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 13"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
-        },
+        "Value": false,
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "248",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "foo",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 14"
-                    }
-                }
-            ]
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "249",
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -6780,96 +6741,141 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 JAN 2018"
-        },
-        "Value": false,
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "foo",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Question 14",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Question 15"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "Value": false,
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "249",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/QuestionAnswer"
+        },
+        "LastUpdated": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "foo",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Question 15",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "500",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/condition/Injury"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "500",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+        "LastUpdated": {
+            "Value": "28 Nov 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
         "CreationTime": {
+            "Value": "30 Jun 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2018"
+            }
         },
-        "LastUpdated": {
+        "ClinicalStatus": {
+            "Value": "active",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JUN 2018"
+                "Value": "http://standardhealthrecord.org/spec/shr/condition/ClinicalStatus"
+            }
         },
         "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0016658",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0016658",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Fracture",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Fracture"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
-        "Subject": {
+        "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
             "_EntryType": {
@@ -6878,169 +6884,192 @@
         },
         "Category": [
             {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "#structural_abnormality",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "#structural_abnormality"
+                        }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         ],
-        "ClinicalStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/condition/ClinicalStatus"
-            },
-            "Value": "active"
-        },
         "BodySiteOrCode": [
             {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/entity/BodySiteOrCode"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "724231006",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "724231006",
                             "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "Bone structure of left fibula",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Bone structure of left fibula"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ],
         "WhenClinicallyRecognized": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
-            },
             "Value": {
+                "Value": "30 Jun 2018",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedDateTime"
-                },
-                "Value": "13 JAN 2018"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedTemporalContext"
             }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "501",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "13 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "13 JAN 2018"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "433341001",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://snomed.info/sct"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Application of long leg splint"
-                        }
-                    }
-                ]
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-                        "_EntryId": "500",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Injury"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": "13 JAN 2018"
-            }
-        },
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "30 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "30 Jun 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "433341001",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Application of long leg splint",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "500",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Injury"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "30 Jun 2018",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2000",
+        "Value": {
+            "Value": 15,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "%",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "18 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "18 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7048,98 +7077,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "18 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "01 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "01 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 15,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "%"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0019046",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0019046",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Hemoglobin",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Hemoglobin"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "01 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2010",
+        "Value": {
+            "Value": 10.3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "%",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "05 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "05 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7147,98 +7176,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "05 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "19 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "19 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 10.3,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "%"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0019046",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0019046",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Hemoglobin",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Hemoglobin"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "19 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2020",
+        "Value": {
+            "Value": 14.5,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "%",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "27 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "27 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7246,98 +7275,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "27 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "10 JAN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "10 JAN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 14.5,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "%"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0019046",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0019046",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Hemoglobin",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Hemoglobin"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "10 JAN 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2030",
+        "Value": {
+            "Value": 6.74,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "12 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "12 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7345,98 +7374,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "12 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "25 NOV 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "25 NOV 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 6.74,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "25 NOV 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2040",
+        "Value": {
+            "Value": 3.37,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "22 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7444,98 +7473,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "22 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "5 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "5 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 3.37,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "5 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2050",
+        "Value": {
+            "Value": 1.86,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "29 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7543,98 +7572,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "29 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "12 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 1.86,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "12 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2060",
+        "Value": {
+            "Value": 4.72,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "05 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "05 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7642,98 +7671,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "05 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "19 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "19 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 4.72,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "19 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2070",
+        "Value": {
+            "Value": 6.75,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "13 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "13 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7741,93 +7770,93 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "13 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "27 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "27 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 6.75,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
                     "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": "Final"
-                }
-            ]
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
+                    "DisplayText": "Final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "27 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C0023508",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "White blood cell",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2080",
+        "Value": {
+            "Value": 8.12,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "19 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7835,98 +7864,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "19 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 JAN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 JAN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 8.12,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0023508",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0023508",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "White blood cell",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "White blood cell"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "02 JAN 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2100",
+        "Value": {
+            "Value": 4.2,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "12 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "12 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -7934,98 +7963,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "12 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "25 NOV 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "25 NOV 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 4.2,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "25 NOV 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2110",
+        "Value": {
+            "Value": 2.3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "22 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8033,98 +8062,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "22 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "5 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "5 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 2.3,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "5 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2120",
+        "Value": {
+            "Value": 1.2,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "29 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "29 May 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8132,98 +8161,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "29 May 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "12 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "12 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 1.2,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "12 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2130",
+        "Value": {
+            "Value": 1.9,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "05 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "05 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8231,197 +8260,98 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "05 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "19 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "19 DEC 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 1.9,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "19 DEC 2016"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2140",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "27 DEC 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "27 DEC 2016"
-        },
         "Value": {
+            "Value": 2.6,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
             },
-            "Value": 2.6,
             "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
                 "Value": {
+                    "Value": "10^9/L",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                 }
             }
         },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0027950",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
-                    }
-                }
-            ]
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "27 DEC 2016"
-        }
-    },
-    {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2150",
+        "LastUpdated": {
+            "Value": "13 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "13 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8429,98 +8359,205 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "13 Jun 2017",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 JAN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 JAN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
-            },
-            "Value": 4.3,
-            "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10^9/L"
-                }
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             }
         },
         "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "final",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "C0027950",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C0027950",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Neutrophil",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Neutrophil"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "02 JAN 2017"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2150",
+        "Value": {
+            "Value": 4.3,
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Units": {
+                "Value": {
+                    "Value": "10^9/L",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                }
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "LastUpdated": {
+            "Value": "19 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "19 Jun 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C0027950",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Neutrophil",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2160",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2160",
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "369792005",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://snomed.info/sct",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "High grade or poorly differentiated",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8528,81 +8565,81 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "369792005",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://snomed.info/sct"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "High grade or poorly differentiated"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "15 May 2016",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "29 NOV 2015"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2170",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2170",
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C0205160",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Negative",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8610,81 +8647,81 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205160",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Negative"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "15 May 2016",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "29 NOV 2015"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2180",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2180",
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C1446409",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Positive",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8692,81 +8729,81 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1446409",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Positive"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "15 May 2016",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "29 NOV 2015"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2190",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2190",
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C0205160",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Negative",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8774,180 +8811,73 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205160",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Negative"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "15 May 2016",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "29 NOV 2015"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
-        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "2200",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
         "Value": {
+            "Value": 1.6,
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
             },
-            "Value": 1.6,
             "Units": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                },
                 "Value": {
+                    "Value": "cm",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "cm"
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
                 }
             }
         },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0475440",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Tumor Size"
-                    }
-                }
-            ]
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "29 NOV 2015"
-        }
-    },
-    {
         "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage"
+            "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2210",
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -8955,128 +8885,198 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
+        "ClinicallyRelevantTime": {
+            "Value": "15 May 2016",
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "29 NOV 2015"
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
         },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "29 NOV 2015"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
+        "FindingStatus": {
             "Coding": [
                 {
+                    "Value": "final",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "46333007",
                     "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "urn:oid:2.16.840.1.113883.6.96"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Final",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "IA"
+                        }
                     }
                 }
-            ]
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "ObservationCode": {
+            "Coding": [
+                {
+                    "Value": "C0475440",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Tumor Size",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2210",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage"
+        },
+        "LastUpdated": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "46333007",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "urn:oid:2.16.840.1.113883.6.96",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "IA",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "Value": "15 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "FindingMethod": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/FindingMethod"
             },
             "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
                 "Coding": [
                     {
+                        "Value": "ajcc_v7",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
-                        "Value": "ajcc_v7",
                         "CodeSystem": {
+                            "Value": "",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": ""
+                            }
                         },
                         "DisplayText": {
+                            "Value": "AJCC Breast Carcinoma Version 7",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "AJCC Breast Carcinoma Version 7"
+                            }
                         }
                     }
-                ]
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
             }
         },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
             "Coding": [
                 {
+                    "Value": "",
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "",
                     "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        }
                     },
                     "DisplayText": {
+                        "Value": "Staging",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Staging"
+                        }
                     }
                 }
-            ]
-        },
-        "ClinicallyRelevantTime": {
+            ],
             "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "29 NOV 2015"
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         },
         "ObservationComponent": [
             {
@@ -9084,29 +9084,29 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/T_Stage"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "433391000124107",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "433391000124107",
                             "CodeSystem": {
+                                "Value": "urn:oid:2.16.840.1.113883.6.96",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "urn:oid:2.16.840.1.113883.6.96"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "T1c",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "T1c"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             },
             {
@@ -9114,29 +9114,29 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/N_Stage"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "436311000124105",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "436311000124105",
                             "CodeSystem": {
+                                "Value": "urn:oid:2.16.840.1.113883.6.96",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "urn:oid:2.16.840.1.113883.6.96"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "N0",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "N0"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             },
             {
@@ -9144,39 +9144,76 @@
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/M_Stage"
                 },
                 "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
                     "Coding": [
                         {
+                            "Value": "433581000124101",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "433581000124101",
                             "CodeSystem": {
+                                "Value": "urn:oid:2.16.840.1.113883.6.96",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "urn:oid:2.16.840.1.113883.6.96"
+                                }
                             },
                             "DisplayText": {
+                                "Value": "M0",
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "M0"
+                                }
                             }
                         }
-                    ]
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
                 }
             }
         ]
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2220",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/EstrogenReceptorStatus"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2220",
+        "LastUpdated": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C0205160",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Negative",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -9184,81 +9221,81 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205160",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Negative"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "07 Mar 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "20 SEP 2017"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2230",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/ProgesteroneReceptorStatus"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2230",
+        "LastUpdated": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C1446409",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Positive",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -9266,81 +9303,81 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1446409",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Positive"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "07 Mar 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "20 SEP 2017"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     },
     {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "2240",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/HER2ReceptorStatus"
         },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "2240",
+        "LastUpdated": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "07 Mar 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Value": {
+            "Coding": [
+                {
+                    "Value": "C1446409",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://ncimeta.nci.nih.gov",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Positive",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
+        },
         "PersonOfRecord": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -9348,73 +9385,36 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
         },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "20 SEP 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1446409",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Positive"
-                    }
-                }
-            ]
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
         "ClinicallyRelevantTime": {
+            "Value": "07 Mar 2018",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "20 SEP 2017"
+            }
+        },
+        "FindingStatus": {
+            "Coding": [
+                {
+                    "Value": "final",
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "CodeSystem": {
+                        "Value": "http://hl7.org/fhir/observation-status",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        }
+                    },
+                    "DisplayText": {
+                        "Value": "Final",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        }
+                    }
+                }
+            ],
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            }
         }
     }
 ]

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -534,7 +534,7 @@ describe('6 FluxNotesEditor', function() {
         conditionButton.simulate('click');
 
         const optionsForm = notesPanelWrapper.find('#pickList-options-panel').find('.option-btn').find('span');
-        const invasiveButton = optionsForm.find({ children: 'Invasive ductal carcinoma of breast 13 JAN 2012' });
+        const invasiveButton = optionsForm.find({ children: 'Invasive ductal carcinoma of breast 01 Jun 2012' });
         expect(invasiveButton).to.have.lengthOf(1);
         invasiveButton.simulate('click');
 


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

I noticed yesterday that some of the entries on Ella that we usually demo are out of the 6 month range that we show. In order to keep those features visible in the application, I used the utility @daniellee1025 created to update the dates in both Debra and Ella's record. I used the EncounterRequested entry for both (entryId 32 for Debra and 100 for Ella). If you notice any issues with the app with the updated dates, let me know.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
