### PR TITLE
annotation became an array so dereferenced to first element

### DIFF
--- a/src/model/condition/FluxCondition.js
+++ b/src/model/condition/FluxCondition.js
@@ -251,12 +251,21 @@ class FluxCondition {
 
         return mostRecentLabResultsArray;
     }
+
     /**
      *  function to build HPI Narrative
      *  Starts with initial summary of patient information
      *  Then details chronological history of patient's procedures, medications, and most recent progression
      */
     buildHpiNarrative(patient) {
+        let hpiText = this.buildInitialPatientDiagnosisPreamble(patient);
+
+        hpiText = this.buildEventNarrative(hpiText, patient, this.code);
+
+        return hpiText;
+    }
+
+    buildInitialPatientDiagnosisPreamble(patient) {
         // Initial patient introduction section
         const name = patient.getName();
         const age = patient.getAge();
@@ -264,8 +273,6 @@ class FluxCondition {
 
         let hpiText = `${name} is a ${age} year old ${gender}.`;
         hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
-
-        hpiText = this.buildEventNarrative(hpiText, patient);
 
         return hpiText;
     }

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -65,13 +65,7 @@ class FluxBreastCancer extends FluxCondition {
      *  Then details chronological history of patient's procedures, medications, and most recent progression
      */
     buildHpiNarrative(patient) {
-        // Initial patient introduction section
-        const name = patient.getName();
-        const age = patient.getAge();
-        const gender = patient.getGender();
-
-        let hpiText = `${name} is a ${age} year old ${gender}.`;
-        hpiText += ` Patient was diagnosed with ${this.type} on ${this.diagnosisDate}.`;
+        let hpiText = this.buildInitialPatientDiagnosisPreamble(patient);
         
         // Laterality
         if (this.laterality) {

--- a/src/model/procedure/FluxProcedureRequested.js
+++ b/src/model/procedure/FluxProcedureRequested.js
@@ -68,8 +68,8 @@ class FluxProcedureRequested {
     }
     
     get annotation() {
-        if (this._procedureRequested.annotation) {
-            return this._procedureRequested.annotation.value;
+        if (this._procedureRequested.annotation && this._procedureRequested.annotation.length > 0) {
+            return this._procedureRequested.annotation[0].value;
         } else {
             return null;
         }


### PR DESCRIPTION
Fixed a bug I noticed which was trivial to resolve but important for the pilot. JIRA 1303. Show result annotations for procedures in HPI.

To test, @HPI on pilot1 should show results for the procedures:

 Patient underwent CT of thorax, abdomen and pelvis with contrast on 15 Feb 2016 which revealed 1.6cm mass in stomach.
 Patient underwent Biopsy on 15 Mar 2016 which indicate diagnosis of malignant epithelioid gastrointestinal stromal tumor.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
