### PR TITLE
Show source information data action

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -221,7 +221,8 @@ export class FullApp extends Component {
     }
 
     nameSourceAction = (element) => {
-        if (element.value && element.value.length > 2) {
+        console.log(element);
+        if (element.value && Lang.isArray(element.value) && element.value.length > 2) {
             return (element.value[2] instanceof Reference ? "Open Source Note" : "View Source");
         }
         return "No source information";

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -239,14 +239,14 @@ export class FullApp extends Component {
     }
 
     nameSourceAction = (element) => {
-        if (element.value && Lang.isArray(element.value) && element.value.length > 2) {
+        if (element.value && Lang.isArray(element.value) && element.value.length > 2 && element.value[2]) {
             return (element.value[2] instanceof Reference ? "Open Source Note" : "View Source");
         }
         return "No source information";
     }
 
     openReferencedNote = (item, itemLabel) => {
-        if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2])) {
+        if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2]) || Lang.isNull(item.value[2]) || item.value[2] === '') {
             this.setState({
                 snackbarOpen: true,
                 snackbarMessage: "No source information or note available."

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -117,6 +117,7 @@ export class FullApp extends Component {
             {
                 handler: this.openReferencedNote,
                 textfunction: this.nameSourceAction,
+                isdisabled: this.sourceActionIsDisabled,
                 icon: "sticky-note",
                 whenToDisplay: {
                     valueExists: true,
@@ -236,6 +237,13 @@ export class FullApp extends Component {
         this.setState({
             openClinicalNote: openClinicalNote
         });
+    }
+
+    sourceActionIsDisabled = (element) => {
+        if (element.value && Lang.isArray(element.value) && element.value.length > 2 && element.value[2]) {
+            return false;
+        }
+        return true;
     }
 
     nameSourceAction = (element) => {

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -8,6 +8,8 @@ import lightBlue from 'material-ui/colors/lightBlue';
 import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
 import Snackbar from 'material-ui/Snackbar';
+import Modal from 'material-ui/Modal';
+import Typography from 'material-ui/Typography';
 import Lang from 'lodash';
 import Reference from '../model/Reference';
 
@@ -29,6 +31,22 @@ const theme = createMuiTheme({
         error: red
     }
 });
+
+function getModalStyle() {
+    const top = 50;
+    const left = 50;
+  
+    return {
+      top: `${top}%`,
+      left: `${left}%`,
+      transform: `translate(-${top}%, -${left}%)`,
+      position: 'absolute',
+      width: 400,
+      backgroundColor: 'white',
+      boxShadow: 'black',
+      padding: 8,
+    };
+  }
 
 export class FullApp extends Component {
     constructor(props) {
@@ -59,6 +77,9 @@ export class FullApp extends Component {
             layout: "",
             isNoteViewerVisible: false,
             isNoteViewerEditable: false,
+            isModalOpen: false,
+            modalTitle: '',
+            modalContent: '',
             loginUser: "",
             noteClosed: false,
             openClinicalNote: null,
@@ -221,7 +242,6 @@ export class FullApp extends Component {
     }
 
     nameSourceAction = (element) => {
-        console.log(element);
         if (element.value && Lang.isArray(element.value) && element.value.length > 2) {
             return (element.value[2] instanceof Reference ? "Open Source Note" : "View Source");
         }
@@ -232,7 +252,7 @@ export class FullApp extends Component {
         if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2])) {
             this.setState({
                 snackbarOpen: true,
-                snackbarMessage: "No source note available. Information was probably entered into EHR as structured data."
+                snackbarMessage: "No source note available. Information was probably entered directly into EHR as structured data."
             });
             return;
         }
@@ -241,8 +261,9 @@ export class FullApp extends Component {
             this.setOpenClinicalNote(sourceNote);
         } else {
             this.setState({
-                snackbarOpen: true,
-                snackbarMessage: item.value[2]
+                isModalOpen: true,
+                modalTitle: "Source for " + item.value[0],
+                modalContent: item.value[2]
             });
         }
     }
@@ -276,6 +297,10 @@ export class FullApp extends Component {
 
     handleSnackbarClose = () => {
         this.setState({ snackbarOpen: false });
+    }
+
+    handleModalClose = () => {
+        this.setState({ isModalOpen: false });
     }
 
     render() {
@@ -330,6 +355,22 @@ export class FullApp extends Component {
                             summaryMetadata={this.summaryMetadata}
                             updateErrors={this.updateErrors}
                         />
+                        <Modal 
+                            aria-labelledby="simple-modal-title"
+                            aria-describedby="simple-modal-description"
+                            open={this.state.isModalOpen}
+                            onClose={this.handleModalClose}
+                            onClick={this.handleModalClose}
+                        >
+                            <div style={getModalStyle()} >
+                                <Typography id="modal-title">
+                                    {this.state.modalTitle}
+                                </Typography>
+                                <Typography id="simple-modal-description">
+                                    {this.state.modalContent}
+                                </Typography>
+                            </div>
+                        </Modal>
 
                         <Snackbar
                             anchorOrigin={{vertical: 'bottom', horizontal: 'center',}}

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -249,7 +249,7 @@ export class FullApp extends Component {
         if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2])) {
             this.setState({
                 snackbarOpen: true,
-                snackbarMessage: "No source note available. Information was probably entered directly into EHR as structured data."
+                snackbarMessage: "No source information or note available."
             });
             return;
         }
@@ -257,9 +257,11 @@ export class FullApp extends Component {
             const sourceNote = this.state.patient.getEntryFromReference(item.value[2]);
             this.setOpenClinicalNote(sourceNote);
         } else {
+            const labelForItem = (Lang.isArray(itemLabel) ? itemLabel[0] : itemLabel );
+            const title = "Source for " + (labelForItem === item.value[0] ? labelForItem : labelForItem + " of " + item.value[0]);
             this.setState({
                 isModalOpen: true,
-                modalTitle: "Source for " + itemLabel + " of " + item.value[0],
+                modalTitle: title,
                 modalContent: item.value[2]
             });
         }

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -119,9 +119,6 @@ export class FullApp extends Component {
                 textfunction: this.nameSourceAction,
                 icon: "sticky-note",
                 whenToDisplay: {
-                    function: (element, arrayIndex, subsectionName, isSigned, allowItemClick) => {
-                        return true;
-                    },
                     valueExists: true,
                     existingValueSigned: "either",
                     editableNoteOpen: "either"
@@ -248,7 +245,7 @@ export class FullApp extends Component {
         return "No source information";
     }
 
-    openReferencedNote = (item, arrayIndex = -1) => {
+    openReferencedNote = (item, itemLabel) => {
         if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2])) {
             this.setState({
                 snackbarOpen: true,
@@ -262,7 +259,7 @@ export class FullApp extends Component {
         } else {
             this.setState({
                 isModalOpen: true,
-                modalTitle: "Source for " + item.value[0],
+                modalTitle: "Source for " + itemLabel + " of " + item.value[0],
                 modalContent: item.value[2]
             });
         }

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -9,6 +9,7 @@ import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
 import Snackbar from 'material-ui/Snackbar';
 import Lang from 'lodash';
+import Reference from '../model/Reference';
 
 import SecurityManager from '../security/SecurityManager';
 import DashboardManager from '../dashboard/DashboardManager';
@@ -97,6 +98,9 @@ export class FullApp extends Component {
                 text: "Open Source Note",
                 icon: "sticky-note",
                 whenToDisplay: {
+                    function: (element, arrayIndex, subsectionName, isSigned, allowItemClick) => {
+                        return true;
+                    },
                     valueExists: true,
                     existingValueSigned: "either",
                     editableNoteOpen: "either"
@@ -224,8 +228,16 @@ export class FullApp extends Component {
             });
             return;
         }
-        const sourceNote = this.state.patient.getEntryFromReference(item.value[2]);
-        this.setOpenClinicalNote(sourceNote);
+        console.log(item.value[2]);
+        if (item.value[2] instanceof Reference) {
+            const sourceNote = this.state.patient.getEntryFromReference(item.value[2]);
+            this.setOpenClinicalNote(sourceNote);
+        } else {
+            this.setState({
+                snackbarOpen: true,
+                snackbarMessage: "Source: " + item.value[2]
+            });
+        }
     }
 
     // Update the summaryItemToInsert based on the item given

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -95,7 +95,7 @@ export class FullApp extends Component {
             },
             {
                 handler: this.openReferencedNote,
-                text: "Open Source Note",
+                textfunction: this.nameSourceAction,
                 icon: "sticky-note",
                 whenToDisplay: {
                     function: (element, arrayIndex, subsectionName, isSigned, allowItemClick) => {
@@ -220,6 +220,13 @@ export class FullApp extends Component {
         });
     }
 
+    nameSourceAction = (element) => {
+        if (element.value && element.value.length > 2) {
+            return (element.value[2] instanceof Reference ? "Open Source Note" : "View Source");
+        }
+        return "No source information";
+    }
+
     openReferencedNote = (item, arrayIndex = -1) => {
         if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2])) {
             this.setState({
@@ -228,14 +235,13 @@ export class FullApp extends Component {
             });
             return;
         }
-        console.log(item.value[2]);
         if (item.value[2] instanceof Reference) {
             const sourceNote = this.state.patient.getEntryFromReference(item.value[2]);
             this.setOpenClinicalNote(sourceNote);
         } else {
             this.setState({
                 snackbarOpen: true,
-                snackbarMessage: "Source: " + item.value[2]
+                snackbarMessage: item.value[2]
             });
         }
     }

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -561,13 +561,6 @@
                 "_EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"
                 }
-            },
-            {
-                "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                "_EntryId": "2",
-                "_EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/oncology/MitoticCountScore"
-                }
             },            
             {
                 "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -2312,7 +2312,14 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
-            "Value": "30 JAN 2018"
+            "Value": "28 FEB 2018"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1085",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
         }
     },
     {
@@ -5520,6 +5527,18 @@
             },
             "Value": "15 FEB 2018"
         },
+        "Author" : {
+           "EntryType": {
+               "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+           },
+            "Value": "Joe Rodney22A"
+        },
+        "Informant": {
+           "EntryType": {
+               "Value": "http://standardhealthrecord.org/spec/shr/base/Informant"
+           },
+            "Value": "Dr. Kyle Jennings681"
+        },
         "Value": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
@@ -5741,7 +5760,7 @@
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "signed": true,
         "subject": "Treatment Check-in",
-        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with @condition[[Gastrointestinal stromal tumor]]. He was feeling sharp pains in his stomach and a palpable lump two months later. **A diagnostic procedure showed unremarkable views of the abdomen; however an indeterminate lymph node in the ?? was apparent.** A targeted **ultrasound** revealed a tumor measuring 1.6 cm. \n**Biopsy and results? Right axillary lymph node was negative for malignancy.**  Stage IA T1 N0 M0 disease with mitotic count score of 1. KIT testing was positive, PDGFRA testing was negative. \nIn preparation for treatment, **procedures needed?** **TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.** \n\nHe began taking Imatinib (one 400mg tablet per day) on February 15, 2018 as adjuvant therapy, which will continue for one year after surgery. **Reduced/stopped medications?**\n\nHe underwent surgery with Dr. Ford for the tumor **details on tumor/surgery (surgery should be structured data)?**, which resulted in a complete resection **date? Results?**. \n\n**Other procedures? Radiation? Dates?** \n\n**Other medications?** \n\n**CT of the abdomen with contrast on date?? revealed ?? (Would need structured procedure).** **A bone scan September 28, 2017 was negative for skeletal metastases.** \n\n**Relapse?** \n\n**Medication stopped?** \n\nASSESSMENT:\nAlthough his #disease status is #stable #as of #1/30/2018, he is experiencing #toxicity #Grade 2 #Stomach pain **attributed to ??** and #toxicity #Grade 2 #Rash maculo-papular **attributed to ??**.",
+        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with @condition[[Gastrointestinal stromal tumor]]. He was feeling sharp pains in his stomach and a palpable lump two months later. **A diagnostic procedure showed unremarkable views of the abdomen; however an indeterminate lymph node in the ?? was apparent.** A targeted **ultrasound** revealed a tumor measuring 1.6 cm. \n**Biopsy and results? Right axillary lymph node was negative for malignancy.**  Stage IA T1 N0 M0 disease with mitotic count score of 1. KIT testing was positive, PDGFRA testing was negative. \nIn preparation for treatment, **procedures needed?** **TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.** \n\nHe began taking Imatinib (one 400mg tablet per day) on February 15, 2018 as adjuvant therapy, which will continue for one year after surgery. **Reduced/stopped medications?**\n\nHe underwent surgery with Dr. Ford for the tumor **details on tumor/surgery (surgery should be structured data)?**, which resulted in a complete resection **date? Results?**. \n\n**Other procedures? Radiation? Dates?** \n\n**Other medications?** \n\n**CT of the abdomen with contrast on date?? revealed ?? (Would need structured procedure).** **A bone scan September 28, 2017 was negative for skeletal metastases.** \n\n**Relapse?** \n\n**Medication stopped?** \n\nASSESSMENT:\nAlthough his #disease status is #stable #as of #2/28/2018, he is experiencing #toxicity #Grade 2 #Stomach pain **attributed to ??** and #toxicity #Grade 2 #Rash maculo-papular **attributed to ??**.",
         "EntryId": "1085",
         "hospital": "Hospital X",
         "clinician": "Dr. Smith",

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -3571,7 +3571,19 @@
                 },
                 "Value": "13 JAN 2018"
             }
-        }
+        },
+        "Author" : {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+             "Value": "Joyce Byers111"
+         },
+         "Informant": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Informant"
+            },
+             "Value": "Dr. Wilma Rubenstein144"
+         } 
     },
     {
         "EntryType": {

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -645,8 +645,107 @@
                 },
                 "Value": "15 FEB 2016"
             }
