### PR TITLE
Delete note button now always visible

### DIFF
--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -96,8 +96,11 @@
 }
 
 #delete-note-container{
+    background: white;
     display: flex;
     justify-content: center;
+    position: sticky;
+    bottom: 0;
 }
 
 #delete-note-button {

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -4,8 +4,6 @@
   flex-direction: column;
   width: 175px;
   margin-left: auto;
-  /* 92px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
-  max-height: calc(100vh - 92px - 20px);
   min-height: 400px !important;
   /* Notes */
   /* Sort */ }

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -1,4 +1,4 @@
-/* Wrappers */
+/* Wrapper */
 .note-assistant-wrapper {
   display: flex;
   flex-direction: column;
@@ -12,7 +12,14 @@
   .note-assistant-wrapper .note-assistant-content-wrapper {
     margin-top: 5px;
     overflow-y: auto;
-    overflow-x: hidden; }
+    overflow-x: hidden;
+    /* 92px is the height of the on large screens Patient Control Panel, 
+           20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars
+           5px is the height of the container's top margin
+           42px is the height of the toggle buttons
+           56px is the height of the delete button 
+        */
+    max-height: calc(100vh - 92px - 20px - 5px - 42px - 51px); }
   .note-assistant-wrapper .toggle-buttons-container {
     display: flex !important;
     margin-right: auto;
@@ -28,20 +35,13 @@
       display: inline-block !important;
       background-color: #FFFFFF !important; }
     .note-assistant-wrapper .toggle-buttons-container .toggle-button-selected {
-      background-color: #3399FF !important; }
+      background-color: #028DEA !important; }
     .note-assistant-wrapper .toggle-buttons-container .toggle-button-disabled {
-      background-color: #e6e6e6 !important; }
+      background-color: #DDDDDD !important; }
   .note-assistant-wrapper .clinical-notes-panel {
     margin-left: auto;
     width: inherit;
     margin-right: 5px; }
-    .note-assistant-wrapper .clinical-notes-panel .in-progress-note {
-      border: 2px dashed #ccc; }
-    .note-assistant-wrapper .clinical-notes-panel .in-progress-text {
-      font-weight: bold; }
-    .note-assistant-wrapper .clinical-notes-panel .selected {
-      border-width: 2px;
-      border-color: #9ecfef; }
     .note-assistant-wrapper .clinical-notes-panel .previous-notes-label {
       font-weight: bold;
       font-size: 0.8em;
@@ -53,15 +53,15 @@
       max-width: 150px;
       padding: 0.5em 1em;
       margin: 1em 0;
-      background: #fff;
-      border: 1px solid #ccc;
+      background: #FFFFFF;
+      border: 1px solid #DDDDDD;
       border-radius: 5px 0 5px 5px; }
       .note-assistant-wrapper .clinical-notes-panel .note > * {
         font-size: 0.8rem;
-        color: #555; }
+        color: #3F3F3F; }
       .note-assistant-wrapper .clinical-notes-panel .note:hover {
         cursor: pointer;
-        background-color: #e6e6e6; }
+        background-color: #F0F0F0; }
       .note-assistant-wrapper .clinical-notes-panel .note::before {
         content: "";
         position: absolute;
@@ -69,7 +69,7 @@
         right: -2px;
         border-width: 0 16px 16px 0;
         border-style: solid;
-        border-color: #ccc #fff; }
+        border-color: #DDDDDD #fff; }
       .note-assistant-wrapper .clinical-notes-panel .note.note-new {
         /*margin: 10px 20px;*/
         width: auto;
@@ -77,42 +77,51 @@
         display: block; }
         .note-assistant-wrapper .clinical-notes-panel .note.note-new:hover {
           cursor: pointer;
-          background: #e6e6e6; }
+          background: #F0F0F0; }
         .note-assistant-wrapper .clinical-notes-panel .note.note-new .note-new-text {
           font-size: 1.1rem; }
           .note-assistant-wrapper .clinical-notes-panel .note.note-new .note-new-text .fa {
             padding-right: 10px; }
+      .note-assistant-wrapper .clinical-notes-panel .note.selected {
+        border-width: 2px;
+        border-color: #028DEA; }
       .note-assistant-wrapper .clinical-notes-panel .note.existing-note .existing-note-date {
         padding-bottom: 5px;
         font-weight: bold; }
       .note-assistant-wrapper .clinical-notes-panel .note.existing-note .existing-note-subject {
         padding-bottom: 10px;
-        border-bottom: 1px solid #ccc; }
+        border-bottom: 1px solid #DDDDDD; }
       .note-assistant-wrapper .clinical-notes-panel .note.existing-note .existing-note-metadata {
         margin-bottom: 5px; }
+      .note-assistant-wrapper .clinical-notes-panel .note.in-progress-note {
+        border-width: 2px;
+        border-style: dashed; }
+        .note-assistant-wrapper .clinical-notes-panel .note.in-progress-note .in-progress-text {
+          font-weight: bold; }
     .note-assistant-wrapper .clinical-notes-panel .more-notes-btn {
-      background-color: white !important;
+      background-color: #FFFFFF !important;
       padding: 10px !important;
       margin-top: 20px;
       max-width: 184px; }
       .note-assistant-wrapper .clinical-notes-panel .more-notes-btn:hover {
-        background: #e6e6e6 !important; }
+        background: #F0F0F0 !important; }
   .note-assistant-wrapper #delete-note-container {
-    background: white;
+    background: #FFFFFF;
     display: flex;
     justify-content: center;
     position: absolute;
-    bottom: 0; }
+    bottom: 0;
+    width: 175px; }
     .note-assistant-wrapper #delete-note-container #delete-note-button {
       padding: 10px;
       margin-bottom: 10px;
       text-transform: none;
-      background-color: #ffffff; }
+      background-color: #FFFFFF; }
       .note-assistant-wrapper #delete-note-container #delete-note-button:hover {
-        background-color: #e6e6e6; }
+        background-color: #F0F0F0; }
       .note-assistant-wrapper #delete-note-container #delete-note-button #trash-icon {
         margin-right: 10px;
-        color: rgba(255, 0, 0, 0.7); }
+        color: #C80B0B; }
   .note-assistant-wrapper .sort-label {
     margin-left: 10px;
     font-size: 0.8em; }
@@ -126,8 +135,8 @@
   .note-assistant-wrapper .sort-selection .sort-select {
     font-size: 0.8em; }
   .note-assistant-wrapper li.sort-item:hover {
-    background-color: #1384b5;
-    color: #fff; }
+    background-color: #028DEA;
+    color: #FFFFFF; }
 
 #pick-list-options-modal {
   height: 80%;
@@ -136,12 +145,14 @@
   left: 50%;
   transform: translate(-50%, -50%);
   position: absolute;
-  background: white;
+  background: #FFFFFF;
   padding: 20px; }
 
 @media only screen and (min-width: 1200px) and (max-width: 1300px) {
   .note-assistant-wrapper {
-    width: 160px; } }
+    width: 170px; }
+    .note-assistant-wrapper #delete-note-container {
+      width: 170px; } }
 
 @media only screen and (max-width: 1024px) {
   .note-assistant-wrapper {
@@ -150,4 +161,6 @@
 
 @media only screen and (min-width: 577px) and (max-width: 768px) {
   .note-assistant-wrapper {
-    width: 170px; } }
+    width: 160px; }
+    .note-assistant-wrapper #delete-note-container {
+      width: 160px; } }

--- a/src/notes/NoteAssistant.css
+++ b/src/notes/NoteAssistant.css
@@ -1,225 +1,153 @@
 /* Wrappers */
 .note-assistant-wrapper {
-    display: flex;
-    flex-direction: column;
-    width: 175px;
-    margin-left: auto;
-    /* 92px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
-    max-height: calc(100vh - 92px - 20px);
-    min-height: 400px !important;
-}
-
-.note-assistant-content-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 175px;
+  margin-left: auto;
+  /* 92px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
+  max-height: calc(100vh - 92px - 20px);
+  min-height: 400px !important;
+  /* Notes */
+  /* Sort */ }
+  .note-assistant-wrapper .note-assistant-content-wrapper {
     margin-top: 5px;
     overflow-y: auto;
-    overflow-x: hidden;
-}
-@media only screen and (min-width: 1200px) and (max-width: 1300px) {
-    .note-assistant-wrapper {
-        width: 160px;
-    }
-}
-@media only screen and (min-width: 577px) and (max-width: 768px) {
-    .note-assistant-wrapper {
-        width: 170px;
-     }
-}
-
-.toggle-buttons-container {
+    overflow-x: hidden; }
+  .note-assistant-wrapper .toggle-buttons-container {
     display: flex !important;
     margin-right: auto;
     width: inherit;
     max-width: 95%;
     min-height: 41px;
-}
-
-.clinical-notes-panel {
+    /* Buttons */ }
+    .note-assistant-wrapper .toggle-buttons-container .toggle-button {
+      min-width: 50px !important;
+      min-height: 20px !important;
+      max-height: 41px !important;
+      width: 50% !important;
+      display: inline-block !important;
+      background-color: #FFFFFF !important; }
+    .note-assistant-wrapper .toggle-buttons-container .toggle-button-selected {
+      background-color: #3399FF !important; }
+    .note-assistant-wrapper .toggle-buttons-container .toggle-button-disabled {
+      background-color: #e6e6e6 !important; }
+  .note-assistant-wrapper .clinical-notes-panel {
     margin-left: auto;
     width: inherit;
-    margin-right: 5px;
-}
-
-/* Buttons */
-.toggle-button {
-    min-width: 50px !important;
-    min-height: 20px !important;
-    max-height: 41px !important;
-    width: 50% !important;
-    display: inline-block !important;
-    background-color: #FFFFFF !important;
-}
-
-.toggle-button-selected {
-    background-color: #3399FF !important;
-}
-
-.toggle-button-disabled {
-    background-color: #e6e6e6 !important;
-}
-
-.previous-notes-label {
-    font-weight: bold;
-    font-size: 0.8em;
-    margin: 10px;
-    max-width: 184px;
-}
-
-.note.note-new {
-    /*margin: 10px 20px;*/
-    width: auto;
-    text-align: center;
-    display: block;
-}
-
-.note.note-new:hover {
-    cursor:pointer;
-    background: #e6e6e6;
-}
-
-.note.note-new .note-new-text {
-    font-size: 1.1rem;
-}
-
-.note .note-new-text .fa {
-    padding-right: 10px;
-}
-
-.more-notes-btn {
-    background-color: white !important;
-    padding: 10px !important;
-    margin-top: 20px;
-    max-width: 184px;
-}
-
-.more-notes-btn:hover {
-    background: #e6e6e6 !important;
-}
-
-#delete-note-container{
+    margin-right: 5px; }
+    .note-assistant-wrapper .clinical-notes-panel .in-progress-note {
+      border: 2px dashed #ccc; }
+    .note-assistant-wrapper .clinical-notes-panel .in-progress-text {
+      font-weight: bold; }
+    .note-assistant-wrapper .clinical-notes-panel .selected {
+      border-width: 2px;
+      border-color: #9ecfef; }
+    .note-assistant-wrapper .clinical-notes-panel .previous-notes-label {
+      font-weight: bold;
+      font-size: 0.8em;
+      margin: 10px;
+      max-width: 184px; }
+    .note-assistant-wrapper .clinical-notes-panel .note {
+      position: relative;
+      width: inherit;
+      max-width: 150px;
+      padding: 0.5em 1em;
+      margin: 1em 0;
+      background: #fff;
+      border: 1px solid #ccc;
+      border-radius: 5px 0 5px 5px; }
+      .note-assistant-wrapper .clinical-notes-panel .note > * {
+        font-size: 0.8rem;
+        color: #555; }
+      .note-assistant-wrapper .clinical-notes-panel .note:hover {
+        cursor: pointer;
+        background-color: #e6e6e6; }
+      .note-assistant-wrapper .clinical-notes-panel .note::before {
+        content: "";
+        position: absolute;
+        top: -2px;
+        right: -2px;
+        border-width: 0 16px 16px 0;
+        border-style: solid;
+        border-color: #ccc #fff; }
+      .note-assistant-wrapper .clinical-notes-panel .note.note-new {
+        /*margin: 10px 20px;*/
+        width: auto;
+        text-align: center;
+        display: block; }
+        .note-assistant-wrapper .clinical-notes-panel .note.note-new:hover {
+          cursor: pointer;
+          background: #e6e6e6; }
+        .note-assistant-wrapper .clinical-notes-panel .note.note-new .note-new-text {
+          font-size: 1.1rem; }
+          .note-assistant-wrapper .clinical-notes-panel .note.note-new .note-new-text .fa {
+            padding-right: 10px; }
+      .note-assistant-wrapper .clinical-notes-panel .note.existing-note .existing-note-date {
+        padding-bottom: 5px;
+        font-weight: bold; }
+      .note-assistant-wrapper .clinical-notes-panel .note.existing-note .existing-note-subject {
+        padding-bottom: 10px;
+        border-bottom: 1px solid #ccc; }
+      .note-assistant-wrapper .clinical-notes-panel .note.existing-note .existing-note-metadata {
+        margin-bottom: 5px; }
+    .note-assistant-wrapper .clinical-notes-panel .more-notes-btn {
+      background-color: white !important;
+      padding: 10px !important;
+      margin-top: 20px;
+      max-width: 184px; }
+      .note-assistant-wrapper .clinical-notes-panel .more-notes-btn:hover {
+        background: #e6e6e6 !important; }
+  .note-assistant-wrapper #delete-note-container {
     background: white;
     display: flex;
     justify-content: center;
-    position: sticky;
-    bottom: 0;
-}
-
-#delete-note-button {
-    padding: 10px;
-    margin-bottom: 10px;
-    text-transform: none;
-    background-color: #ffffff;
-}
-
-#delete-note-button:hover {
-    background-color: #e6e6e6;
-}
-
-#delete-note-button #trash-icon {
-    margin-right: 10px;
-    color: rgba(255, 0, 0, 0.7);
-}
-
-/* Sort */
-
-.sort-label {
+    position: absolute;
+    bottom: 0; }
+    .note-assistant-wrapper #delete-note-container #delete-note-button {
+      padding: 10px;
+      margin-bottom: 10px;
+      text-transform: none;
+      background-color: #ffffff; }
+      .note-assistant-wrapper #delete-note-container #delete-note-button:hover {
+        background-color: #e6e6e6; }
+      .note-assistant-wrapper #delete-note-container #delete-note-button #trash-icon {
+        margin-right: 10px;
+        color: rgba(255, 0, 0, 0.7); }
+  .note-assistant-wrapper .sort-label {
     margin-left: 10px;
-    font-size: 0.8em;
-}
-
-.sort-selection {
+    font-size: 0.8em; }
+  .note-assistant-wrapper .sort-selection {
     margin-bottom: 20px;
-    max-width: 184px;
-}
-
-.sort-select {
+    max-width: 184px; }
+  .note-assistant-wrapper .sort-select {
     width: 90%;
     max-width: 200px;
-    margin-left: 10px;
-}
-
-.sort-selection .sort-select {
-    font-size: 0.8em;
-}
-
-li.sort-item:hover {
+    margin-left: 10px; }
+  .note-assistant-wrapper .sort-selection .sort-select {
+    font-size: 0.8em; }
+  .note-assistant-wrapper li.sort-item:hover {
     background-color: #1384b5;
-    color: #fff;
-}
-
-/* Notes */
-
-.note {
-    position: relative;
-    width: inherit;
-    max-width: 150px;
-    padding: 0.5em 1em;
-    margin: 1em 0;
-    background: #fff;
-    border: 1px solid #ccc;
-    border-radius: 5px 0 5px 5px;
-}
-.note > * {
-    font-size: 0.8rem;
-    color: #555;
- }
-
-.note:hover {
-    cursor: pointer;
-    background-color: #e6e6e6;
-}
-
-.note::before {
-    content: "";
-    position: absolute;
-    top: -2px;
-    right: -2px;
-    border-width: 0 16px 16px 0;
-    border-style: solid;
-    border-color: #ccc #fff;
-}
-
-.in-progress-note {
-    border: 2px dashed #ccc;
-}
-
-.in-progress-text {
-    font-weight: bold;
-}
-
-.existing-note-date {
-    padding-bottom: 5px;
-    font-weight: bold;
-}
-
-.existing-note-subject {
-    padding-bottom: 10px;
-    border-bottom: 1px solid #ccc;
-}
-
-.existing-note-metadata {
-    margin-bottom: 5px;
-}
-
-.selected {
-    border-width: 2px;
-    border-color: #9ecfef;
-}
+    color: #fff; }
 
 #pick-list-options-modal {
-    height: 80%;
-    width: 80%;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    position: absolute;
-    background: white;
-    padding: 20px;
-}
+  height: 80%;
+  width: 80%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  position: absolute;
+  background: white;
+  padding: 20px; }
 
+@media only screen and (min-width: 1200px) and (max-width: 1300px) {
+  .note-assistant-wrapper {
+    width: 160px; } }
 
-@media only screen and (max-width: 1024px) { 
-    .note-assistant-wrapper {
-        /* 117px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
-        max-height: calc(100vh - 117px - 20px);
-    }
-}
+@media only screen and (max-width: 1024px) {
+  .note-assistant-wrapper {
+    /* 117px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
+    max-height: calc(100vh - 117px - 20px); } }
+
+@media only screen and (min-width: 577px) and (max-width: 768px) {
+  .note-assistant-wrapper {
+    width: 170px; } }

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -1,8 +1,14 @@
-/* Wrappers */
+@import '../styles/variables';
+
+$note-assitant-width-1: 175px;
+$note-assitant-width-2: 170px;
+$note-assitant-width-3: 160px; 
+
+/* Wrapper */
 .note-assistant-wrapper {
     display: flex;
     flex-direction: column;
-    width: 175px;
+    width: $note-assitant-width-1;
     margin-left: auto;
     /* 92px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
     max-height: calc(100vh - 92px - 20px);
@@ -12,6 +18,13 @@
         margin-top: 5px;
         overflow-y: auto;
         overflow-x: hidden;
+        /* 92px is the height of the on large screens Patient Control Panel, 
+           20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars
+           5px is the height of the container's top margin
+           42px is the height of the toggle buttons
+           56px is the height of the delete button 
+        */
+        max-height: calc(100vh - 92px - 20px - 5px - 42px - 51px);
     }
     
     .toggle-buttons-container {
@@ -27,32 +40,21 @@
             max-height: 41px !important;
             width: 50% !important;
             display: inline-block !important;
-            background-color: #FFFFFF !important;
+            background-color: $background !important;
         }
         
         .toggle-button-selected {
-            background-color: #3399FF !important;
+            background-color: $interface-blue !important;
         }
         
         .toggle-button-disabled {
-            background-color: #e6e6e6 !important;
+            // Shouldn't be line gray cannonically, but it is the best one for now. 
+            background-color: $line-gray !important;
         }
     }
     
     /* Notes */
     .clinical-notes-panel {
-        .in-progress-note {
-            border: 2px dashed #ccc;
-        }
-        
-        .in-progress-text {
-            font-weight: bold;
-        }
-        
-        .selected {
-            border-width: 2px;
-            border-color: #9ecfef;
-        }
         margin-left: auto;
         width: inherit;
         margin-right: 5px;
@@ -68,16 +70,16 @@
             max-width: 150px;
             padding: 0.5em 1em;
             margin: 1em 0;
-            background: #fff;
-            border: 1px solid #ccc;
+            background: $background;
+            border: 1px solid $line-gray;
             border-radius: 5px 0 5px 5px;
             & > * {
                 font-size: 0.8rem;
-                color: #555;
+                color: $body-gray;
             }
             &:hover {
                 cursor: pointer;
-                background-color: #e6e6e6;
+                background-color: $feature-gray;
             }
             &::before {
                 content: "";
@@ -86,7 +88,7 @@
                 right: -2px;
                 border-width: 0 16px 16px 0;
                 border-style: solid;
-                border-color: #ccc #fff;
+                border-color: $line-gray #fff;
             }
             &.note-new {
                 /*margin: 10px 20px;*/
@@ -95,7 +97,7 @@
                 display: block;
                 &:hover {
                     cursor:pointer;
-                    background: #e6e6e6;
+                    background: $feature-gray;
                 }
                 .note-new-text {
                     font-size: 1.1rem;
@@ -103,6 +105,10 @@
                         padding-right: 10px;
                     }
                 }
+            }
+            &.selected {
+                border-width: 2px;
+                border-color: $interface-blue;
             }
             &.existing-note {         
                 .existing-note-date {
@@ -112,49 +118,56 @@
                 
                 .existing-note-subject {
                     padding-bottom: 10px;
-                    border-bottom: 1px solid #ccc;
+                    border-bottom: 1px solid $line-gray;
                 }
                 
                 .existing-note-metadata {
                     margin-bottom: 5px;
                 }
             }   
+            &.in-progress-note {
+                border-width: 2px;
+                border-style: dashed;
+                .in-progress-text {
+                    font-weight: bold;
+                }
+            }
         }
         
         .more-notes-btn {
-            background-color: white !important;
+            background-color: $background !important;
             padding: 10px !important;
             margin-top: 20px;
             max-width: 184px;
             &:hover {
-                background: #e6e6e6 !important;
+                background: $feature-gray !important;
             }    
         }
     }
     
-    #delete-note-container{
-        background: white;
+    #delete-note-container {
+        background: $background;
         display: flex;
         justify-content: center;
         position: absolute;
         bottom: 0;
+        width: $note-assitant-width-1;
         #delete-note-button {
             padding: 10px;
             margin-bottom: 10px;
             text-transform: none;
-            background-color: #ffffff;
+            background-color: $background;
             &:hover {
-                background-color: #e6e6e6;
+                background-color: $feature-gray;
             }
             #trash-icon {
                 margin-right: 10px;
-                color: rgba(255, 0, 0, 0.7);
+                color: $warning-red;
             }
         }
     }
     
     /* Sort */
-    
     .sort-label {
         margin-left: 10px;
         font-size: 0.8em;
@@ -176,11 +189,9 @@
     }
     
     li.sort-item:hover {
-        background-color: #1384b5;
-        color: #fff;
-    }
-    
-     
+        background-color: $interface-blue;
+        color: $background;
+    }  
 }
 
 #pick-list-options-modal {
@@ -190,16 +201,18 @@
     left: 50%;
     transform: translate(-50%, -50%);
     position: absolute;
-    background: white;
+    background: $background;
     padding: 20px;
 }
 
 @media only screen and (min-width: 1200px) and (max-width: 1300px) {
     .note-assistant-wrapper {
-        width: 160px;
+        width: $note-assitant-width-2;
+        #delete-note-container { 
+            width: $note-assitant-width-2;
+        }
     }
 }
-
 
 @media only screen and (max-width: 1024px) { 
     .note-assistant-wrapper {
@@ -210,6 +223,9 @@
 
 @media only screen and (min-width: 577px) and (max-width: 768px) {
     .note-assistant-wrapper {
-        width: 170px;
+        width: $note-assitant-width-3;
+        #delete-note-container { 
+            width: $note-assitant-width-3;
+        }
      }
 }

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -10,8 +10,6 @@ $note-assitant-width-3: 160px;
     flex-direction: column;
     width: $note-assitant-width-1;
     margin-left: auto;
-    /* 92px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
-    max-height: calc(100vh - 92px - 20px);
     min-height: 400px !important;
     
     .note-assistant-content-wrapper {

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -1,0 +1,215 @@
+/* Wrappers */
+.note-assistant-wrapper {
+    display: flex;
+    flex-direction: column;
+    width: 175px;
+    margin-left: auto;
+    /* 92px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
+    max-height: calc(100vh - 92px - 20px);
+    min-height: 400px !important;
+    
+    .note-assistant-content-wrapper {
+        margin-top: 5px;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+    
+    .toggle-buttons-container {
+        display: flex !important;
+        margin-right: auto;
+        width: inherit;
+        max-width: 95%;
+        min-height: 41px;
+        /* Buttons */
+        .toggle-button {
+            min-width: 50px !important;
+            min-height: 20px !important;
+            max-height: 41px !important;
+            width: 50% !important;
+            display: inline-block !important;
+            background-color: #FFFFFF !important;
+        }
+        
+        .toggle-button-selected {
+            background-color: #3399FF !important;
+        }
+        
+        .toggle-button-disabled {
+            background-color: #e6e6e6 !important;
+        }
+    }
+    
+    /* Notes */
+    .clinical-notes-panel {
+        .in-progress-note {
+            border: 2px dashed #ccc;
+        }
+        
+        .in-progress-text {
+            font-weight: bold;
+        }
+        
+        .selected {
+            border-width: 2px;
+            border-color: #9ecfef;
+        }
+        margin-left: auto;
+        width: inherit;
+        margin-right: 5px;
+        .previous-notes-label {
+            font-weight: bold;
+            font-size: 0.8em;
+            margin: 10px;
+            max-width: 184px;
+        }
+        .note { 
+            position: relative;
+            width: inherit;
+            max-width: 150px;
+            padding: 0.5em 1em;
+            margin: 1em 0;
+            background: #fff;
+            border: 1px solid #ccc;
+            border-radius: 5px 0 5px 5px;
+            & > * {
+                font-size: 0.8rem;
+                color: #555;
+            }
+            &:hover {
+                cursor: pointer;
+                background-color: #e6e6e6;
+            }
+            &::before {
+                content: "";
+                position: absolute;
+                top: -2px;
+                right: -2px;
+                border-width: 0 16px 16px 0;
+                border-style: solid;
+                border-color: #ccc #fff;
+            }
+            &.note-new {
+                /*margin: 10px 20px;*/
+                width: auto;
+                text-align: center;
+                display: block;
+                &:hover {
+                    cursor:pointer;
+                    background: #e6e6e6;
+                }
+                .note-new-text {
+                    font-size: 1.1rem;
+                    .fa {
+                        padding-right: 10px;
+                    }
+                }
+            }
+            &.existing-note {         
+                .existing-note-date {
+                    padding-bottom: 5px;
+                    font-weight: bold;
+                }
+                
+                .existing-note-subject {
+                    padding-bottom: 10px;
+                    border-bottom: 1px solid #ccc;
+                }
+                
+                .existing-note-metadata {
+                    margin-bottom: 5px;
+                }
+            }   
+        }
+        
+        .more-notes-btn {
+            background-color: white !important;
+            padding: 10px !important;
+            margin-top: 20px;
+            max-width: 184px;
+            &:hover {
+                background: #e6e6e6 !important;
+            }    
+        }
+    }
+    
+    #delete-note-container{
+        background: white;
+        display: flex;
+        justify-content: center;
+        position: absolute;
+        bottom: 0;
+        #delete-note-button {
+            padding: 10px;
+            margin-bottom: 10px;
+            text-transform: none;
+            background-color: #ffffff;
+            &:hover {
+                background-color: #e6e6e6;
+            }
+            #trash-icon {
+                margin-right: 10px;
+                color: rgba(255, 0, 0, 0.7);
+            }
+        }
+    }
+    
+    /* Sort */
+    
+    .sort-label {
+        margin-left: 10px;
+        font-size: 0.8em;
+    }
+    
+    .sort-selection {
+        margin-bottom: 20px;
+        max-width: 184px;
+    }
+    
+    .sort-select {
+        width: 90%;
+        max-width: 200px;
+        margin-left: 10px;
+    }
+    
+    .sort-selection .sort-select {
+        font-size: 0.8em;
+    }
+    
+    li.sort-item:hover {
+        background-color: #1384b5;
+        color: #fff;
+    }
+    
+     
+}
+
+#pick-list-options-modal {
+    height: 80%;
+    width: 80%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    position: absolute;
+    background: white;
+    padding: 20px;
+}
+
+@media only screen and (min-width: 1200px) and (max-width: 1300px) {
+    .note-assistant-wrapper {
+        width: 160px;
+    }
+}
+
+
+@media only screen and (max-width: 1024px) { 
+    .note-assistant-wrapper {
+        /* 117px is the height of the on large screens Patient Control Panel, 20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars*/
+        max-height: calc(100vh - 117px - 20px);
+    }
+}
+
+@media only screen and (min-width: 577px) and (max-width: 768px) {
+    .note-assistant-wrapper {
+        width: 170px;
+     }
+}

