### PR TITLE
Moved project repo text to correct location

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -176,7 +176,8 @@ export default class LandingPage extends Component {
                         <div className="landing-get-involved-info-description">
                             Support the collection of high quality real-world data (RWD) to enable clinical oncology
                             research. Contact us to learn more about the project, or about piloting Flux Notes™ in a
-                            clinical setting.
+                            clinical setting. Help grow Flux Notes™ by committing to the <a href="https://github.com/standardhealth/flux" 
+                            alt="Flux Notes Repository">repository</a> today.
                         </div>
                     </div>
 
@@ -205,7 +206,7 @@ export default class LandingPage extends Component {
                             <p>
                                 This tool is one of multiple prototypes in development by MITRE with the
                                 end goal of providing complete, accurate, and computable records to inform the best
-                                care for each individual. Help grow Flux Notes™ by committing to the <a href="https://github.com/standardhealth/flux" alt="Flux Notes Repository">repository</a> today.
+                                care for each individual.
                             </p>
 
                             <p>


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA 1225: Moved "Help grow Flux Notes™ by committing to the repository today" text from SHR to "Get Involved" section. 

## Submitter: Lucy

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- Cheat sheet is updated
- Demo script is updated 
- Documentation on Wiki has been updated 
- Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- Note parser has been updated if structured phrases change

**Code Quality**

- 4-space indents - convert any tabs to spaces
- Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- Code is commented

**Tests**

- [x] Existing tests passed
- Added Enzyme-UI tests for slim mode 
- Added Enzyme-UI tests for full mode
- Added backend tests for new functionality added
- Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
