### PR TITLE
Cursor jumps to newline bug fix

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -488,14 +488,15 @@ class FluxNotesEditor extends React.Component {
 
     insertStructuredFieldTransform = (transform, shortcut) => {
         if (Lang.isNull(shortcut)) return transform.focus();
-        let result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
-        // console.log("result[0]");
-        // console.log(result[0]);
+        const result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
+
         return result[0];
     }
+
     insertStructuredFieldTransformAtRange = (transform, shortcut, range) => {
         if (Lang.isNull(shortcut)) return transform.focus();
-        let result = this.structuredFieldPlugin.transforms.insertStructuredFieldAtRange(transform, shortcut, range);
+        const result = this.structuredFieldPlugin.transforms.insertStructuredFieldAtRange(transform, shortcut, range);
+
         return result[0];
     }
 

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -308,10 +308,21 @@ function StructuredFieldPlugin(opts) {
  * @return {Slate.Transform}
  */
 function insertStructuredField(opts, transform, shortcut) {
-    return insertStructuredFieldAtRange(opts, transform, shortcut, transform.state.selection)
+    const { state } = transform;
+    if (!state.selection.startKey) return false;
+
+    // Create the structured-field node
+    const sf = createStructuredField(opts, shortcut);
+    shortcut.setKey(sf.key);
+
+    if (sf.kind === 'block') {
+        return [transform.insertBlock(sf), sf.key];
+    } else {
+        return [transform.insertInline(sf), sf.key];
+    }
 }
 
-function insertStructuredFieldAtRange(opts, transform, shortcut, range) { 
+function insertStructuredFieldAtRange(opts, transform, shortcut, range) {
     if (!range.startKey) return false;
 
     // Create the structured-field node
@@ -319,10 +330,10 @@ function insertStructuredFieldAtRange(opts, transform, shortcut, range) {
     shortcut.setKey(sf.key);
 
     if (sf.kind === 'block') {
-		return [transform.insertBlockAtRange(range, sf), sf.key];
-	} else {
-		return [transform.insertInlineAtRange(range, sf), sf.key];
-	}
+        return [transform.insertBlockAtRange(range, sf), sf.key];
+    } else {
+        return [transform.insertInlineAtRange(range, sf), sf.key];
+    }
 }
 
 /**

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -308,6 +308,8 @@ function StructuredFieldPlugin(opts) {
  * @return {Slate.Transform}
  */
 function insertStructuredField(opts, transform, shortcut) {
+    // insertStructuredField originally called insertStructuredFieldAtRange but reverted back to old implementation due to new lines being added
+    // return insertStructuredFieldAtRange(opts, transform, shortcut, transform.state.selection)
     const { state } = transform;
     if (!state.selection.startKey) return false;
 


### PR DESCRIPTION
Addresses JIRA-1283.

- Cursor no longer moves to next line when inserting a structured phrase.
- Reverted changes to `insertStructuredField` in `StructuredFieldPlugin.jsx`.
- NLP shortcut is still calling `insertStructuredFieldAtRange` but `insertStructuredField`(which is called by non-NLP shortcuts) has its own implementation instead of calling `insertStructuredFieldAtRange`.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