+         },
+         "RelatedEncounter": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/RelatedEncounter"
+            },
+             "Value": {
+                 "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                 "_EntryId": "10",
+                 "_EntryType": {
+                     "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterPerformed"
+                 }
+             }
+         },
+         "Author" : {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+             "Value": "Judy Smith332"
+         },
+         "Informant": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Informant"
+            },
+             "Value": "Dr. Joseph Burn234"
+         }
+    },
+
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterPerformed"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "10",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "15 FEB 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 FEB 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/PerformedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Mr. Martinez45 complaining of stomach pain."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "finished"
+            },
+            "OccurrenceTimeOrPeriod": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrencePeriod"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodStart": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        },
+                        "Value": "15 FEB 2016 15:00 -0500"
+                    }
+                }
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
         }
     },
+
+
+
+
+
     {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationChange"

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -75,15 +75,27 @@ class FluxCondition {
     }
 
     get author() {
-        return this._condition.author.value;
+        if (this._condition.author) {
+            return this._condition.author.value;
+        } else {
+            return null;
+        }
     }
 
     get informant() {
-        return this._condition.informant.value;
+        if (this._condition.informant) {
+            return this._condition.informant.value;
+        } else {
+            return null;
+        }
     }
 
     get relatedEncounterReference() {
-        return this._condition.relatedEncounter.value;
+        if (this._condition.relatedEncounter) {
+            return this._condition.relatedEncounter.value;
+        } else {
+            return null;
+        }
     }
 
     // Given a toxicity adverse event, return the grade value

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -74,6 +74,14 @@ class FluxCondition {
         return this._condition.bodySiteOrCode[0].value.laterality.value.coding[0].displayText.value;
     }
 
+    get author() {
+        return this._condition.author.value;
+    }
+
+    get informant() {
+        return this._condition.informant.value;
+    }
+
 
     // Given a toxicity adverse event, return the grade value
     getToxicitiesByCodes(codes) {

--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -82,6 +82,9 @@ class FluxCondition {
         return this._condition.informant.value;
     }
 
+    get relatedEncounterReference() {
+        return this._condition.relatedEncounter.value;
+    }
 
     // Given a toxicity adverse event, return the grade value
     getToxicitiesByCodes(codes) {

--- a/src/model/condition/FluxInjury.js
+++ b/src/model/condition/FluxInjury.js
@@ -3,7 +3,7 @@ import Injury from '../shr/condition/Injury';
 
 class FluxInjury extends FluxCondition {
     constructor(json) {
-        super(json);
+        super();
         this._condition = Injury.fromJSON(json);
     }
 

--- a/src/model/oncology/FluxTNMStage.js
+++ b/src/model/oncology/FluxTNMStage.js
@@ -166,11 +166,19 @@ class FluxTNMStage extends FluxObservation {
     }
 
     get author() {
-        return this._observation.author.value;
+        if (this._observation.author) {
+            return this._observation.author.value;
+        } else {
+            return null;
+        }
     }
 
     get informant() {
-        return this._observation.informant.value;
+        if (this._observation.informant) {
+            return this._observation.informant.value;
+        } else {
+            return null;
+        }
     }
 
     toJSON() {

--- a/src/model/oncology/FluxTNMStage.js
+++ b/src/model/oncology/FluxTNMStage.js
@@ -152,6 +152,10 @@ class FluxTNMStage extends FluxObservation {
         t.value = clinicallyRelevantTime;
         this._observation._clinicallyRelevantTime = t;
     }
+
+    get clinicallyRelevantTime() {
+        return this._observation._clinicallyRelevantTime.value;
+    }
     
     _calculateStage() {
         const t = this.t_Stage;
@@ -159,6 +163,14 @@ class FluxTNMStage extends FluxObservation {
         const m = this.m_Stage;
 
         this.stage = staging.breastCancerPrognosticStage(t, n, m);
+    }
+
+    get author() {
+        return this._observation.author.value;
+    }
+
+    get informant() {
+        return this._observation.informant.value;
     }
 
     toJSON() {

--- a/src/styles/FullApp.css
+++ b/src/styles/FullApp.css
@@ -54,3 +54,13 @@
     border-radius: 10px;
     background-color: #FFFFFF;
 }
+
+#modal-title {
+    margin-bottom: 10px;
+    font-size: 1.1rem;
+    font-weight: 400;
+}
+
+#simple-modal-description {
+    margin: 0px;
+}

--- a/src/summary/NarrativeNameValuePairsVisualizer.css
+++ b/src/summary/NarrativeNameValuePairsVisualizer.css
@@ -44,18 +44,18 @@ div.narrative-inserter-menu-item {
 span.plain {
 }
 
-span.missing-data {
+span.narrative-missing-data {
     border-bottom: 1px solid rgba(255, 0, 0, 0.5);
     text-decoration: none;
 }
 
-span.structured-data {
+span.narrative-structured-data {
     cursor: pointer;
     border-bottom: 1px solid rgba(1, 130, 215, 0.5);
     text-decoration: none;
 }
 
-span.unsigned-data {
+span.narrative-unsigned-data {
     cursor: pointer;
     border-bottom: 1.5px dashed rgba(1, 130, 215, 0.8);
     text-decoration: none;

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -126,7 +126,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
         let _addListItemToResult = (listItem) => {
             if (!first) result.push( { text: ', ', type: 'plain' });
             value = _addLabResultToNarrative(listItem);
-            type = "structured-data";
+            type = "narrative-structured-data";
             result.push({
                 text: value,
                 type: type,
@@ -145,12 +145,12 @@ class NarrativeNameValuePairsVisualizer extends Component {
             if (index === -1) {
                 subsectionName = valueSpec;
                 if(Lang.isUndefined(subsections[subsectionName])) {
-                    result.push( { text: valueSpec, type: 'missing-data' } );
+                    result.push( { text: valueSpec, type: 'narrative-missing-data' } );
                 } else {
                     list = this.getList(subsections[subsectionName]);
                     if (Lang.isEmpty(list) || Lang.isNull(list)) {
                         value = "missing";
-                        type = "missing-data";
+                        type = "narrative-missing-data";
                         result.push( { text: value, type: type } );
                         // add an else-if here? and 'subsections' should contain the unsigned-ness
                     } else {
@@ -166,13 +166,13 @@ class NarrativeNameValuePairsVisualizer extends Component {
                 
                 if(item.value && item.unsigned){
                     value = item.value;
-                    type = "unsigned-data";
+                    type = "narrative-unsigned-data";
                 }else if (item.value) {
                     value = item.value;
-                    type = "structured-data";
+                    type = "narrative-structured-data";
                 } else {
                     value = "missing";
-                    type = "missing-data";
+                    type = "narrative-missing-data";
                 }
                 result.push( { text: value, type: type, item: item } );
             }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1352,11 +1352,15 @@ export default class SummaryMetadata {
     determineSource = (patient, entry) => {
         if (entry.sourceClinicalNoteReference) return entry.sourceClinicalNoteReference;
         let result = "";
-        if (entry.author) result += "Author: " + entry.author;
-        if (entry.informant) result += (result.length > 0 ? "  |  " : "") + "Informant: " + entry.informant;
+        if (entry.author) result += "recorded by " + entry.author;
+        if (entry.informant) result += (result.length > 0 ? " " : "") + "based on information from " + entry.informant;
         if (entry.relatedEncounterReference) {
             const relatedEncounter = patient.getEntryFromReference(entry.relatedEncounterReference);
-            result += (result.length > 0 ? "  |  " : "") + " from encounter on " + relatedEncounter.actionContext.occurrenceTimeOrPeriod.timePeriod.timePeriodStart.value;
+            result += (result.length > 0 ? " " : "") + "from encounter on " + new moment(relatedEncounter.actionContext.occurrenceTimeOrPeriod.timePeriod.timePeriodStart.value, 'D MMM YYY HH:mm Z').format('D MMM YYY hh:mm a');
+        } else if (entry.creationTime) {
+            result += (result.length > 0 ? " " : "") + "on " + entry.creationTime.format('D MMM YYY hh:mm a');
+        } else if (entry.diagnosisDate) {
+            result += (result.length > 0 ? " " : "") + "clinically recognized on " + new moment(entry.diagnosisDate, 'D MMM YYYY').format('D MMM YYYY');
         }
         return result;
     }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -69,7 +69,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             const nextEncounter = patient.getNextEncounter();
                                             if (Lang.isUndefined(nextEncounter)) return ["No upcoming appointments", false];
-                                            return [patient.getNextEncounterReasonAsText(), patient.isUnsigned(nextEncounter)];
+                                            return [patient.getNextEncounterReasonAsText(), patient.isUnsigned(nextEncounter), this.determineSource(patient, nextEncounter)];
                                         },
                                         shortcut: "@reason for next visit"
                                     }
@@ -100,7 +100,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             const previousEncounter = patient.getPreviousEncounter();
                                             if (Lang.isUndefined(previousEncounter)) return ["No recent appointments", false];
-                                            return [patient.getPreviousEncounterReasonAsText(), patient.isUnsigned(previousEncounter)] ;
+                                            return [patient.getPreviousEncounterReasonAsText(), patient.isUnsigned(previousEncounter), this.determineSource(patient, previousEncounter)] ;
                                         },
                                         shortcut: "@reason for previous visit"
                                     }
@@ -175,14 +175,14 @@ export default class SummaryMetadata {
                                     {
                                         name: "Name",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.type, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.type, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                         },
                                         shortcut: "@condition"
                                     },
                                     {
                                         name: "Laterality",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.laterality, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.laterality, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                         }
                                     },
                                     {
@@ -190,7 +190,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             let s = currentConditionEntry.getMostRecentStaging();
                                             if (s && s.stage && s.stage.length > 0) {
-                                                return [s.stage, patient.isUnsigned(s), s.sourceClinicalNoteReference];
+                                                return [s.stage, patient.isUnsigned(s), this.determineSource(patient, s)];
                                             } else {
                                                 return null;
                                             }
@@ -204,7 +204,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(p) || !p.status) {
                                                 return null;
                                             } else {
-                                                return [p.status, patient.isUnsigned(p), p.sourceClinicalNoteReference];
+                                                return [p.status, patient.isUnsigned(p), this.determineSource(patient, p)];
                                             }
                                         }
                                     },
@@ -215,7 +215,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(p) || !p.status) {
                                                 return null;
                                             } else {
-                                                return [p.asOfDate, patient.isUnsigned(p), p.sourceClinicalNoteReference];
+                                                return [p.asOfDate, patient.isUnsigned(p), this.determineSource(patient, p)];
                                             }
                                         }
                                     },
@@ -228,7 +228,7 @@ export default class SummaryMetadata {
                                             } else {
                                                 return [p.evidence.map(function (ev) {
                                                     return ev;
-                                                }).join(', '), patient.isUnsigned(p), p.sourceClinicalNoteReference];
+                                                }).join(', '), patient.isUnsigned(p), this.determineSource(patient, p)];
                                             }
                                         }
                                     }
@@ -274,7 +274,7 @@ export default class SummaryMetadata {
                                     {
                                         name: "Diagnosis",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.diagnosisDate, patient.isUnsigned(currentConditionEntry)] ;
+                                            return [currentConditionEntry.diagnosisDate, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)] ;
                                         }
                                     },
                                     {
@@ -283,7 +283,7 @@ export default class SummaryMetadata {
                                             if (currentConditionEntry.clinicalStatus === "recurrence") {
                                                 return null;
                                             } else {
-                                                return ["N/A", patient.isUnsigned(currentConditionEntry)];
+                                                return ["N/A", patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                             } // TODO: actually get date once we know where it is in SHR
                                         }
                                     }
@@ -299,7 +299,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(er)) {
                                                 return null;
                                             } else {
-                                                return [er.status, patient.isUnsigned(er), er.sourceClinicalNoteReference];
+                                                return [er.status, patient.isUnsigned(er), this.determineSource(patient, er)];
                                             }
                                         }
                                     },
