### PR TITLE
Fix arbitrary addition of newlines when closing and re-opening note

### DIFF
--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -94,7 +94,12 @@ function StructuredFieldPlugin(opts) {
             // console.log("node")
             // console.log(node)
             if (node.type === 'line') {
-                result += `<div>${convertSlateNodesToText(node.nodes)}</div>`;
+                // This checks whether the current line is the last one to be processed. If it is, then we don't want to add a div set; this will cause newlines to be perpetually added to the end of the note every time it is closed.
+                if (index === nodes.length - 1) {
+                    result += `${convertSlateNodesToText(node.nodes)}`;
+                } else {
+                    result += `<div>${convertSlateNodesToText(node.nodes)}</div>`;
+                }
             } else if (node.characters && node.characters.length > 0) {
                 node.characters.forEach(char => {
                     const inMarksNotLocal = Lang.differenceBy(char.marks, localStyle, 'type');


### PR DESCRIPTION
This PR addresses the bug detailed in ASCODCP-1200. In short, the application was inserting an extra newline every time the note was closed and re-opened, leading to perpetual expansion of the note.

The bug manifested itself in the application's handling of `div` tags; FluxNotes uses them to separate paragraphs and lines from each other, adding newlines after `div` ending tags. As it turns out, the presence of a `div` ending tag at the very end of the note would cause an arbitrary newline to be added, which would then cause *another* newline to be added every time the note was closed and re-opened.

The fix for this is simple: when processing the note line-by-line, check if the current line is the last one in the set. If it is, then don't append `div` tags to that line. Doing so will prevent the arbitrary newline from being added and solve the bug.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
