### PR TITLE
breadcumbs no longer display when note is signed

### DIFF
--- a/src/notes/EditorToolbar.jsx
+++ b/src/notes/EditorToolbar.jsx
@@ -132,6 +132,18 @@ class EditorToolbar extends React.Component {
      * Render the toolbar.
      */
     render = () => {
+
+        let breadcrumbs = "";
+
+        if (!this.props.isReadOnly) {
+            breadcrumbs = (
+                <ActiveContextsBreadcrumbs
+                    contextManager={this.props.contextManager}
+                />
+            );
+        }
+
+
         return (
             <div className="menu toolbar-menu">
                 {this.renderMarkButton('bold', 'fa-bold ')}
@@ -140,9 +152,7 @@ class EditorToolbar extends React.Component {
                 {this.renderBlockButton('bulleted-list', 'fa-list')}
                 {this.renderBlockButton('numbered-list', 'fa-list-ol')}
                 <hr className="toolbar-breadcrumbs-separator"/>
-                <ActiveContextsBreadcrumbs
-                    contextManager={this.props.contextManager}
-                />
+                {breadcrumbs}
                 { this.props.loadingTimeWarrantsWarning && this.renderLoadingNotification()}    
                 {/* {this.renderCopyButton()} */}
             </div>


### PR DESCRIPTION
Signed notes no longer have breadcrumbs at the top


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