@@ -310,7 +310,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(pr)) {
                                                 return null;
                                             } else {
-                                                return [pr.status, patient.isUnsigned(pr), pr.sourceClinicalNoteReference];
+                                                return [pr.status, patient.isUnsigned(pr), this.determineSource(patient, pr)];
                                             }
                                         }
                                     },
@@ -321,7 +321,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(her2)) {
                                                 return null;
                                             } else {
-                                                return [her2.status, patient.isUnsigned(her2), her2.sourceClinicalNoteReference];
+                                                return [her2.status, patient.isUnsigned(her2), this.determineSource(patient, her2)];
                                             }
                                         }
                                     }
@@ -506,7 +506,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             let list = currentConditionEntry.getObservationsOfType(FluxTumorDimensions);
                                             if (list.length === 0) return null;
-                                            return [list[0].quantity.value + " " + list[0].quantity.unit, patient.isUnsigned(list[0])];
+                                            return [list[0].quantity.value + " " + list[0].quantity.unit, patient.isUnsigned(list[0]), this.determineSource(patient, list[0])];
                                         }
                                     },
                                     {
@@ -517,7 +517,7 @@ export default class SummaryMetadata {
                                         name: "Histological Grade",
                                         value: (patient, currentConditionEntry) => {
                                             let histologicalGrade = currentConditionEntry.getMostRecentHistologicalGrade();
-                                            return [ histologicalGrade.grade, patient.isUnsigned(histologicalGrade) ];
+                                            return [ histologicalGrade.grade, patient.isUnsigned(histologicalGrade), this.determineSource(patient, histologicalGrade) ];
                                         }
                                     },
                                     {
@@ -527,7 +527,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(er)) {
                                                 return null;
                                             } else {
-                                                return [er.status, patient.isUnsigned(er), er.sourceClinicalNoteReference];
+                                                return [er.status, patient.isUnsigned(er), this.determineSource(patient, er)];
                                             }
                                         }
                                     },
