### PR TITLE
Command support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,12 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/logos/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/logos/favicon-16x16.png">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i" rel="stylesheet">
-
     <title>Flux Notes - Powered by SHR</title>
+    <script language="javascript">
+            function flux_command(name, data) {
+                return window.fluxnotes_app.receive_command(name,data);
+            }
+    </script>            
   </head>
   <body>
     <div id="root"></div>

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -90,6 +90,7 @@ export class FullApp extends Component {
             snackbarMessage: "",
             superRole: 'Clinician', // possibly add that to security manager too
             summaryItemToInsert: '',
+            summaryItemToInsertSource: '',
             forceRefresh: false
         };
 
@@ -162,7 +163,7 @@ export class FullApp extends Component {
             const sectionName = data.section;
             return this.dashboard.moveTargetedDataPanelToSection(sectionName);
         } else if (commandType === 'insert-structured-phrase') {
-            return this.dashboard.insertStructuredPhraseInCurrentNote(data);
+            return this.dashboard.insertStructuredPhraseInCurrentNote(data, "command");
         } else {
             return "Unknown command type: " + commandType;
         }
@@ -218,13 +219,14 @@ export class FullApp extends Component {
 
     // Determines the item to be inserted
     itemInserted = () => {
-        this.setState({summaryItemToInsert: ''});
+        this.setState({summaryItemToInsert: '', summaryItemToInsertSource: ''});
     }
 
     // Given a shortcutClass, a type and an object, create a new shortcut and change errors as needed.
-    newCurrentShortcut = (shortcutC, shortcutType, shortcutData, updatePatient = true) => {
+    newCurrentShortcut = (shortcutC, shortcutType, shortcutData, updatePatient = true, source) => {
 
         let newShortcut = this.shortcutManager.createShortcut(shortcutC, shortcutType, this.state.patient, shortcutData, this.handleShortcutUpdate);
+        newShortcut.setSource(source);
         const errors = newShortcut.validateInCurrentContext(this.contextManager);
         if (errors.length > 0) {
             errors.forEach((error) => {
@@ -288,30 +290,35 @@ export class FullApp extends Component {
     }
 
     // Update the summaryItemToInsert based on the item given
-    handleSummaryItemSelected = (item, arrayIndex = -1) => {
+    handleSummaryItemSelected = (item, arrayIndex = -1, source = undefined) => {
         if (item) {
+            let newStateValues;
             if (Lang.isArray(item.value)) item.value = item.value[0];
             // calls to this method from the buttons on a ListType pass in 'item' as an array.
             if (Lang.isArray(item) && arrayIndex >= 0) {
                 // If the object to insert has an associated shortcut, is will be an object like {name: x, shortcut: z}
                 if(Lang.isObject(item[arrayIndex])){
-                    this.setState({ summaryItemToInsert: `${item[arrayIndex].shortcut}[[${item[arrayIndex].name}]]` });
+                    newStateValues = { summaryItemToInsert: `${item[arrayIndex].shortcut}[[${item[arrayIndex].name}]]` };
                 } else {
-                    this.setState({ summaryItemToInsert: item[arrayIndex]});
+                    newStateValues = { summaryItemToInsert: item[arrayIndex] };
                 }
             } else if (item.shortcut) {
-                this.setState({ summaryItemToInsert: `${item.shortcut}[[${item.value}]]` });
+                newStateValues = { summaryItemToInsert: `${item.shortcut}[[${item.value}]]` };
             } else if (item.value) {
-                this.setState({ summaryItemToInsert: item.value });
+                newStateValues = { summaryItemToInsert: item.value };
             } else {
-                this.setState({ summaryItemToInsert: item });
+                newStateValues = { summaryItemToInsert: item };
             }
+            if (!Lang.isUndefined(source)) {
+                newStateValues["summaryItemToInsertSource"] = source;
+            }
+            this.setState(newStateValues);
         }
     }
 
     // Enrolls the patient in the selected trial
-    addEnrollmentToEditor = (item) => {  
-        this.setState({ summaryItemToInsert: `#enrollment #${item.value}`});
+    addEnrollmentToEditor = (item) => {
+        this.setState({ summaryItemToInsert: `#enrollment #${item.value}`, summaryItemToInsertSource: 'Targeted Data Panel action'});
     }
 
     handleSnackbarClose = () => {

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -51,6 +51,7 @@ function getModalStyle() {
 export class FullApp extends Component {
     constructor(props) {
         super(props);
+        window.fluxnotes_app = this;
         this.possibleClinicalEvents = [
             "pre-encounter",
             "encounter",
@@ -153,6 +154,17 @@ export class FullApp extends Component {
             this.setState({loginUser: userProfile.getUserName()});
         } else {
             console.error("Login failed");
+        }
+    }
+
+    receive_command(commandType, data) {
+        if (commandType === 'navigate_targeted_data_panel') {
+            const sectionName = data.section;
+            return this.dashboard.moveTargetedDataPanelToSection(sectionName);
+        } else if (commandType === 'insert-structured-phrase') {
+            return this.dashboard.insertStructuredPhraseInCurrentNote(data);
+        } else {
+            return "Unknown command type: " + commandType;
         }
     }
 
@@ -361,6 +373,7 @@ export class FullApp extends Component {
                             structuredFieldMapManager={this.structuredFieldMapManager}
                             summaryMetadata={this.summaryMetadata}
                             updateErrors={this.updateErrors}
+                            ref={(dashboard) => { this.dashboard = dashboard; }}
                         />
                         <Modal 
                             aria-labelledby="simple-modal-title"

--- a/src/containers/SlimApp.jsx
+++ b/src/containers/SlimApp.jsx
@@ -31,6 +31,7 @@ export class SlimApp extends Component {
         if (newShortcut) {
             newShortcut.setConfiguration((this.props.shortcutConfigurations) ?
                     this.props.shortcutConfigurations[shortcutType] : {});
+            newShortcut.setSource("slim mode");
         }
         this.setState({
             currentShortcut: newShortcut

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -147,8 +147,8 @@ export default class ClinicianDashboard extends Component {
         return this.targetedDataPanel.moveToSection(sectionName);
     }
 
-    insertStructuredPhraseInCurrentNote = (data) => {
-        return this.notesPanel.insertStructuredPhraseInCurrentNote(data);
+    insertStructuredPhraseInCurrentNote = (data, source) => {
+        return this.notesPanel.insertStructuredPhraseInCurrentNote(data, source);
     }
 
     render() {
@@ -213,6 +213,7 @@ export default class ClinicianDashboard extends Component {
                         shortcutManager={this.props.shortcutManager}
                         structuredFieldMapManager={this.props.structuredFieldMapManager}
                         summaryItemToInsert={this.props.appState.summaryItemToInsert}
+                        summaryItemToInsertSource={this.props.appState.summaryItemToInsertSource}
                         updateErrors={this.props.updateErrors}
                         ref={(np) => { this.notesPanel = np; }}
                     />

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -143,6 +143,14 @@ export default class ClinicianDashboard extends Component {
         }
     }
 
+    moveTargetedDataPanelToSection = (sectionName) => {
+        return this.targetedDataPanel.moveToSection(sectionName);
+    }
+
+    insertStructuredPhraseInCurrentNote = (data) => {
+        return this.notesPanel.insertStructuredPhraseInCurrentNote(data);
+    }
+
     render() {
         const currentLayout = this.props.appState.layout;
         const isNoteViewerVisible = this.props.appState.isNoteViewerVisible;
@@ -175,6 +183,7 @@ export default class ClinicianDashboard extends Component {
                         summaryMetadata={this.props.summaryMetadata}
                         setForceRefresh={this.props.setForceRefresh}
                         targetedDataPanelSize={this.state.targetedDataPanelSize}
+                        ref={(tdp) => { this.targetedDataPanel = tdp; }}
                     />
                 </div>
                 <div style={notesPanelStyles}>
@@ -205,6 +214,7 @@ export default class ClinicianDashboard extends Component {
                         structuredFieldMapManager={this.props.structuredFieldMapManager}
                         summaryItemToInsert={this.props.appState.summaryItemToInsert}
                         updateErrors={this.props.updateErrors}
+                        ref={(np) => { this.notesPanel = np; }}
                     />
                 </div>
             </div>

--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types'
 import Child from './components/Child'
 import './react-minimap.css'
+import Lang from 'lodash';
 
 export class Minimap extends React.Component {
   static propTypes = {
@@ -99,6 +100,7 @@ export class Minimap extends React.Component {
       }
     }
 
+    this.sectionPositions = {};
     const nodes = this.ref.querySelectorAll(this.props.selector)
     let diff = 0;
     this.setState({
@@ -120,6 +122,11 @@ export class Minimap extends React.Component {
           hM = 0;
         }
 
+        this.sectionPositions[title] = this.sectionPositions[shortTitle] = {
+            left: Math.round( xM ),
+            top: Math.round( yM )
+        };
+
         return (
           <ChildComponent
             key={key}
@@ -134,6 +141,18 @@ export class Minimap extends React.Component {
         )
       })
     })
+  }
+
+  moveToSection(sectionName) {
+      const posForSection = this.sectionPositions[sectionName];
+      if (Lang.isUndefined(posForSection)) return "No section named '" + sectionName + "' found.";
+      const { left, top } = posForSection;
+      if (Lang.isUndefined(this.x) || Lang.isUndefined(this.y)) {
+        this.x = 0
+        this.y = 0;
+      }
+      this.scrollTo(left, top);
+      return null;
   }
 
   down( e ) {
@@ -154,7 +173,6 @@ export class Minimap extends React.Component {
     if (this.downState === false)
       return
 
-    const {width, height} = this.state
     let event;
 
     e.preventDefault();
@@ -167,8 +185,14 @@ export class Minimap extends React.Component {
       event = e;
     }
 
-    let dx = event.clientX - this.x;
-    let dy = event.clientY - this.y;
+    this.scrollTo(event.clientX, event.clientY);
+  }
+
+  scrollTo(x, y) {
+    const {width, height} = this.state
+
+    let dx = x - this.x;
+    let dy = y - this.y;
     if ( this.l + dx < 0 ) {
       dx = -this.l;
     }

--- a/src/noteparser/NoteParser.js
+++ b/src/noteparser/NoteParser.js
@@ -60,7 +60,7 @@ export default class NoteParser {
         const shortcut = this.shortcutManager.createShortcut(
             triggerOrKeywordObject.definition, triggerOrKeywordText, this.patient, 
             triggerOrKeywordObject.selectedValue, this.handleShortcutUpdate);
-       
+        shortcut.setSource("parsed note");
         shortcut.initialize(this.contextManager, triggerOrKeywordText, true, triggerOrKeywordObject.selectedValue);
      
         if (shortcut instanceof CreatorBase || shortcut instanceof SingleHashtagKeyword || shortcut instanceof UpdaterBase) {

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -68,14 +68,27 @@ export default class FillPlaceholder extends Component {
     }
 
     fillFromData = (data) => {
-        //TODO: creating/deleting toxicities
+        const { placeholder } = this.props;
         let errorToReturn = null, error; // return first error only
+
+        let entryIndex = 0;
+        if (placeholder.multiplicity === 'many') {
+            let lastEntryIndex = placeholder.entryShortcuts.length - 1;
+            const valFirstField = placeholder.getAttributeValue(data.fields[0].name, lastEntryIndex);
+            console.log(valFirstField);
+            if (Lang.isUndefined(valFirstField) || Lang.isNull(valFirstField) || valFirstField.length === 0) {
+                entryIndex = lastEntryIndex;
+            } else {
+                this.addEntry();
+                entryIndex = lastEntryIndex + 1;
+            }
+        }
+
         data.fields.forEach((field) => {
-            error = this.onSetValue({name: field.name }, 0, field.value, false);
+            error = this.onSetValue({name: field.name }, entryIndex, field.value, false);
             if (!Lang.isNull(error) && Lang.isNull(errorToReturn)) errorToReturn = error;
         });
 
-        const { placeholder } = this.props;
         if (Lang.isNull(errorToReturn) && placeholder.multiplicity !== 'many') {
             this.setState({ done: true });
         }
@@ -149,6 +162,7 @@ export default class FillPlaceholder extends Component {
 
     onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
         const { placeholder } = this.props;
+        //if (entryIndex === -1) entryIndex = placeholder.entryShortcuts.length - 1;
         const attributes = placeholder.getAttributeValue(attributeSpec.name, entryIndex);
         let error;
 

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -142,6 +142,7 @@ export default class FillPlaceholder extends Component {
     };
 
     onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
+        let { currentField, done } = this.state;
         const { placeholder } = this.props;
 
         if (currentField[entryIndex] + 1 === placeholder.attributes.length) {

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -142,26 +142,6 @@ export default class FillPlaceholder extends Component {
     };
 
     onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
-        let { currentField, done } = this.state;
-        const { placeholder } = this.props;
-
-        if (currentField[entryIndex] + 1 === placeholder.attributes.length) {
-            // User has entered final attribute, so mark row as done
-            if (placeholder.multiplicity !== 'many') {
-                done = true;
-                this.props.placeholder.done = true;
-                this.setState({ done });
-            } else {
-                currentField[entryIndex] = 0;
-                this.setState({ currentField });
-            }
-        } else {
-            currentField[entryIndex] += 1;
-            this.setState({ currentField });
-        }
-    };
-
-    onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
         const { placeholder } = this.props;
         //if (entryIndex === -1) entryIndex = placeholder.entryShortcuts.length - 1;
         const attributes = placeholder.getAttributeValue(attributeSpec.name, entryIndex);

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -148,7 +148,8 @@ export default class FillPlaceholder extends Component {
     };
 
     onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
-        const attributes = this.props.placeholder.getAttributeValue(attributeSpec.name, entryIndex);
+        const { placeholder } = this.props;
+        const attributes = placeholder.getAttributeValue(attributeSpec.name, entryIndex);
         let error;
 
         if (Lang.isArray(attributes) && Lang.includes(attributes, newValue)) {

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -130,7 +130,25 @@ export default class FillPlaceholder extends Component {
 
     onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
         const { placeholder } = this.props;
-        const attributes = placeholder.getAttributeValue(attributeSpec.name, entryIndex);
+
+        if (currentField[entryIndex] + 1 === placeholder.attributes.length) {
+            // User has entered final attribute, so mark row as done
+            if (placeholder.multiplicity !== 'many') {
+                done = true;
+                this.props.placeholder.done = true;
+                this.setState({ done });
+            } else {
+                currentField[entryIndex] = 0;
+                this.setState({ currentField });
+            }
+        } else {
+            currentField[entryIndex] += 1;
+            this.setState({ currentField });
+        }
+    };
+
+    onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
+        const attributes = this.props.placeholder.getAttributeValue(attributeSpec.name, entryIndex);
         let error;
 
         if (Lang.isArray(attributes) && Lang.includes(attributes, newValue)) {

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -129,7 +129,8 @@ export default class FillPlaceholder extends Component {
     };
 
     onSetValue = (attributeSpec, entryIndex, newValue, moveToNextField = true) => {
-        const attributes = this.props.placeholder.getAttributeValue(attributeSpec.name, entryIndex);
+        const { placeholder } = this.props;
+        const attributes = placeholder.getAttributeValue(attributeSpec.name, entryIndex);
         let error;
 
         if (Lang.isArray(attributes) && Lang.includes(attributes, newValue)) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -91,7 +91,7 @@ class FluxNotesEditor extends React.Component {
 
         // Set the initial state when the app is first constructed.
         this.resetEditorState();
-
+        
         // setup structured field plugin
         const structuredFieldPluginOptions = {
             contextManager: this.contextManager,
@@ -106,7 +106,7 @@ class FluxNotesEditor extends React.Component {
         });
         this.structuredFieldPlugin = StructuredFieldPlugin(structuredFieldPluginOptions);
         this.plugins.push(this.structuredFieldPlugin)
-
+        
         // setup single hashtag structured field plugin
         const singleHashtagKeywordStructuredFieldPluginOptions = {
             shortcutManager: this.props.shortcutManager,
@@ -132,7 +132,7 @@ class FluxNotesEditor extends React.Component {
         };
         this.NLPHashtagPlugin = NLPHashtagPlugin(NLPHashtagPluginOptions);
         this.plugins.push(this.NLPHashtagPlugin)
-
+        
         // setup creator suggestions plugin (autocomplete)
         this.suggestionsPluginCreators = SuggestionsPlugin({
             capture: /#([\w\s\-,]*)/,
@@ -141,7 +141,7 @@ class FluxNotesEditor extends React.Component {
             trigger: '#',
         });
         this.plugins.push(this.suggestionsPluginCreators)
-
+        
         // setup inserter suggestions plugin (autocomplete)
         this.suggestionsPluginInserters = SuggestionsPlugin({
             capture: /@([\w\s\-,]*)/,
@@ -226,8 +226,9 @@ class FluxNotesEditor extends React.Component {
         };
     }
 
-    updateFetchingStatus = (isFetchingAsyncData) => {
-        if (!isFetchingAsyncData) {
+
+    updateFetchingStatus = (isFetchingAsyncData) => { 
+        if (!isFetchingAsyncData) { 
             // If we're not fetching, clear any lagging timers;
             if (this.state.fetchTimeout !== null) clearTimeout(this.state.fetchTimeout._id)
             this.setState({
@@ -236,7 +237,7 @@ class FluxNotesEditor extends React.Component {
                 // Clear fetch timer
                 fetchTimeout: null,
             });
-        } else {
+        } else { 
             // If we are fetching, set a timer that will display a loading animation in the editor after trigger
             this.setState({
                 fetchTimeout: setTimeout (() => {
@@ -245,7 +246,7 @@ class FluxNotesEditor extends React.Component {
                         loadingTimeWarrantsWarning: true
                     });
                 }, 10),
-            })
+            })  
         }
     }
 
@@ -305,7 +306,7 @@ class FluxNotesEditor extends React.Component {
 
     choseSuggestedShortcut(suggestion) {
         const {state} = this.state;
-        const shortcut = this.props.newCurrentShortcut(null, suggestion.value.name);
+        const shortcut = this.props.newCurrentShortcut(null, suggestion.value.name, undefined, true, "auto-complete");
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions()) {
             return this.openPortalToSelectValueForShortcut(shortcut, true, state.transform()).apply();
         } else {
@@ -327,7 +328,7 @@ class FluxNotesEditor extends React.Component {
         return this.insertPlaceholder(suggestion.value, transformBeforeInsert).apply();
     }
 
-    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, shouldPortalOpen = true) => {
+    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, shouldPortalOpen = true, source) => {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
@@ -337,7 +338,7 @@ class FluxNotesEditor extends React.Component {
             return this.insertPlainText(transform, shortcutTrigger);
         }
 
-        let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, text, updatePatient);
+        let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, text, updatePatient, source);
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions() && text.length === 0) {
             return this.openPortalToSelectValueForShortcut(shortcut, false, transform, shouldPortalOpen);
         }
@@ -363,11 +364,11 @@ class FluxNotesEditor extends React.Component {
             return this.insertPlaceholder(matches.before[0], transform).insertText(characterToAppend);
         }
 
-        return this.insertShortcut(def, matches.before[0], "", transform).insertText(characterToAppend);
+        return this.insertShortcut(def, matches.before[0], "", transform, true, true, 'typed').insertText(characterToAppend);
     }
 
     getTextCursorPosition = () => {
-        const positioningUsingSlateNodes = () => {
+        const positioningUsingSlateNodes = () => { 
             const pos = {};
             const parentNode = this.state.state.document.getParent(this.state.state.selection.startKey);
             const el = Slate.findDOMNode(parentNode);
@@ -384,9 +385,9 @@ class FluxNotesEditor extends React.Component {
         }
 
         if (!this.editorHasFocus) {
-            if (this.lastPosition.top === 0 && this.lastPosition.left === 0) {
+            if (this.lastPosition.top === 0 && this.lastPosition.left === 0) {   
                 this.lastPosition = positioningUsingSlateNodes();
-            }
+            } 
         } else {
             const pos = position();
             // If position is calculated to be 0, 0, use our old method of calculating position.
@@ -410,7 +411,7 @@ class FluxNotesEditor extends React.Component {
             this.insertPlainText(transform, shortcut.initiatingTrigger);
             return transform.blur();
         }
-
+        
         let portalOptions = shortcut.getValueSelectionOptions();
 
         this.setState({
@@ -428,9 +429,9 @@ class FluxNotesEditor extends React.Component {
         let shortcut = this.selectingForShortcut;
 
         this.selectingForShortcut = null;
-        this.setState({
+        this.setState({ 
             openedPortal: null,
-            portalOptions: null,
+            portalOptions: null, 
         });
         if (Lang.isNull(selection)) {
             // Removes the shortcut from its parent
@@ -548,7 +549,7 @@ class FluxNotesEditor extends React.Component {
             focusOffset: data.focusOffset
         }).delete()
 
-        this.insertTextWithStructuredPhrases(data.newText, nextState)
+        this.insertTextWithStructuredPhrases(data.newText, nextState, true, true, "dictation");
     }
 
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
@@ -625,7 +626,7 @@ class FluxNotesEditor extends React.Component {
         // Check if the item to be inserted is updated
         if (nextProps.shouldEditorContentUpdate && this.props.summaryItemToInsert !== nextProps.summaryItemToInsert && nextProps.summaryItemToInsert.length > 0) {
             if (this.props.isNoteViewerEditable) {
-                this.insertTextWithStructuredPhrases(nextProps.summaryItemToInsert);
+                this.insertTextWithStructuredPhrases(nextProps.summaryItemToInsert, undefined, true, true, nextProps.summaryItemToInsertSource);
                 this.props.itemInserted();
             }
         }
@@ -650,7 +651,7 @@ class FluxNotesEditor extends React.Component {
                 this.resetEditorAndContext();
 
                 let shouldPortalOpen = this.props.noteAssistantMode !== 'pick-list-options-panel';
-                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content, undefined, false, shouldPortalOpen);
+                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content, undefined, false, shouldPortalOpen, "loaded note");
 
                 // If the note is in progress, set isNoteViewerEditable to true. If the note is an existing note, set isNoteViewerEditable to false
                 if (nextProps.updatedEditorNote.signed) {
@@ -673,13 +674,13 @@ class FluxNotesEditor extends React.Component {
         // Check if mode is changing from 'pick-list-options-panel' to 'context-tray'
         // This means user either clicked the OK or Cancel button on the modal
         if (this.props.noteAssistantMode === 'pick-list-options-panel' && nextProps.noteAssistantMode === 'context-tray') {
-            this.adjustActiveContexts(this.state.state.selection, this.state.state);
+            this.adjustActiveContexts(this.state.state.selection, this.state.state); 
             this.props.contextManager.clearNonActiveContexts();
             // User clicked cancel button
             if (nextProps.contextTrayItemToInsert === null) {
-                this.props.setNoteViewerEditable(true);
+                this.props.setNoteViewerEditable(true);   
             } else { // User clicked OK button so insert text
-                this.insertTextWithStructuredPhrases(this.props.contextTrayItemToInsert);
+                this.insertTextWithStructuredPhrases(this.props.contextTrayItemToInsert, undefined, true, true, "pick list/template");
                 this.props.updateContextTrayItemToInsert(null);
                 this.props.setNoteViewerEditable(true);
             }
@@ -706,7 +707,7 @@ class FluxNotesEditor extends React.Component {
         let listItemEndIndex = text.indexOf('</li>');
 
         // No styles to be added.
-        if (boldStartIndex === -1 && boldEndIndex === -1
+        if (boldStartIndex === -1 && boldEndIndex === -1 
             && italicStartIndex === -1 && italicEndIndex === -1
             && underlinedStartIndex === -1 && underlinedEndIndex === -1
             && unorderedListStartIndex === -1 && unorderedListEndIndex === -1
@@ -748,7 +749,7 @@ class FluxNotesEditor extends React.Component {
         } else if (firstStyle.name === 'orderedListEndIndex') {
             this.endList(transform, text, orderedListStartIndex, orderedListEndIndex, 'numbered-list');
         } else if (firstStyle.name === 'listItemStartIndex' || firstStyle.name === 'listItemEndIndex') {
-            const currentList = styleMarkings.find(a =>
+            const currentList = styleMarkings.find(a => 
                 a.value > -1 &&
                 (a.name === 'orderedListStartIndex' || a.name === 'orderedListEndIndex'
                 || a.name === 'unorderedListStartIndex' || a.name === 'unorderedListEndIndex'))
@@ -867,7 +868,7 @@ class FluxNotesEditor extends React.Component {
             startOffset = wordOffset;
         } else {
             // No HTML style tag present so set startIndex to the beginning of the string and leave startOffset as 0 since no word to remove.
-            startIndex = 0;
+            startIndex = 0; 
         }
 
         let endOffset = 0; // This represents how many characters to cut off from the text string at the endIndex.
@@ -956,7 +957,7 @@ class FluxNotesEditor extends React.Component {
     /*
      * Handle updates when we have a new insert text with structured phrase
      */
-    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true, shouldPortalOpen = true) => {
+    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true, shouldPortalOpen = true, source) => {
         const currentState = this.state.state;
 
         let transform = (currentTransform) ? currentTransform : currentState.transform();
@@ -1006,7 +1007,7 @@ class FluxNotesEditor extends React.Component {
                 } else {
                     after = "";
                 }
-                transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, shouldPortalOpen);
+                transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, shouldPortalOpen, source);
             });
         }
         if (!Lang.isUndefined(remainder) && remainder.length > 0) {
@@ -1072,15 +1073,15 @@ class FluxNotesEditor extends React.Component {
             this.props.updateNoteAssistantMode('pick-list-options-panel');
             if (this.props.inModal) {
                 this.resetEditorState();
-                this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false);
+                this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false, "Selection from pick list (modal)");
             }
         } else if (this.props.noteAssistantMode === 'pick-list-options-panel') {
             if (this.props.inModal) {
                 this.resetEditorState();
-                this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false);
+                this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false, "Template");
             }
         } else { // If the text to be inserted does not contain any pick lists, insert the text
-            this.insertTextWithStructuredPhrases(contextTrayItem);
+            this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, true, "Shortcuts in Context");
             this.props.updateContextTrayItemToInsert(null);
             this.props.updateNoteAssistantMode('context-tray');
         }
@@ -1245,13 +1246,12 @@ class FluxNotesEditor extends React.Component {
     renderNoteNameEditor = (noteTitle, signed) => {
         let noteTag;
         if (signed) {
-            noteTag = <p className="note-name" id="note-title">{noteTitle}</p>;
+            noteTag = <p className="note-description-detail-value" id="note-title">{noteTitle}</p>;
         } else {
-            noteTag = <p className="note-name" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
+            noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
         }
         if (this.state.isEditingNoteName) {
             return (
-                <div id="text-field-container">
                 <TextField
                     id="note-title-input"
                     autoFocus={true}
@@ -1259,7 +1259,6 @@ class FluxNotesEditor extends React.Component {
                     defaultValue={noteTitle}
                     onKeyPress={this.submitNoteNameChange}
                 />
-                </div>
             );
         } else {
             return noteTag;
@@ -1267,7 +1266,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     // Renders the noteDescription of the editor
-    renderNoteDescriptionContent = () => {
+    renderNoteDescriptionContent = () => { 
         // Preset note header information
         let noteTitle = "New Note";
         let date = Moment(new Date()).format('DD MMM YYYY');
@@ -1294,25 +1293,27 @@ class FluxNotesEditor extends React.Component {
         } else {
             return (
                 <div id="note-description">
-                    <Row>
-                        <Col xs={9}>
-                            <Row>
-                                {this.renderNoteNameEditor(noteTitle, signed)}
-                            </Row>
-                            <Row >
-                                <Col xs={7}>
-                                    <p className="note-description-detail"><span className="note-description-detail-name">Signed By: </span><span className="note-description-detail-value">{signedString}</span></p>
-                                    <p className="note-description-detail"><span className="note-description-detail-name">Source: </span><span className="note-description-detail-value">{source}</span></p>
-                                </Col>
-                                <Col xs={5}>
-                                    <p className="note-description-detail"><span className="note-description-detail-name">Signed Date: </span><span className="note-description-detail-value">{date}</span></p>
-                                </Col>
-                            </Row>
+                    <Row end="xs">
+                        <Col xs={2}>
+                            <p className="note-description-detail-name">Name</p>
+                            {this.renderNoteNameEditor(noteTitle, signed)}
                         </Col>
-                        <Col xs={3}>
-                            {!this.props.inModal &&
+                        <Col xs={2}>
+                            <p className="note-description-detail-name">Date</p>
+                            <p className="note-description-detail-value">{date}</p>
+                        </Col>
+                        <Col xs={2}>
+                            <p className="note-description-detail-name">Source</p>
+                            <p className="note-description-detail-value">{source}</p>
+                        </Col>
+                        <Col xs={2}>
+                            <p className="note-description-detail-name">Signed By</p>
+                            <p className="note-description-detail-value">{signedString}</p>
+                        </Col>
+                        <Col xs={4}>
+                            { !this.props.inModal &&
                                 <Button
-                                    raised
+                                    raised 
                                     className="close-note-btn"
                                     disabled={this.context_disabled}
                                     onClick={this.closeNote}
@@ -1321,13 +1322,13 @@ class FluxNotesEditor extends React.Component {
                                         lineHeight: "2.1rem"
                                     }}
                                 >
-                                    <FontAwesome
+                                    <FontAwesome 
                                         name="times"
                                         style={{
                                             color: "red",
                                             marginRight: "5px"
                                         }}
-                                    />
+                                    /> 
                                     <span>
                                         Close
                                     </span>
@@ -1335,17 +1336,18 @@ class FluxNotesEditor extends React.Component {
                             }
                         </Col>
                     </Row>
-                    <Divider className="note-description-divider" />
+
+                    <Divider className="note-description-divider"/>
                 </div>
             );
         }
     }
-
+    
     render = () => {
         const CreatorsPortal = this.suggestionsPluginCreators.SuggestionPortal;
         const InsertersPortal = this.suggestionsPluginInserters.SuggestionPortal;
         const PlaceholdersPortal = this.suggestionsPluginPlaceholders.SuggestionPortal;
-
+        
         let errorDisplay = "";
         if (this.props.errors && this.props.errors.length > 0) {
             errorDisplay = (

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1246,19 +1246,21 @@ class FluxNotesEditor extends React.Component {
     renderNoteNameEditor = (noteTitle, signed) => {
         let noteTag;
         if (signed) {
-            noteTag = <p className="note-description-detail-value" id="note-title">{noteTitle}</p>;
+            noteTag = <p className="note-name" id="note-title">{noteTitle}</p>;
         } else {
-            noteTag = <p className="note-description-detail-value" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
+            noteTag = <p className="note-name" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
         }
         if (this.state.isEditingNoteName) {
             return (
-                <TextField
-                    id="note-title-input"
-                    autoFocus={true}
-                    fullWidth={true}
-                    defaultValue={noteTitle}
-                    onKeyPress={this.submitNoteNameChange}
-                />
+                <div id="text-field-container">
+                    <TextField
+                        id="note-title-input"
+                        autoFocus={true}
+                        fullWidth={true}
+                        defaultValue={noteTitle}
+                        onKeyPress={this.submitNoteNameChange}
+                    />
+                </div>
             );
         } else {
             return noteTag;
@@ -1293,25 +1295,23 @@ class FluxNotesEditor extends React.Component {
         } else {
             return (
                 <div id="note-description">
-                    <Row end="xs">
-                        <Col xs={2}>
-                            <p className="note-description-detail-name">Name</p>
+                    <Row>
+                        <Col xs={9}>
+                            <Row>
                             {this.renderNoteNameEditor(noteTitle, signed)}
+                            </Row>
+                            <Row >
+                                <Col xs={7}>
+                                    <p className="note-description-detail"><span className="note-description-detail-name">Signed By: </span><span className="note-description-detail-value">{signedString}</span></p>
+                                    <p className="note-description-detail"><span className="note-description-detail-name">Source: </span><span className="note-description-detail-value">{source}</span></p>
+                                </Col>
+                                <Col xs={5}>
+                                    <p className="note-description-detail"><span className="note-description-detail-name">Signed Date: </span><span className="note-description-detail-value">{date}</span></p>
+                                </Col>
+                            </Row>
                         </Col>
-                        <Col xs={2}>
-                            <p className="note-description-detail-name">Date</p>
-                            <p className="note-description-detail-value">{date}</p>
-                        </Col>
-                        <Col xs={2}>
-                            <p className="note-description-detail-name">Source</p>
-                            <p className="note-description-detail-value">{source}</p>
-                        </Col>
-                        <Col xs={2}>
-                            <p className="note-description-detail-name">Signed By</p>
-                            <p className="note-description-detail-value">{signedString}</p>
-                        </Col>
-                        <Col xs={4}>
-                            { !this.props.inModal &&
+                        <Col xs={3}>
+                            {!this.props.inModal &&
                                 <Button
                                     raised 
                                     className="close-note-btn"
@@ -1337,7 +1337,7 @@ class FluxNotesEditor extends React.Component {
                         </Col>
                     </Row>
 
-                    <Divider className="note-description-divider"/>
+                    <Divider className="note-description-divider" />
                 </div>
             );
         }

--- a/src/notes/NLPHashtagPlugin.jsx
+++ b/src/notes/NLPHashtagPlugin.jsx
@@ -154,7 +154,8 @@ function NLPHashtagPlugin(opts) {
                 const typeOfPhrase = phraseValue.name;
                 const NLPShortcutMetadata = shortcutManager.getShortcutMetadata(typeOfPhrase);
                 const NLPKeyword = parseKeywordFromCanonicalizationBasedOnPhrase(phraseValue.canonicalization, NLPShortcutMetadata).toLowerCase();
-                const NLPShortcut = createShortcut(null, NLPKeyword)
+                const NLPShortcut = createShortcut(null, NLPKeyword);
+                NLPShortcut.setSource("NLP Engine");
                 // get range for originalText
                 originalTextRange = getRangeBasedOnPhrase(nodeAfterNLPShortcut.key, phraseValue)
                 // Insert the structured field at this range; 

--- a/src/notes/PointOfCare.jsx
+++ b/src/notes/PointOfCare.jsx
@@ -27,10 +27,10 @@ export default class PointOfCare extends Component {
         );
     }
 
-    insertStructuredPhrase = (data) => {
+    insertStructuredPhrase = (data, source) => {
         const fph = this.fillPlaceholders['#' + data.phrase];
         if (fph) {
-            return fph.fillFromData(data);
+            return fph.fillFromData(data, source);
         } else {
             return "No placeholder found for " + data.phrase + ".";
         }

--- a/src/notes/PointOfCare.jsx
+++ b/src/notes/PointOfCare.jsx
@@ -8,19 +8,32 @@ export default class PointOfCare extends Component {
     render() {
         const { structuredFieldMapManager } = this.props;
 
+        this.fillPlaceholders = {};
         const result = structuredFieldMapManager.placeholders.map((placeholder, index) => (
-            <Row key={index}>
-                <Col xs>
-                    <FillPlaceholder placeholder={placeholder} backgroundColor={(((index + 1) % 2) === 0) ? 'lightgrey' : ''} />
-                </Col>
-            </Row>
-        ));
+                <Row key={index}>
+                    <Col xs>
+                        <FillPlaceholder 
+                            placeholder={placeholder} 
+                            backgroundColor={(((index + 1) % 2) === 0) ? 'lightgrey' : ''}
+                            ref={(fph) => { this.fillPlaceholders[placeholder.shortcutName] = fph; }} />
+                    </Col>
+                </Row>
+            ));
 
         return (
             <div id="poc-panel">
                 {result}
             </div>
         );
+    }
+
+    insertStructuredPhrase = (data) => {
+        const fph = this.fillPlaceholders['#' + data.phrase];
+        if (fph) {
+            return fph.fillFromData(data);
+        } else {
+            return "No placeholder found for " + data.phrase + ".";
+        }
     }
 }
 

--- a/src/notes/SingleHashtagKeywordStructuredFieldPlugin.jsx
+++ b/src/notes/SingleHashtagKeywordStructuredFieldPlugin.jsx
@@ -42,17 +42,18 @@ function SingleHashtagKeywordStructuredFieldPlugin(opts) {
 				keywords.sort(_sortKeywordByNameLength);
 				const keywordInClosetBlock = scanTextForKeywordObject(curNode.text, keywords)
 				if (!Lang.isUndefined(keywordInClosetBlock)) { 
-					const keywordText = keywordInClosetBlock.name.toLowerCase()
-					const newKeywordShortcut = createShortcut(null, keywordText)
+					const keywordText = keywordInClosetBlock.name.toLowerCase();
+                    const newKeywordShortcut = createShortcut(null, keywordText);
+                    newKeywordShortcut.setSource("Keyword");
 					// KeywordRange never be null -- we've already confirmed the existance of the keyword
 					let keywordRange;
 					if(curNode.nodes) { 
 						for (const childNode of curNode.nodes){
-							keywordRange = getRangeForKeyword(childNode, keywordText)
+							keywordRange = getRangeForKeyword(childNode, keywordText);
 							if (keywordRange) break;
 						}
 					} else {
-						keywordRange = getRangeForKeyword(curNode, keywordText)
+						keywordRange = getRangeForKeyword(curNode, keywordText);
 					}
 					// Remove keyword from block, using first character as the prefix
 					curTransform = curTransform.select(keywordRange).delete();

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -245,13 +245,13 @@ function StructuredFieldPlugin(opts) {
             // NoteParser also overrides this function since there is no slate
             const saveIsBlock1BeforeBlock2 = contextManager.getIsBlock1BeforeBlock2();
             contextManager.setIsBlock1BeforeBlock2(() => { return false; });
-            insertText(decoded);
+            insertText(decoded, undefined, true, true, 'paste');
             contextManager.setIsBlock1BeforeBlock2(saveIsBlock1BeforeBlock2);
             event.preventDefault();
             return state;
         } else if (data.text) {
             event.preventDefault();
-            insertText(data.text);
+            insertText(data.text, undefined, true, true, 'paste');
             return state;
         }
     }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -10,6 +10,7 @@ import NoteAssistant from '../notes/NoteAssistant';
 import NoteParser from '../noteparser/NoteParser';
 import './NotesPanel.css';
 import PointOfCare from '../notes/PointOfCare';
+import { createSentenceFromStructuredData } from '../shortcuts/ShortcutUtils';
 
 export default class NotesPanel extends Component {
     constructor(props) {
@@ -36,6 +37,27 @@ export default class NotesPanel extends Component {
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
             this.saveNote(this.state.localDocumentText);
             this.handleUpdateEditorWithNote(nextProps.openClinicalNote);
+        }
+    }
+
+    insertStructuredPhraseInCurrentNote = (data) => {
+        if (this.state.noteAssistantMode === 'poc') {
+            return this.pointOfCare.insertStructuredPhrase(data);
+        } else if (this.props.isNoteViewerVisible && this.props.isNoteViewerEditable && this.state.selectedNote) {
+            const metadata = this.props.shortcutManager.getMetadataForTrigger(`#${data.phrase}`);
+            if (Lang.isUndefined(metadata)) return "No structured phrase named '" + data.phrase + "' found.";
+            const structuredPhrase = createSentenceFromStructuredData(
+                metadata["structuredPhrase"], 
+                (name) => {
+                    const foundItem = data.fields.find((item) => item.name === name);
+                    if (Lang.isUndefined(foundItem)) return undefined;
+                    return foundItem.value;
+                },
+                `#${data.phrase}`);
+            this.props.handleSummaryItemSelected(structuredPhrase);
+            return null;
+        } else {
+            return "Received command to insert structured phrase but no valid note to insert it into right now.";
         }
     }
 
@@ -295,7 +317,8 @@ export default class NotesPanel extends Component {
                             </Row>
                             <Row start="xs" style={{ marginLeft: '2px', marginRight: '10px' }}>
                                 <PointOfCare
-                                    structuredFieldMapManager={this.props.structuredFieldMapManager} />
+                                    structuredFieldMapManager={this.props.structuredFieldMapManager}
+                                    ref={(poc) => { this.pointOfCare = poc; }} />
                             </Row>
                         </div>
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -40,9 +40,9 @@ export default class NotesPanel extends Component {
         }
     }
 
-    insertStructuredPhraseInCurrentNote = (data) => {
+    insertStructuredPhraseInCurrentNote = (data, source) => {
         if (this.state.noteAssistantMode === 'poc') {
-            return this.pointOfCare.insertStructuredPhrase(data);
+            return this.pointOfCare.insertStructuredPhrase(data, source);
         } else if (this.props.isNoteViewerVisible && this.props.isNoteViewerEditable && this.state.selectedNote) {
             const metadata = this.props.shortcutManager.getMetadataForTrigger(`#${data.phrase}`);
             if (Lang.isUndefined(metadata)) return "No structured phrase named '" + data.phrase + "' found.";
@@ -54,7 +54,7 @@ export default class NotesPanel extends Component {
                     return foundItem.value;
                 },
                 `#${data.phrase}`);
-            this.props.handleSummaryItemSelected(structuredPhrase);
+            this.props.handleSummaryItemSelected(structuredPhrase, -1, source);
             return null;
         } else {
             return "Received command to insert structured phrase but no valid note to insert it into right now.";
@@ -390,6 +390,7 @@ export default class NotesPanel extends Component {
                     shouldEditorContentUpdate={this.state.noteAssistantMode !== 'pick-list-options-panel'}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
                     summaryItemToInsert={this.props.summaryItemToInsert}
+                    summaryItemToInsertSource={this.props.summaryItemToInsertSource}
                     contextTrayItemToInsert={this.state.contextTrayItemToInsert}
                     updateLocalDocumentText={this.updateLocalDocumentText}
                     // Pass in note that the editor is to be updated with

--- a/src/panels/TargetedDataPanel.jsx
+++ b/src/panels/TargetedDataPanel.jsx
@@ -13,6 +13,10 @@ export default class TargetedDataPanel extends Component {
         }
     }
 
+    moveToSection(sectionName) {
+        return this.minimap.moveToSection(sectionName);
+    }
+
     render () {
         // The css data attribute associated with the minimap
         const minimapAttribute = 'data-test-summary-section';
@@ -27,6 +31,7 @@ export default class TargetedDataPanel extends Component {
                     shortTitleAttribute={shortTitleAttribute}
                     width={80}
                     isFullHeight={true}
+                    ref={(minimap) => { this.minimap = minimap; }}
                 >
                     <div id="summary-subpanel">
                         <div className="summary-section">

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -1,6 +1,6 @@
 import Shortcut from './Shortcut';
 import Lang from 'lodash';
-import moment from 'moment';
+import { createSentenceFromStructuredData } from './ShortcutUtils';
 
 export default class EntryShortcut extends Shortcut {
     constructor(metadata) {
@@ -60,66 +60,7 @@ export default class EntryShortcut extends Shortcut {
     }
 
     getAsString() {
-        const structuredPhrase = this.metadata["structuredPhrase"];
-
-        let last = 0, valueName, value;
-        let start = structuredPhrase.indexOf("${"), end;
-        let result = "";
-        let haveAValue = false;
-        let isConditional;
-        let conditional, start2, end2, before, after;
-        while (start !== -1) {
-            if (last !== start) {
-                result += structuredPhrase.substring(last, start);
-            }
-            end = structuredPhrase.indexOf("}", start + 2);
-            valueName = structuredPhrase.substring(start + 2, end);
-            isConditional = valueName.startsWith("%");
-            if (isConditional) {
-                end = structuredPhrase.indexOf("}", end + 1); // adjust end to be 2nd close bracket
-                conditional = structuredPhrase.substring(start + 3, end);
-                start2 = conditional.indexOf("${");
-                end2 = conditional.indexOf("}", start2 + 2);
-                valueName = conditional.substring(start2 + 2, end2);
-                before = conditional.substring(0, start2);
-                after = conditional.substring(end2 + 1);
-                value = this.getAttributeValue(valueName);
-                if (Lang.isNull(value) || Lang.isUndefined(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
-                } else {
-                    if (value instanceof moment) value = value.format('MM/DD/YYYY');
-                    haveAValue = true;
-                    result += before;
-                    if (Lang.isArray(value)) {
-                        result += value.join(", #");
-                    } else {
-                        result += value;
-                    }
-                    result += after;
-                }
-            } else {
-                value = this.getAttributeValue(valueName);
-                if (Lang.isNull(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
-                    value = '?';
-                } else {
-                    if (value instanceof moment) value = value.format('MM/DD/YYYY');
-                    haveAValue = true;
-                }
-                if (Lang.isArray(value)) {
-                    result += value.join(", #");
-                } else {
-                    result += value;
-                }
-            }
-            last = end + 1;
-            start = structuredPhrase.indexOf("${", last);
-        }
-        if (last < structuredPhrase.length) {
-            result += structuredPhrase.substring(last);
-        }
-        if (!haveAValue) {
-            return this.getText();
-        }
-        return result;
+        return createSentenceFromStructuredData(this.metadata["structuredPhrase"], this.getAttributeValue.bind(this), this.getText());
     }
 
     _followPath(object, attributePath, startIndex) {

--- a/src/shortcuts/NLPHashtag.jsx
+++ b/src/shortcuts/NLPHashtag.jsx
@@ -3,6 +3,7 @@ import Shortcut from './Shortcut';
 import FluxObjectFactory from '../model/FluxObjectFactory';
 import Lang from 'lodash';
 import moment from 'moment';
+import { createSentenceFromStructuredData } from './ShortcutUtils';
 
 export default class NLPHashtag extends Shortcut {
     constructor(onUpdate, metadata, patient, shortcutData) {
@@ -133,66 +134,7 @@ export default class NLPHashtag extends Shortcut {
     }
 
     getAsString() {
-        const structuredPhrase = this.metadata["structuredPhrase"];
-
-        let last = 0, valueName, value;
-        let start = structuredPhrase.indexOf("${"), end;
-        let result = "";
-        let haveAValue = false;
-        let isConditional;
-        let conditional, start2, end2, before, after;
-        while (start !== -1) {
-            if (last !== start) {
-                result += structuredPhrase.substring(last, start);
-            }
-            end = structuredPhrase.indexOf("}", start + 2);
-            valueName = structuredPhrase.substring(start + 2, end);
-            isConditional = valueName.startsWith("%");
-            if (isConditional) {
-                end = structuredPhrase.indexOf("}", end + 1); // adjust end to be 2nd close bracket
-                conditional = structuredPhrase.substring(start + 3, end);
-                start2 = conditional.indexOf("${");
-                end2 = conditional.indexOf("}", start2 + 2);
-                valueName = conditional.substring(start2 + 2, end2);
-                before = conditional.substring(0, start2);
-                after = conditional.substring(end2 + 1);
-                value = this.getAttributeValue(valueName);
-                if (Lang.isNull(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
-                } else {
-                    if (value instanceof moment) value = value.format('MM/DD/YYYY');
-                    haveAValue = true;
-                    result += before;
-                    if (Lang.isArray(value)) {
-                        result += value.join(", #");
-                    } else {
-                        result += value;
-                    }
-                    result += after;
-                }
-            } else {
-                value = this.getAttributeValue(valueName);
-                if (Lang.isNull(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
-                    value = '?';
-                } else {
-                    if (value instanceof moment) value = value.format('MM/DD/YYYY');
-                    haveAValue = true;
-                }
-                if (Lang.isArray(value)) {
-                    result += value.join(", #");
-                } else {
-                    result += value;
-                }
-            }
-            last = end + 1;
-            start = structuredPhrase.indexOf("${", last);
-        }
-        if (last < structuredPhrase.length) {
-            result += structuredPhrase.substring(last);
-        }
-        if (!haveAValue) {
-            return this.text;
-        }
-        return result;
+        return createSentenceFromStructuredData(this.metadata["structuredPhrase"], this.getAttributeValue.bind(this), this.getText());
     }
 
     _followPath(object, attributePath, startIndex) {

--- a/src/shortcuts/Placeholder.jsx
+++ b/src/shortcuts/Placeholder.jsx
@@ -82,7 +82,7 @@ class Placeholder {
         return this._entryShortcuts[index].getAttributeValue(name);
     }
 
-    setAttributeValue(name, value, index = 0) {
+    setAttributeValue(name, value, index = 0, source) {
         if (!this._entryShortcuts[index].hasParentContext()) {
             this._entryShortcuts[index].establishParentContext(this._contextManager);
         }
@@ -96,6 +96,7 @@ class Placeholder {
                 parentContextOptions + ".";
         } else {
             this._entryShortcuts[index].setAttributeValue(name, value);
+            this._entryShortcuts[index].setSource(source);
             this._setForceRefresh();
             return null;
         }

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -133,6 +133,14 @@ class Shortcut extends Context {
             }
         }
     }
+
+    setSource(source) {
+        this._source = source;
+    }
+
+    getSource() {
+        return this._source;
+    }
 }
 
 export default Shortcut;

--- a/src/shortcuts/ShortcutUtils.js
+++ b/src/shortcuts/ShortcutUtils.js
@@ -1,0 +1,63 @@
+import Lang from 'lodash';
+import moment from 'moment';
+
+export function createSentenceFromStructuredData(structuredPhraseTemplate, getAttributeValue, textIfNoData) {
+    let last = 0, valueName, value;
+    let start = structuredPhraseTemplate.indexOf("${"), end;
+    let result = "";
+    let haveAValue = false;
+    let isConditional;
+    let conditional, start2, end2, before, after;
+    while (start !== -1) {
+        if (last !== start) {
+            result += structuredPhraseTemplate.substring(last, start);
+        }
+        end = structuredPhraseTemplate.indexOf("}", start + 2);
+        valueName = structuredPhraseTemplate.substring(start + 2, end);
+        isConditional = valueName.startsWith("%");
+        if (isConditional) {
+            end = structuredPhraseTemplate.indexOf("}", end + 1); // adjust end to be 2nd close bracket
+            conditional = structuredPhraseTemplate.substring(start + 3, end);
+            start2 = conditional.indexOf("${");
+            end2 = conditional.indexOf("}", start2 + 2);
+            valueName = conditional.substring(start2 + 2, end2);
+            before = conditional.substring(0, start2);
+            after = conditional.substring(end2 + 1);
+            value = getAttributeValue(valueName);
+            if (Lang.isNull(value) || Lang.isUndefined(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
+            } else {
+                if (value instanceof moment) value = value.format('MM/DD/YYYY');
+                haveAValue = true;
+                result += before;
+                if (Lang.isArray(value)) {
+                    result += value.join(", #");
+                } else {
+                    result += value;
+                }
+                result += after;
+            }
+        } else {
+            value = getAttributeValue(valueName);
+            if (Lang.isNull(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
+                value = '?';
+            } else {
+                if (value instanceof moment) value = value.format('MM/DD/YYYY');
+                haveAValue = true;
+            }
+            if (Lang.isArray(value)) {
+                result += value.join(", #");
+            } else {
+                result += value;
+            }
+        }
+        last = end + 1;
+        start = structuredPhraseTemplate.indexOf("${", last);
+    }
+    if (last < structuredPhraseTemplate.length) {
+        result += structuredPhraseTemplate.substring(last);
+    }
+    if (!haveAValue) {
+        return textIfNoData;
+    }
+    return result;
+}

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -68,7 +68,7 @@
                         {   "title":"Metastasis", "name":"M", "type":"radioButtons", "values": {"category":"staging", "valueSet":"M", "args":"7"} }
                       ]
     },
-    "structuredPhrase": "#staging ${T} ${N} ${M}",
+    "structuredPhrase": "#staging ${T} ${N}${% ${M}}",
     "contextValueObjectEntryTypes": ["http://standardhealthrecord.org/spec/shr/oncology/BreastCancer", "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"],
     "knownParentContexts": "ConditionInserter",
     "description": "The stage of a cancer, assessed according to the standard established by American Joint Committee on Cancer (AJCC). TNM Stage Grouping categorizes the progression of cancer using the Roman Numeral system.",


### PR DESCRIPTION
JIRA 1203. Adds a javascript function at root level for submitting commands to Flux Notes. javascript function can be called from an iOS app or Android app with Flux Notes embedded in a webview.

To test this, open console and insert one of the following commands. Note that the insert structured phrase ones require a note to do much (either in editor or point of care).

Commands are as follows:
flux_command('insert-structured-phrase', {phrase:'toxicity', fields: [{name:'adverseEvent', value: 'nausea'}, {name:'grade', value: 'grade 2'}]})
flux_command('insert-structured-phrase', {phrase:'toxicity', fields: [{name:'adverseEvent', value: 'anemia'}, {name:'grade', value: 'grade 3'},{name:'attribution', value:'Treatment'}]})

flux_command('insert-structured-phrase', {phrase:'disease status', fields: [{name:'status', value: 'Stable'}, {name:'reasons', value: ['Physical exam', 'Symptoms']}]})

flux_command('insert-structured-phrase', {phrase:'enrollment', fields: [{name:'title', value:'PATINA'}]})

flux_command('navigate_targeted_data_panel', {section:'Medications'})
flux_command('navigate_targeted_data_panel', {section:'Timeline'})

Any section in targeted data panel can be navigated to (using short or long name for section).

inserts into open note or point of care
returns error message from flux_command so voice or whatever external app is sending commands knows it was unsuccessful (when result is not null it is a string which is an error message for user) and why and can let user know if appropriate.
Multiple toxicities can be inserted while the other 3 replace any previous values.


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