--- a/src/panels/NotesPanel.css
+++ b/src/panels/NotesPanel.css
@@ -1,21 +1,18 @@
 #finish-sign-component {
-    position: fixed;
-    bottom: 0px;
-    width: calc(35vw);
-    background-color: #ffffff;
-    text-align: left;
-    z-index: 5;
-    display: flex;
-    justify-content: center;
-}
-.panel-content.note-assistant-panel { 
-    padding: 0px !important;
-}
+  position: fixed;
+  bottom: 0px;
+  width: calc(35vw);
+  background-color: #ffffff;
+  text-align: left;
+  z-index: 5;
+  display: flex;
+  justify-content: center; }
+  #finish-sign-component .btn-finish {
+    background-color: #FFFFFF;
+    text-transform: none;
+    display: inline-block;
+    min-width: 90%;
+    margin: 10px; }
 
-.btn_finish {
-    background-color: #FFFFFF !important;
-    text-transform: none !important;
-    display: inline-block !important;
-    min-width: 90% !important;
-    margin: 20px 20px 20px 20px !important;
-}
+.panel-content.note-assistant-panel {
+  padding: 0px !important; }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -260,9 +260,15 @@ export default class NotesPanel extends Component {
     renderSignButton = () => {
         return (
             <div id="finish-sign-component">
-                <Button raised className="btn_finish" onClick={() => {
-                    this.handleSignButtonClick();
-                }}>
+                <Button 
+                    raised 
+                    classes={{
+                        root: "btn-finish"
+                    }} 
+                    onClick={() => {
+                        this.handleSignButtonClick();
+                    }}
+                >
                     Sign note
                 </Button>
             </div>

--- a/src/panels/NotesPanel.scss
+++ b/src/panels/NotesPanel.scss
@@ -1,0 +1,20 @@
+#finish-sign-component {
+    position: fixed;
+    bottom: 0px;
+    width: calc(35vw);
+    background-color: #ffffff;
+    text-align: left;
+    z-index: 5;
+    display: flex;
+    justify-content: center;
+    .btn-finish {
+        background-color: #FFFFFF;
+        text-transform: none;
+        display: inline-block;
+        min-width: 90%;
+        margin: 10px;
+    }
+}
+.panel-content.note-assistant-panel { 
+    padding: 0px !important;
+}


### PR DESCRIPTION
Changes the styling of the delete note button so that it is always visible. Changed note-assistant and note-panel CSS to SCSS and reorganized the classes for improved readability. Also used color variables defined in _variables.scss; people should let me know if they think the colors are alright still! 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added Enzyme-UI tests for slim mode 
- **N/A** Added Enzyme-UI tests for full mode
- **N/A** Added backend tests for new functionality added
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