@@ -538,7 +538,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(pr)) {
                                                 return null;
                                             } else {
-                                                return [pr.status, patient.isUnsigned(pr), pr.sourceClinicalNoteReference];
+                                                return [pr.status, patient.isUnsigned(pr), this.determineSource(patient, pr)];
                                             }
                                         }
                                     },
@@ -549,7 +549,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(her2)) {
                                                 return null;
                                             } else {
-                                                return [her2.status, patient.isUnsigned(her2), her2.sourceClinicalNoteReference];
+                                                return [her2.status, patient.isUnsigned(her2), this.determineSource(patient, her2)];
                                             }
                                         }
                                     }
@@ -587,7 +587,7 @@ export default class SummaryMetadata {
                                             return [panel.members.map((item) => {
                                                 const v = item.value === 'Positive' ? '+' : '-';
                                                 return item.abbreviatedName + v;
-                                            }).join(","), patient.isUnsigned(panel)];
+                                            }).join(","), patient.isUnsigned(panel), this.determineSource(patient, panel)];
                                         }
                                     }
                                 ]
@@ -696,7 +696,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             const nextEncounter = patient.getNextEncounter();
                                             if (Lang.isUndefined(nextEncounter)) return ["No upcoming appointments", false];
-                                            return [patient.getNextEncounterReasonAsText(), patient.isUnsigned(nextEncounter)];
+                                            return [patient.getNextEncounterReasonAsText(), patient.isUnsigned(nextEncounter), this.determineSource(patient, nextEncounter)];
                                         },
                                         shortcut: "@reason for next visit"
                                     }
