### PR TITLE
SMART on FHIR OAuth Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "d3-time": "^1.0.8",
     "downshift": "^1.30.1",
     "es6-shim": "0.35.3",
-    "fhirclient": "0.1.12",
+    "fhirclient": "^0.1.12",
     "flat": "^4.1.0",
     "font-awesome": "4.7.0",
     "guid": "0.0.12",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "d3-time": "^1.0.8",
     "downshift": "^1.30.1",
     "es6-shim": "0.35.3",
+    "fhirclient": "0.1.12",
     "flat": "^4.1.0",
     "font-awesome": "4.7.0",
     "guid": "0.0.12",

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -1,6 +1,7 @@
 import FullApp from '../containers/FullApp';
 import SlimApp from '../containers/SlimApp';
 import LandingPage from '../components/LandingPage';
+import LaunchPage from '../components/LaunchPage';
 
 export default class AppManager {
     constructor() {
@@ -8,6 +9,12 @@ export default class AppManager {
                 path: '/',
                 display: 'Flux Notes™',
                 app: LandingPage,
+                isExact: true
+            },
+            {
+                path: '/launch',
+                display: 'Flux',
+                app: LaunchPage,
                 isExact: true
             },
             {

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -1,8 +1,8 @@
 import FullApp from '../containers/FullApp';
 import SlimApp from '../containers/SlimApp';
 import SmartApp from '../containers/SmartApp';
-import LandingPage from '../components/LandingPage';
 import LaunchPage from '../components/LaunchPage';
+import LandingPage from '../components/LandingPage';
 
 export default class AppManager {
     constructor() {  

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -124,7 +124,15 @@ export default class AppManager {
                 dataSource: 'HardCodedReadOnlyDataSource',
                 patientId: '788dcbc3-ed18-470c-89ef-35ff91854c7f',
                 shortcuts: []
-            },            
+            },     
+            {
+                path: '/smart',
+                display: 'Flux Notes™',
+                app: SmartApp,
+                isExact: true,
+                dataSource: 'HardCodedReadOnlyDataSource',
+                shortcuts: []
+            },         
             {
                 path: '/p2',
                 display: 'Flux Notes™',

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -1,5 +1,6 @@
 import FullApp from '../containers/FullApp';
 import SlimApp from '../containers/SlimApp';
+import SmartApp from '../containers/SmartApp';
 import LandingPage from '../components/LandingPage';
 import LaunchPage from '../components/LaunchPage';
 
@@ -97,6 +98,7 @@ export default class AppManager {
                 app: FullApp,
                 isExact: true,
                 dataSource: 'HardCodedReadOnlyDataSource',
+                patientId: '788dcbc3-ed18-470c-89ef-35ff91854c7d',
                 shortcuts: []
             },
             {
@@ -120,7 +122,7 @@ export default class AppManager {
             {
                 path: '/pilot1',
                 display: 'Flux Notes™',
-                app: FullApp,
+                app: SmartApp,
                 isExact: true,
                 dataSource: 'HardCodedReadOnlyDataSource',
                 patientId: '788dcbc3-ed18-470c-89ef-35ff91854c7f',

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -4,7 +4,8 @@ import LandingPage from '../components/LandingPage';
 import LaunchPage from '../components/LaunchPage';
 
 export default class AppManager {
-    constructor() {
+    constructor() {  
+
         this.apps = [{
                 path: '/',
                 display: 'Flux Notes™',

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -122,7 +122,7 @@ export default class AppManager {
             {
                 path: '/pilot1',
                 display: 'Flux Notes™',
-                app: SmartApp,
+                app: FullApp,
                 isExact: true,
                 dataSource: 'HardCodedReadOnlyDataSource',
                 patientId: '788dcbc3-ed18-470c-89ef-35ff91854c7f',

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -13,7 +13,26 @@ export default class LandingPage extends Component {
 
     render() {
         return (
-            <div>Loading...</div>
+            <div className="LandingPage">
+                <div className="landing-header">
+                    <div className="landing-header-logo">
+                        <img src="./fluxnotes_logo_color.png" alt="Flux Notes" className="landing-header-logo-image" />
+                        <span className="landing-header-title">Flux Notes</span>
+                        <span className="landing-header-trademark">™</span>
+                    </div>
+                </div>
+
+                <div className="landing-tagline">
+                    <div className="landing-tagline-title">
+                        Capture and view structured real-world clinical care data
+                    </div>
+
+                    <div className="landing-tagline-text">
+                        Flux Notes™ is an open source approach to capturing treatment data in a structured form as a
+                        clinician authors a clinical note in the preferred narrative form.
+                    </div>
+                </div>
+            </div>
         )
     }
     

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -3,6 +3,10 @@ import '../styles/LandingPage.css';
 import 'fhirclient';
 import launchContext from '../dataaccess/SmartOnFhirLaunchContext.json';
 
+/*
+    Component page to launch authorization of EHR user that redirects to the /smart endpoint.
+*/
+
 export default class LandingPage extends Component {
 
     componentWillMount() {

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -3,12 +3,15 @@ import '../styles/LandingPage.css';
 import 'fhirclient';
 
 export default class LandingPage extends Component {
-    componentDidMount() {
+
+    constructor() {
+        super();
         window.FHIR.oauth2.authorize({
             "client_id": '6c12dff4-24e7-4475-a742-b08972c4ea27',
             "scope":  "patient/*.read user/*.* openid profile", 
-            "redirect_uri": "http://localhost:3000/demo2"
-        });
+            "redirect_uri": "http://localhost:3000/smart"
+        }); 
+    
     }
 
     render() {

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -7,7 +7,7 @@ import launchContext from '../dataaccess/SmartOnFhirLaunchContext.json';
     Component page to launch authorization of EHR user that redirects to the /smart endpoint.
 */
 
-export default class LandingPage extends Component {
+export default class LaunchPage extends Component {
 
     componentWillMount() {
         window.FHIR.oauth2.authorize(launchContext);

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import '../styles/LandingPage.css';
+import 'fhirclient';
+
+export default class LandingPage extends Component {
+    componentDidMount() {
+        window.FHIR.oauth2.authorize({
+            "client_id": '6c12dff4-24e7-4475-a742-b08972c4ea27',
+            "scope":  "patient/*.read user/*.* openid profile", 
+            "redirect_uri": "http://localhost:3000/demo2"
+        });
+    }
+
+    render() {
+        return (
+            <div>Loading...</div>
+        )
+    }
+    
+}

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -1,15 +1,12 @@
 import React, { Component } from 'react';
 import '../styles/LandingPage.css';
 import 'fhirclient';
+import launchContext from '../dataaccess/SmartOnFhirLaunchContext.json';
 
 export default class LandingPage extends Component {
 
     componentWillMount() {
-        window.FHIR.oauth2.authorize({
-            "client_id": '6c12dff4-24e7-4475-a742-b08972c4ea27',
-            "scope":  "patient/*.read user/*.* openid profile", 
-            "redirect_uri": "http://localhost:3000/smart"
-        }); 
+        window.FHIR.oauth2.authorize(launchContext);
     }
 
     render() {

--- a/src/components/LaunchPage.jsx
+++ b/src/components/LaunchPage.jsx
@@ -4,14 +4,12 @@ import 'fhirclient';
 
 export default class LandingPage extends Component {
 
-    constructor() {
-        super();
+    componentWillMount() {
         window.FHIR.oauth2.authorize({
             "client_id": '6c12dff4-24e7-4475-a742-b08972c4ea27',
             "scope":  "patient/*.read user/*.* openid profile", 
             "redirect_uri": "http://localhost:3000/smart"
         }); 
-    
     }
 
     render() {

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
+import 'fhirclient';
 
 import AppManager from '../apps/AppManager';
 import WithTracker from '../components/WithTracker';

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -58,7 +58,6 @@ export class FullApp extends Component {
             layout: "",
             isNoteViewerVisible: false,
             isNoteViewerEditable: false,
-            userId: "",
             loginUser: "",
             noteClosed: false,
             openClinicalNote: null,
@@ -126,7 +125,7 @@ export class FullApp extends Component {
 
     componentWillMount() {
         this.loadPatient(this.props.patientId);
-        const userProfile = this.securityManager.getUser();
+        const userProfile = this.securityManager.getDefaultUser();
         if (userProfile) {
             this.setState({loginUser: userProfile.getUserName()});
         } else {

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -9,6 +9,7 @@ import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
 import Snackbar from 'material-ui/Snackbar';
 import Lang from 'lodash';
+import 'fhirclient';
 
 import SecurityManager from '../security/SecurityManager';
 import DashboardManager from '../dashboard/DashboardManager';
@@ -18,9 +19,6 @@ import ContextManager from '../context/ContextManager';
 import DataAccess from '../dataaccess/DataAccess';
 import SummaryMetadata from '../summary/SummaryMetadata';
 import PatientControlPanel from '../panels/PatientControlPanel';
-
-
-import 'fhirclient';
 
 import '../styles/FullApp.css';
 
@@ -132,7 +130,8 @@ export class FullApp extends Component {
     componentDidMount() {
         window.FHIR.oauth2.ready((smart) => {
             smart.user.read().then((user) => {
-                console.log(user.name);
+                console.log("The user is:", user);
+                console.log("Te user name is: ", user.name);
                 let name = this.parseUserName(user.name);
                 const userProfile = this.securityManager.getUserProfile(name);
                 if (userProfile) {
@@ -144,8 +143,9 @@ export class FullApp extends Component {
         });        
     }
 
+    // Return the user's name by concatenating the values inside the user's name object
     parseUserName = (nameObject) => {
-        return nameObject.given[0] + " " + nameObject.family[0] + ", " + nameObject.suffix[0];
+        return (nameObject.suffix) ? (`${nameObject.given[0]} ${nameObject.family[0]}, ${nameObject.suffix[0]}`) : (`${nameObject.given[0]} ${nameObject.family[0]}`);
     }
 
     // pass this function to children to set full app global state

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -39,22 +39,6 @@ export class FullApp extends Component {
             "post-encounter"
         ];
 
-        console.log("Props", props);
-
-        window.FHIR.oauth2.ready((smart) => {
-            smart.user.read().then((user) => {
-                const userProfile = this.securityManager.getUserProfile(user);
-                if (userProfile) {
-                    this.setState({loginUser: userProfile.getUserName()});
-                } else {
-                    console.error("Login failed");
-                }
-            })
-            smart.patient.read().then((patient) => {
-                console.log(patient);
-            })
-        });   
-
         if (Lang.isUndefined(this.props.dataSource)) {
             this.dataAccess = new DataAccess("HardCodedReadOnlyDataSource");
         } else {
@@ -143,20 +127,35 @@ export class FullApp extends Component {
     }
 
     // On component mount, grab the username of the logged in user
-    componentDidMount() {
-        // window.FHIR.oauth2.ready((smart) => {
-        //     smart.user.read().then((user) => {
-        //         const userProfile = this.securityManager.getUserProfile(user);
-        //         if (userProfile) {
-        //             this.setState({loginUser: userProfile.getUserName()});
-        //         } else {
-        //             console.error("Login failed");
-        //         }
-        //     })
-        //     smart.patient.read().then((patient) => {
-        //         console.log(patient);
-        //     })
-        // });        
+    componentWillMount() {
+        window.FHIR.oauth2.ready((smart) => {
+            smart.user.read().then((user) => {
+                const userProfile = this.securityManager.getUserProfile(user);
+                if (userProfile) {
+                    this.setState({loginUser: userProfile.getUserName()});
+                } else {
+                    console.error("Login failed");
+                }
+            })
+            if (this.props.path === "/smart") {
+                smart.patient.read().then((patient) => {
+                    console.log("Our Patient Is: ", patient);
+                    let patientId;
+                    if (patient.id === "099e7de7-c952-40e2-9b4e-0face78c9d80") {
+                        console.log("deborah!");
+                        patientId = DataAccess.DEMO_PATIENT_ID;
+                    }
+                    else if (patient.id === "04327b09-4d3a-4c8b-9959-83bc1b358203") {
+                        console.log("ella!");
+                        patientId = "788dcbc3-ed18-470c-89ef-35ff91854c7e";
+                    }
+                    let patientFullApp = this.dataAccess.getPatient(patientId);
+                    this.setState({
+                        patient: patientFullApp
+                    })
+                })
+            }
+        });       
     }
 
     // Return the user's name by concatenating the values inside the user's name object

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -39,6 +39,22 @@ export class FullApp extends Component {
             "post-encounter"
         ];
 
+        console.log("Props", props);
+
+        window.FHIR.oauth2.ready((smart) => {
+            smart.user.read().then((user) => {
+                const userProfile = this.securityManager.getUserProfile(user);
+                if (userProfile) {
+                    this.setState({loginUser: userProfile.getUserName()});
+                } else {
+                    console.error("Login failed");
+                }
+            })
+            smart.patient.read().then((patient) => {
+                console.log(patient);
+            })
+        });   
+
         if (Lang.isUndefined(this.props.dataSource)) {
             this.dataAccess = new DataAccess("HardCodedReadOnlyDataSource");
         } else {
@@ -128,19 +144,19 @@ export class FullApp extends Component {
 
     // On component mount, grab the username of the logged in user
     componentDidMount() {
-        window.FHIR.oauth2.ready((smart) => {
-            smart.user.read().then((user) => {
-                console.log("The user is:", user);
-                console.log("Te user name is: ", user.name);
-                let name = this.parseUserName(user.name);
-                const userProfile = this.securityManager.getUserProfile(name);
-                if (userProfile) {
-                    this.setState({loginUser: userProfile.getUserName()});
-                } else {
-                    console.error("Login failed");
-                }
-            })
-        });        
+        // window.FHIR.oauth2.ready((smart) => {
+        //     smart.user.read().then((user) => {
+        //         const userProfile = this.securityManager.getUserProfile(user);
+        //         if (userProfile) {
+        //             this.setState({loginUser: userProfile.getUserName()});
+        //         } else {
+        //             console.error("Login failed");
+        //         }
+        //     })
+        //     smart.patient.read().then((patient) => {
+        //         console.log(patient);
+        //     })
+        // });        
     }
 
     // Return the user's name by concatenating the values inside the user's name object

--- a/src/containers/SmartApp.jsx
+++ b/src/containers/SmartApp.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { FullApp } from "./FullApp";
+import 'fhirclient';
+
+class SmartApp extends FullApp {
+
+    constructor(props) {
+        super(props);
+    }
+
+    componentWillMount() {
+        this.setState({authorization: false});
+        window.FHIR.oauth2.ready((smart) => {
+            smart.user.read().then((user) => {
+                const userProfile = this.securityManager.getUserProfile(user);
+                if (userProfile) {
+                    this.setState({loginUser: userProfile.getUserName()});
+                } else {
+                    console.error("Login failed");
+                }
+            })
+            smart.patient.read().then((patient) => {
+                let patientId;
+                if (patient.id === "099e7de7-c952-40e2-9b4e-0face78c9d80") {
+                    patientId = "788dcbc3-ed18-470c-89ef-35ff91854c7d";
+                }
+                else if (patient.id === "04327b09-4d3a-4c8b-9959-83bc1b358203") {
+                    patientId = "788dcbc3-ed18-470c-89ef-35ff91854c7e";
+                }
+                this.loadPatient(patientId);
+                this.setState({authorizationReady: true})
+            })
+        }); 
+    }
+
+    render() {
+        if (this.state.authorizationReady) {
+            return (<div>{super.render()}</div>)
+        }
+        else {
+            return (<div>Loading...</div>)
+        }
+    }
+
+}
+
+export default SmartApp;

--- a/src/containers/SmartApp.jsx
+++ b/src/containers/SmartApp.jsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { FullApp } from "./FullApp";
 import 'fhirclient';
 
+const usermap = {
+    // Ms. Buena Abbott maps to Deborah Hernandez
+    "099e7de7-c952-40e2-9b4e-0face78c9d80": "788dcbc3-ed18-470c-89ef-35ff91854c7d", 
+    // Pok Abbott maps to Ella Ortiz
+    "04327b09-4d3a-4c8b-9959-83bc1b358203": "788dcbc3-ed18-470c-89ef-35ff91854c7e"
+}
+
 class SmartApp extends FullApp {
 
-    constructor(props) {
-        super(props);
-    }
-
     componentWillMount() {
-        this.setState({authorization: false});
         window.FHIR.oauth2.ready((smart) => {
             smart.user.read().then((user) => {
                 const userProfile = this.securityManager.getUserProfile(user);
@@ -20,21 +22,15 @@ class SmartApp extends FullApp {
                 }
             })
             smart.patient.read().then((patient) => {
-                let patientId;
-                if (patient.id === "099e7de7-c952-40e2-9b4e-0face78c9d80") {
-                    patientId = "788dcbc3-ed18-470c-89ef-35ff91854c7d";
-                }
-                else if (patient.id === "04327b09-4d3a-4c8b-9959-83bc1b358203") {
-                    patientId = "788dcbc3-ed18-470c-89ef-35ff91854c7e";
-                }
+                let patientId = usermap[patient.id];
                 this.loadPatient(patientId);
-                this.setState({authorizationReady: true})
+                this.setState({loadingReady: true})
             })
         }); 
     }
 
     render() {
-        if (this.state.authorizationReady) {
+        if (this.state.loadingReady) {
             return (<div>{super.render()}</div>)
         }
         else {

--- a/src/containers/SmartApp.jsx
+++ b/src/containers/SmartApp.jsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { FullApp } from "./FullApp";
 import 'fhirclient';
 
+/*
+    App container to display theoretical SMART patient. 
+    Upon successful authorization of EHR user, app will handle reading of patient and loads either Hernandez or Ella according to the usermap.
+    If user authorization fails or if selected patient is not in the usermap, app will load a fail screen. 
+*/
+
 const usermap = {
     // Ms. Buena Abbott maps to Deborah Hernandez
     "099e7de7-c952-40e2-9b4e-0face78c9d80": "788dcbc3-ed18-470c-89ef-35ff91854c7d", 
@@ -22,20 +28,28 @@ class SmartApp extends FullApp {
                 }
             })
             smart.patient.read().then((patient) => {
-                let patientId = usermap[patient.id];
-                this.loadPatient(patientId);
-                this.setState({loadingReady: true})
+                if (usermap[patient.id]) {
+                    let patientId = usermap[patient.id];
+                    this.loadPatient(patientId);
+                    this.setState({loadingReady: true});
+                }
+                else {
+                    this.setState({authorizationFail: true});
+                }
+                
             })
-        }); 
+        
+        },
+        (error) => {
+            this.setState({authorizationFail: true})
+        });
     }
 
     render() {
-        if (this.state.loadingReady) {
-            return (<div>{super.render()}</div>)
+        if (this.state.authorizationFail) {
+            return (<div> Authorization Failed </div>)
         }
-        else {
-            return (<div>Loading...</div>)
-        }
+        return (this.state.loadingReady) ? (<div>{super.render()}</div>) : (<div>Loading...</div>)
     }
 
 }

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -8,6 +8,7 @@ import './ClinicianDashboard.css';
 export default class ClinicianDashboard extends Component {
     constructor() {
         super();
+        
         this.state = {
             targetedDataPanelSize: "default",
             notesPanelSize: "default"

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -8,7 +8,6 @@ import './ClinicianDashboard.css';
 export default class ClinicianDashboard extends Component {
     constructor() {
         super();
-
         this.state = {
             targetedDataPanelSize: "default",
             notesPanelSize: "default"

--- a/src/dataaccess/HardCodedReadOnlyDataSource.jsx
+++ b/src/dataaccess/HardCodedReadOnlyDataSource.jsx
@@ -7,11 +7,7 @@ import hardCodedSarcomaPatient from './HardCodedSarcomaPatient.json';
 import curationPatient from './sample_curation_output.json';
 
 class HardCodedReadOnlyDataSource extends IDataSource {
-    getPatient(id) {
-        console.log("Current Id: ", id);
-        console.log("Demo Id: ", DataAccess.DEMO_PATIENT_ID);
-        console.log("Hardcoded Id: ", hardCodedPatientMidYearDemo18[0]["ShrId"]);
-        console.log("Curation Id: ", curationPatient[0]["ShrId"].Value);
+    getPatient(id) {  
         if (id === DataAccess.DEMO_PATIENT_ID) {
             return new PatientRecord(hardCodedPatient);
         } else if (hardCodedPatientMidYearDemo18[0]["ShrId"] === id) {

--- a/src/dataaccess/HardCodedReadOnlyDataSource.jsx
+++ b/src/dataaccess/HardCodedReadOnlyDataSource.jsx
@@ -8,6 +8,10 @@ import curationPatient from './sample_curation_output.json';
 
 class HardCodedReadOnlyDataSource extends IDataSource {
     getPatient(id) {
+        console.log("Current Id: ", id);
+        console.log("Demo Id: ", DataAccess.DEMO_PATIENT_ID);
+        console.log("Hardcoded Id: ", hardCodedPatientMidYearDemo18[0]["ShrId"]);
+        console.log("Curation Id: ", curationPatient[0]["ShrId"].Value);
         if (id === DataAccess.DEMO_PATIENT_ID) {
             return new PatientRecord(hardCodedPatient);
         } else if (hardCodedPatientMidYearDemo18[0]["ShrId"] === id) {

--- a/src/dataaccess/SmartOnFhirLaunchContext.json
+++ b/src/dataaccess/SmartOnFhirLaunchContext.json
@@ -1,0 +1,6 @@
+{
+    "client_id": "6c12dff4-24e7-4475-a742-b08972c4ea27",
+    "scope":  "patient/*.read user/*.* openid profile", 
+    "redirect_uri": "../smart"
+}
+  

--- a/src/model/medication/FluxMedicationChange.js
+++ b/src/model/medication/FluxMedicationChange.js
@@ -25,7 +25,7 @@ class FluxMedicationChange {
     }
     /**
      * Get the MedicationBeforeChange object.
-     * Returns medicaitonRequested object
+     * Returns medicationRequested object
      */
     get medicationBeforeChange() {     
       return this._medicationChange.medicationBeforeChange;

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -1,10 +1,23 @@
 import UserProfile from './UserProfile';
 
+const defaultUser = {
+    name: {
+        given: ["123"],
+        family: ["XYZ"],
+    },
+    id: "1234567890",
+    resourceType: "Doctor"
+}
+
 // Security Manager will handle all security related functionality of the app (authentication, authorization, etc)
-class SecurityManager {
+class SecurityManager {    
 
      getUserProfile(user) {
         return new UserProfile(user);
+    }
+
+    getUser() {
+        return new UserProfile(defaultUser);
     }
 }
 export default SecurityManager;

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -3,8 +3,8 @@ import UserProfile from './UserProfile';
 // Security Manager will handle all security related functionality of the app (authentication, authorization, etc)
 class SecurityManager {
 
-     getUserProfile(name) {
-        return new UserProfile(name);
+     getUserProfile(userName) {
+        return new UserProfile(userName);
     }
 }
 export default SecurityManager;

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -2,8 +2,9 @@ import UserProfile from './UserProfile';
 
 const defaultUser = {
     name: {
-        given: ["123"],
-        family: ["XYZ"],
+        given: ["X123"],
+        family: ["Y987"],
+        suffix: ["Dr."]
     },
     id: "1234567890",
     resourceType: "Doctor"

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -3,8 +3,8 @@ import UserProfile from './UserProfile';
 // Security Manager will handle all security related functionality of the app (authentication, authorization, etc)
 class SecurityManager {
 
-     getUserProfile() {
-        return new UserProfile("Dr. X123 Y987");
+     getUserProfile(name) {
+        return new UserProfile(name);
     }
 }
 export default SecurityManager;

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -3,8 +3,8 @@ import UserProfile from './UserProfile';
 // Security Manager will handle all security related functionality of the app (authentication, authorization, etc)
 class SecurityManager {
 
-     getUserProfile(userName) {
-        return new UserProfile(userName);
+     getUserProfile(user) {
+        return new UserProfile(user);
     }
 }
 export default SecurityManager;

--- a/src/security/SecurityManager.jsx
+++ b/src/security/SecurityManager.jsx
@@ -17,7 +17,7 @@ class SecurityManager {
         return new UserProfile(user);
     }
 
-    getUser() {
+    getDefaultUser() {
         return new UserProfile(defaultUser);
     }
 }

--- a/src/security/UserProfile.jsx
+++ b/src/security/UserProfile.jsx
@@ -1,15 +1,49 @@
 // This class stores user profile information
 class UserProfile {
-   constructor(name) {
-         this._name = name;
+   constructor(user) {
+       this._name = this.setUserName(user.name);
+       this._roleType = user.resourceType;
+       this._id = user.id;
+       this._role = this.setRole(user.practionerRole);
+       this._speciality = this.setSpecialty(user.practionerRole);
    }
+
+   setUserName(name) {
+        return (`${name.given[0]} ${name.family[0]}`)
+    }
+
+    // Some users do not have the practionerRole object, meaning they do not have a role or speciality specified
+    
+    setRole(practionerRole) {
+        if (practionerRole) {
+            return practionerRole[0].role.coding[0].display;
+        }
+    }
+
+    setSpecialty(practionerRole) {
+        if (practionerRole) {
+            return practionerRole[0].specialization.coding[0].display;
+        }
+    }
 
    getUserName() {
        return this._name;
    }
 
-   getSuperRole() {
-       return "Clinician";
+   getRoleType() {
+       return this._role;
    }
+
+   getSpeciality() {
+       return this._specialty;
+   }
+
+   getId() {
+        return this._id;
+    }
+
+    getRole() {
+        return this._role;
+    }
 }
 export default UserProfile;

--- a/src/security/UserProfile.jsx
+++ b/src/security/UserProfile.jsx
@@ -26,6 +26,10 @@ class UserProfile {
         }
     }
 
+    getSuperRole() {
+        return "Clinician";
+    }
+
    getUserName() {
        return this._name;
    }

--- a/src/security/UserProfile.jsx
+++ b/src/security/UserProfile.jsx
@@ -9,7 +9,7 @@ class UserProfile {
    }
 
    setUserName(name) {
-        return (`${name.given[0]} ${name.family[0]}`)
+        return (name.suffix) ? (`${name.suffix[0]} ${name.given[0]} ${name.family[0]}`) : (`${name.given[0]} ${name.family[0]}`);
     }
 
     // Some users do not have the practionerRole object, meaning they do not have a role or speciality specified

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,7 +2873,7 @@ fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fhirclient@0.1.12:
+fhirclient@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/fhirclient/-/fhirclient-0.1.12.tgz#d9529de1f5c63b76120038a6898382bfc500d916"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,6 +2873,10 @@ fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fhirclient@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/fhirclient/-/fhirclient-0.1.12.tgz#d9529de1f5c63b76120038a6898382bfc500d916"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA 64: Implementation of SMART on FHIR OAuth.
- Allows for user authentication through the EHR.
- New /smart endpoint will read the user and show name on top left under Flux Notes
- New /smart endpoint will also read the selected patient and display either Deborah Hernandez or Ella Ortiz

New Files Made:
- _src/components/LaunchPage.jsx_: page to launch authorization of EHR user, redirects to the /smart endpoint. 
- _src/containers/SmartApp.jsx_: container for the /smart endpoint page, handles reading of patient and user once user authorization has passed, reads the selected patient and loads either Deborah or Ella accordingly

To Test SMART on FHIR OAuth:
- yarn start
- Go to the [SMART App Launcher Sandbox](https://launch.smarthealthit.org/?auth_error=&fhir_version_1=r2&fhir_version_2=r2&iss=&launch_ehr=1&launch_url=&patient=&prov_skip_auth=1&provider=COREPRACTITIONER4%2CSMART-1234%2CCOREPRACTITIONER1&pt_skip_auth=1&public_key=&sb=&sde=&sim_ehr=1&token_lifetime=15&user_pt=)
- In App Launch URL, enter http://localhost:3000/launch
- Click Launch App
- Sign in as the user
- Choose a patient (choosing Pok Abbott should display Ella Ortiz and choosing Buena Abbott should display Deborah Hernandez)

Notes: 
- There is currently a dependency warning, which is caused by our version of React. Once we upgrade React, that should no longer be an issue. 
- If user authentication fails, the /smart endpoint will show just an empty loading screen.
- Going straight to /launch (and not through the sandbox) will cause errors because Flux Notes can't authorize user. 

## Submitter: Lucy Xu

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- [x] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added Enzyme-UI tests for slim mode 
- Added Enzyme-UI tests for full mode
- Added backend tests for new functionality added
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


-- 
Lucy Xu 
Cornell '21