@@ -727,7 +727,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             const previousEncounter = patient.getPreviousEncounter();
                                             if (Lang.isUndefined(previousEncounter)) return ["No recent appointments", false];
-                                            return [patient.getPreviousEncounterReasonAsText(), patient.isUnsigned(previousEncounter)] ;
+                                            return [patient.getPreviousEncounterReasonAsText(), patient.isUnsigned(previousEncounter), this.determineSource(patient, previousEncounter)] ;
                                         },
                                         shortcut: "@reason for previous visit"
                                     }
@@ -787,9 +787,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             return [currentConditionEntry.type, 
                                                     patient.isUnsigned(currentConditionEntry), 
-                                                    (currentConditionEntry.sourceClinicalNoteReference ? 
-                                                        currentConditionEntry.sourceClinicalNoteReference : this.formatSourceString(currentConditionEntry)
-                                                    )
+                                                    this.determineSource(patient, currentConditionEntry)
                                                 ];
                                         },
                                         shortcut: "@condition"
@@ -799,7 +797,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             let s = currentConditionEntry.getMostRecentStaging();
                                             if (s && s.stage && s.stage.length > 0) {
-                                                return [s.stage, patient.isUnsigned(s), s.sourceClinicalNoteReference];
+                                                return [s.stage, patient.isUnsigned(s), this.determineSource(patient, s)];
                                             } else {
                                                 return null;
                                             }
@@ -810,7 +808,7 @@ export default class SummaryMetadata {
                                         name: "Mitotic Count Score",
                                         value: (patient, currentConditionEntry) => {
                                             let m = currentConditionEntry.getMostRecentStaging();
-                                            return [ m.mitoticCountScore, patient.isUnsigned(m) ];
+                                            return [ m.mitoticCountScore, patient.isUnsigned(m), this.determineSource(patient, m) ];
                                         }
                                     },                                    
                                     {
@@ -820,7 +818,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(p) || !p.status) {
                                                 return null;
                                             } else {
-                                                return [p.status, patient.isUnsigned(p), p.sourceClinicalNoteReference];
+                                                return [p.status, patient.isUnsigned(p), this.determineSource(patient, p)];
                                             }
                                         }
                                     },
@@ -831,7 +829,7 @@ export default class SummaryMetadata {
                                             if (Lang.isNull(p) || !p.status) {
                                                 return null;
                                             } else {
-                                                return [p.asOfDate, patient.isUnsigned(p), p.sourceClinicalNoteReference];
+                                                return [p.asOfDate, patient.isUnsigned(p), this.determineSource(patient, p)];
                                             }
                                         }
                                     },
@@ -844,7 +842,7 @@ export default class SummaryMetadata {
                                             } else {
                                                 return [p.evidence.map(function (ev) {
                                                     return ev;
-                                                }).join(', '), patient.isUnsigned(p), p.sourceClinicalNoteReference];
+                                                }).join(', '), patient.isUnsigned(p), this.determineSource(patient, p)];
                                             }
                                         }
                                     }
@@ -878,7 +876,7 @@ export default class SummaryMetadata {
                                     {
                                         name: "Diagnosis",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.diagnosisDate, patient.isUnsigned(currentConditionEntry)] ;
+                                            return [currentConditionEntry.diagnosisDate, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)] ;
                                         }
                                     },
                                     {
@@ -887,7 +885,7 @@ export default class SummaryMetadata {
                                             if (currentConditionEntry.clinicalStatus === "recurrence") {
                                                 return null;
                                             } else {
-                                                return ["N/A", patient.isUnsigned(currentConditionEntry)];
+                                                return ["N/A", patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                             } // TODO: actually get date once we know where it is in SHR
                                         }
                                     }
@@ -1070,7 +1068,7 @@ export default class SummaryMetadata {
                                         value: (patient, currentConditionEntry) => {
                                             let list = currentConditionEntry.getObservationsOfType(FluxTumorDimensions);
                                             if (list.length === 0) return null;
-                                            return [list[0].quantity.value + " " + list[0].quantity.unit, patient.isUnsigned(list[0])];
+                                            return [list[0].quantity.value + " " + list[0].quantity.unit, patient.isUnsigned(list[0]), this.determineSource(patient, list[0])];
                                         }
                                     },
                                     {
@@ -1081,7 +1079,7 @@ export default class SummaryMetadata {
                                         name: "Histological Grade",
                                         value: (patient, currentConditionEntry) => {
                                             let histologicalGrade = currentConditionEntry.getMostRecentHistologicalGrade();
-                                            return [ histologicalGrade.grade, patient.isUnsigned(histologicalGrade) ];
+                                            return [ histologicalGrade.grade, patient.isUnsigned(histologicalGrade), this.determineSource(patient, histologicalGrade) ];
                                         }
                                     },               
                                 ]
@@ -1111,7 +1109,7 @@ export default class SummaryMetadata {
                                             return [panel.members.map((item) => {
                                                 const v = item.value === 'Positive' ? '+' : '-';
                                                 return item.abbreviatedName + v;
-                                            }).join(","), patient.isUnsigned(panel)];
+                                            }).join(","), patient.isUnsigned(panel), this.determineSource(patient, panel)];
                                         }
                                     }
                                 ]
@@ -1214,26 +1212,26 @@ export default class SummaryMetadata {
                                     {
                                         name: "Name",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.type, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.type, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                         },
                                         shortcut: "@condition"
                                     },
                                     {
                                         name: "Diagnosis Date",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.diagnosisDate, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.diagnosisDate, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                         }
                                     },
                                     {
                                         name: "Where",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.bodySite, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.bodySite, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                         }
                                     },
                                     {
                                         name: "Clinical Status",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.clinicalStatus, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.clinicalStatus, patient.isUnsigned(currentConditionEntry), this.determineSource(patient, currentConditionEntry)];
                                         }
                                     }
                                 ]
@@ -1351,29 +1349,31 @@ export default class SummaryMetadata {
         return this.hardCodedMetadata;
     }
 
-    formatSourceString = (entry) => {
+    determineSource = (patient, entry) => {
+        if (entry.sourceClinicalNoteReference) return entry.sourceClinicalNoteReference;
         let result = "";
-        console.log(entry);
-        if (entry.Author) result += "Author: " + entry.author + "\r\n";
-        if (entry.Informant) result += "Informant: " + entry.informant + "\r\n";
+        if (entry.author) result += "Author: " + entry.author;
+        if (entry.informant) result += (result.length > 0 ? "  |  " : "") + "Informant: " + entry.informant;
+        if (entry.relatedEncounterReference) {
+            const relatedEncounter = patient.getEntryFromReference(entry.relatedEncounterReference);
+            result += (result.length > 0 ? "  |  " : "") + " from encounter on " + relatedEncounter.actionContext.occurrenceTimeOrPeriod.timePeriod.timePeriodStart.value;
+        }
         return result;
-//     {   "relatedEncounter": currentConditionEntry.relatedEncounter, 
     }
 
     getKeyToxicityAndUnsignedFromCodes(patient, currentConditionEntry, codes) {
-        //console.log(codes);
         const tox = currentConditionEntry.getToxicitiesByCodes(codes);
-        let val, unsigned, noteRef;
+        let val, unsigned, source;
         if (tox.length > 0) {
             val = tox[0].adverseEventGrade;
             unsigned = patient.isUnsigned(tox[0]);
-            noteRef = tox[0].sourceClinicalNoteReference;
+            source = this.determineSource(patient, tox[0]);
         } else {
             val = 'None';
             unsigned = false;
-            noteRef = null;
+            source = null;
         }
-        return [val, unsigned, noteRef];
+        return [val, unsigned, source];
     }
 
     getItemListForConditions = (patient, currentConditionEntry, subsection) => {

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1352,15 +1352,15 @@ export default class SummaryMetadata {
     determineSource = (patient, entry) => {
         if (entry.sourceClinicalNoteReference) return entry.sourceClinicalNoteReference;
         let result = "";
-        if (entry.author) result += "recorded by " + entry.author;
-        if (entry.informant) result += (result.length > 0 ? " " : "") + "based on information from " + entry.informant;
+        if (entry.author) result += "Recorded by " + entry.author;
+        if (entry.informant) result += (result.length > 0 ? " b" : "B") + "ased on information from " + entry.informant;
         if (entry.relatedEncounterReference) {
             const relatedEncounter = patient.getEntryFromReference(entry.relatedEncounterReference);
-            result += (result.length > 0 ? " " : "") + "from encounter on " + new moment(relatedEncounter.actionContext.occurrenceTimeOrPeriod.timePeriod.timePeriodStart.value, 'D MMM YYY HH:mm Z').format('D MMM YYY hh:mm a');
+            result += (result.length > 0 ? " f" : "F") + "rom encounter on " + new moment(relatedEncounter.actionContext.occurrenceTimeOrPeriod.timePeriod.timePeriodStart.value, 'D MMM YYY HH:mm Z').format('D MMM YYY hh:mm a');
         } else if (entry.creationTime) {
-            result += (result.length > 0 ? " " : "") + "on " + entry.creationTime.format('D MMM YYY hh:mm a');
+            result += (result.length > 0 ? " o" : "O") + "n " + entry.creationTime.format('D MMM YYY hh:mm a');
         } else if (entry.diagnosisDate) {
-            result += (result.length > 0 ? " " : "") + "clinically recognized on " + new moment(entry.diagnosisDate, 'D MMM YYYY').format('D MMM YYYY');
+            result += (result.length > 0 ? " c" : "C") + "linically recognized on " + new moment(entry.diagnosisDate, 'D MMM YYYY').format('D MMM YYYY');
         }
         return result;
     }

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -785,7 +785,12 @@ export default class SummaryMetadata {
                                     {
                                         name: "Name",
                                         value: (patient, currentConditionEntry) => {
-                                            return [currentConditionEntry.type, patient.isUnsigned(currentConditionEntry)];
+                                            return [currentConditionEntry.type, 
+                                                    patient.isUnsigned(currentConditionEntry), 
+                                                    (currentConditionEntry.sourceClinicalNoteReference ? 
+                                                        currentConditionEntry.sourceClinicalNoteReference : this.formatSourceString(currentConditionEntry)
+                                                    )
+                                                ];
                                         },
                                         shortcut: "@condition"
                                     },
@@ -1344,6 +1349,15 @@ export default class SummaryMetadata {
 
     getMetadata = () => {
         return this.hardCodedMetadata;
+    }
+
+    formatSourceString = (entry) => {
+        let result = "";
+        console.log(entry);
+        if (entry.Author) result += "Author: " + entry.author + "\r\n";
+        if (entry.Informant) result += "Informant: " + entry.informant + "\r\n";
+        return result;
+//     {   "relatedEncounter": currentConditionEntry.relatedEncounter, 
     }
 
     getKeyToxicityAndUnsignedFromCodes(patient, currentConditionEntry, codes) {

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -115,15 +115,15 @@ export default class SummaryMetadata {
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
                             {
-                                defaultTemplate: "Patient has ${Current Diagnosis.Name} laterality ${Current Diagnosis.Laterality} stage ${Current Diagnosis.Stage} diagnosed on ${Key Dates.Diagnosis}."
+                                defaultTemplate: "Patient has ${.Name} laterality ${.Laterality} stage ${.Stage} diagnosed on ${Key Dates.Diagnosis}."
                             },
                             {
-                                defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Disease Status} based on ${Current Diagnosis.Rationale}.",
+                                defaultTemplate: "As of ${.As Of Date}, disease is ${.Disease Status} based on ${.Rationale}.",
                                 dataMissingTemplate: "No recent ${disease status}.",
                                 useDataMissingTemplateCriteria: [
-                                    "Current Diagnosis.As Of Date",
-                                    "Current Diagnosis.Disease Status",
-                                    "Current Diagnosis.Rationale"
+                                    ".As Of Date",
+                                    ".Disease Status",
+                                    ".Rationale"
                                 ]
                             },
                             {
@@ -170,7 +170,7 @@ export default class SummaryMetadata {
                         ],
                         data: [
                             {
-                                name: "Current Diagnosis",
+                                name: "",
                                 items: [
                                     {
                                         name: "Name",
@@ -742,15 +742,15 @@ export default class SummaryMetadata {
                         /*eslint no-template-curly-in-string: "off"*/
                         narrative: [
                             {
-                                defaultTemplate: "Patient has ${Current Diagnosis.Name} stage ${Current Diagnosis.Stage} diagnosed on ${Key Dates.Diagnosis}."
+                                defaultTemplate: "Patient has ${.Name} stage ${.Stage} diagnosed on ${Key Dates.Diagnosis}."
                             },
                             {
-                                defaultTemplate: "As of ${Current Diagnosis.As Of Date}, disease is ${Current Diagnosis.Disease Status} based on ${Current Diagnosis.Rationale}.",
+                                defaultTemplate: "As of ${.As Of Date}, disease is ${.Disease Status} based on ${.Rationale}.",
                                 dataMissingTemplate: "No recent ${disease status}.",
                                 useDataMissingTemplateCriteria: [
-                                    "Current Diagnosis.As Of Date",
-                                    "Current Diagnosis.Disease Status",
-                                    "Current Diagnosis.Rationale"
+                                    ".As Of Date",
+                                    ".Disease Status",
+                                    ".Rationale"
                                 ]
                             },
                             {
@@ -780,7 +780,7 @@ export default class SummaryMetadata {
                         ],
                         data: [
                             {
-                                name: "Current Diagnosis",
+                                name: "",
                                 items: [
                                     {
                                         name: "Name",

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1379,7 +1379,7 @@ export default class SummaryMetadata {
     getItemListForConditions = (patient, currentConditionEntry, subsection) => {
         const conditions = patient.getActiveConditions();
         return conditions.map((c, i) => {
-            return [{value: c.type, shortcut: subsection.shortcut}, c.diagnosisDate, c.bodySite];
+            return [{value: [ c.type, patient.isUnsigned(c), this.determineSource(patient, c) ], shortcut: subsection.shortcut}, c.diagnosisDate, c.bodySite];
         });
     }
 
@@ -1391,7 +1391,7 @@ export default class SummaryMetadata {
             if (typeof p.occurrenceTime !== 'string') {
                 return [
                     {
-                        value: p.name,
+                        value: [p.name, patient.isUnsigned(p), this.determineSource(patient, p) ],
                         shortcut: "@procedure",
                     },
                     p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd
@@ -1399,7 +1399,7 @@ export default class SummaryMetadata {
             } else {
                 return [
                     {
-                        value: p.name,
+                        value: [p.name, patient.isUnsigned(p), this.determineSource(patient, p) ],
                         shortcut: "@procedure",
                     },
                     p.occurrenceTime

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -40,7 +40,13 @@ export default class VisualizerMenu extends Component {
                                 <FontAwesome name={a.icon} />
                             </ListItemIcon>
                         ) : null;
-                        const text = a.text.replace("{elementText}", this.props.elementText);
+                        let textSpec;
+                        if (a.text) {
+                            textSpec = a.text;
+                        } else {
+                            textSpec = a.textfunction(this.props.element);
+                        }
+                        const text = textSpec.replace("{elementText}", this.props.elementText);
                         return (
                             <MenuItem
                                 key={`${this.props.elementId}-${index}`}

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -46,10 +46,15 @@ export default class VisualizerMenu extends Component {
                         } else {
                             textSpec = a.textfunction(this.props.element);
                         }
+                        let disabled = false;
+                        if (!Lang.isUndefined(a.isdisabled)) {
+                            disabled = a.isdisabled(this.props.element);
+                        }
                         const text = textSpec.replace("{elementText}", this.props.elementText);
                         return (
                             <MenuItem
                                 key={`${this.props.elementId}-${index}`}
+                                disabled={disabled}
                                 onClick={() => this.props.onMenuItemClicked(a.handler, this.props.element, this.props.rowId)}
                                 className="narrative-inserter-box"
                             >

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -10,6 +10,7 @@ export default class VisualizerMenu extends Component {
     // Filter Actions by whenToDisplay property on an actions.
     filterActions = () => {
         const filteredActions = this.props.unfilteredActions.filter((a) => {
+            if (a.whenToDisplay.function && !a.whenToDisplay.function(this.props.element, this.props.arrayIndex, this.props.subsectionName, this.props.isSigned, this.props.allowItemClick)) return false;
             if (a.whenToDisplay.valueExists && Lang.isNull(this.props.element)) return false;
             if (a.whenToDisplay.displayInSubsections && !a.whenToDisplay.displayInSubsections.includes(this.props.subsectionName)) return false;
             if (a.whenToDisplay.displayForColumns && !a.whenToDisplay.displayForColumns.includes(this.props.arrayIndex)) return false;


### PR DESCRIPTION
JIRA 1102. The action in the targeted data panel visualizer menu for show source note now can show 3 different options depending on the item clicked on: (1) show source note (if there is a reference to a source note, (2) source source (if there's some data available on who authored and/or informed the data entry and/or when it was created), and (3) no source information. The first one opens the source note as before. The 2nd one shows a modal with the available source information shown. The final one just shows the snackbar still indicating that no source info.

I added some data to the sarcoma patient for testing and demonstrating so I'd recommend looking at it on there some - pilot1 endpoint.

I also removed the "Current Diagnosis" subsection heading in the Summary section for both cancer condition summaries. It caused confusion during CancerLinQ demo and isn't really accurate. Of course, let me know if you think otherwise.

JIRA 1255. Sarcoma patient (pilot1) most recent disease status is now the one in the 1 note and they are linked.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
