### PR TITLE
Made changes to update date labels in note header

### DIFF
--- a/src/dataaccess/HardCodedPatient.json
+++ b/src/dataaccess/HardCodedPatient.json
@@ -393,14 +393,15 @@
         }
     },
     {
-        "date": "20 Dec 2015",
+        "signedOn": "20 Dec 2015",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "signed": true,
         "subject": "Clinical follow-up",
         "content": "@name[[Debra Hernandez672]] is a @age[[49]] year old @gender[[Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
         "EntryId": "4",
         "hospital": "Dana Farber",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith",
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -430,14 +431,15 @@
         }
     },
     {
-        "date": "29 Nov 2012",
+        "signedOn": "29 Nov 2012",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "signed": true,
         "subject": "Consult",
         "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name[[Debra Hernandez672]] has staging values T1 N1 and M0, corresponding to stage IIA.",
         "EntryId": "5",
         "hospital": "Dana Farber",
-        "clinician": "Dr. Zheng",
+        "createdBy": "Dr. Zheng",
+        "signedBy": "Dr. Zheng",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -467,14 +469,15 @@
         }
     },
     {
-        "date": "07 Nov 2012",
+        "signedOn": "07 Nov 2012",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "signed": true,
         "subject": "Clinical post-op",
         "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
         "EntryId": "6",
         "hospital": "Brigham and Women's",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith",
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -504,14 +507,15 @@
         }
     },
     {
-        "date": "03 Oct 2012",
+        "signedOn": "03 Oct 2012",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7d",
         "signed": true,
         "subject": "Clinical follow-up",
         "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name[[Debra Hernandez672]] is enrolled in the clinical trial PATINA on 12/24/2017.",
         "EntryId": "7",
         "hospital": "Dana Farber",
-        "clinician": "Dr. Strauss",
+        "createdBy": "Dr. Strauss",
+        "signedBy": "Dr. Strauss",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },

--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -393,14 +393,15 @@
         }
     },
     {
-        "date": "25 Apr 2016",
+        "signedOn": "25 Apr 2016",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "signed": true,
         "subject": "Experienced pain in breast and felt lump in right breast during self-examination",
         "content": "@name[[Ella Ortiz111]] is a @age[[40]] year old @gender[[Female]] presenting with pain in her right breast. She felt a lump during a self-examination.\nOrdering mammography.",
         "EntryId": "1000",
         "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith", 
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -430,14 +431,15 @@
         }
     },
     {
-        "date": "29 Apr 2016",
+        "signedOn": "29 Apr 2016",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "signed": true,
         "subject": "Mammography",
         "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given mammography.\nshowed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. Order a right targeted spot compression breast ultrasound.",
         "EntryId": "1005",
         "hospital": "Hospital X",
-        "clinician": "Dr. Zheng",
+        "createdBy": "Dr. Zheng", 
+        "signedBy": "Dr. Zheng",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -467,14 +469,15 @@
         }
     },
     {
-        "date": "15 May 2016",
+        "signedOn": "15 May 2016",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "signed": true,
         "subject": "Ultrasound Report",
         "content": "@patient[[Ella Ortiz111 is a 40 year old Female]] given a right targeted spot compression breast ultrasound of a palpable lump. Image revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate",
         "EntryId": "1010",
         "hospital": "Hospital X",
-        "clinician": "Dr. Strauss",
+        "createdBy": "Dr. Strauss", 
+        "signedBy": "Dr. Strauss",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -504,14 +507,15 @@
         }
     },
     {
-        "date": "14 Mar 2018",
+        "signedOn": "14 Mar 2018",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "signed": true,
         "subject": "Treatment Progress",
         "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 42-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\n\nASSESSMENT:\nStop Tamoxifen.",
         "EntryId": "1070",
         "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith",
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -541,14 +545,15 @@
         }
     },
     {
-        "date": "27 Mar 2018",
+        "signedOn": "27 Mar 2018",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "signed": true,
         "subject": "Pre-chemotherapy",
         "content": "REASON FOR VISIT:\nReplace Port-A-Cath\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 42-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\nTamoxifen was stopped September 27, 2017.\n\n\nASSESSMENT:\nA Port-A-Cath was replaced today.\nShe will start induction chemotherapy with trastuzumab and paclitaxel due to low volume of metastatic disease, beginning on October 17, 2017.",
         "EntryId": "1080",
         "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith", 
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },
@@ -578,14 +583,15 @@
         }
     },
     {
-        "date": "17 Jul 2018",
+        "signedOn": "17 Jul 2018",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "signed": true,
         "subject": "Treatment Check-in",
         "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\nMs. Ortiz is a 43-year-old premenopausal Hispanic woman who had an unremarkable mammogram March 3, 2013. She felt a sharp pain in her right breast about 8 months later and a palpable lump two months after that. A diagnostic mammogram on November 13, 2015, showed unremarkable views of the right lower outer quadrant; however only an indeterminate lymph node in the right axilla, 13 mm, was apparent. A right targeted spot compression breast ultrasound of the palpable lump on November 29, 2015 revealed a mass at 7 o’clock measuring 1.6 cm, indeterminate right axillary lymph nodes, measuring 1.4 cm with the cortex of 3 mm - indeterminate, and another measuring 12 mm with cortex of 4 mm - indeterminate.\nShe underwent right breast mass core biopsy and right axillary lymph node core biopsy on November 29, 2015 which revealed infiltrating poorly differentiated ductal carcinoma, grade 3, estrogen receptor 0, progesterone receptor weakly positive 1% to 4%, HER2 was negative 0%, and Ki-67 ranged 85% to 95%. Right axillary lymph node was negative for malignancy. Stage IA T1c N0 M0 disease. BRCA1/2 testing was negative.\nIn preparation for treatment, a Port-A-Cath was placed on January 13, 2015. TTE done on January 15, 2015 showed normal systolic function, with ejection fraction 60-65% and trace mitral regurgitation.\n\nShe underwent neoadjuvant cyclophosphamide (ddAC) followed by paclitaxel (T) from January 20, 2015 to May 23, 2016. Paclitaxel was dose reduced to 60mg/m2 for the last 2 cycles and stopped after 11 doses due to Grade 3 neuropathy.  She received 11 of 12 planned doses.\n\nShe underwent right lumpectomy with Dr. Ford on June 12, 2016. Pathology report on June 16, 2016 showed no residual disease, 0/2 SLNs, pathological complete response pCR, stage pT0N0.\n\nShe completed adjuvant radiation therapy with Dr. Bruno from August 18, 2016 to September 29, 2016.\n\nShe started Tamoxifen October 6, 2016.\n\nA bilateral 3D mammogram on December 15, 2016 showed benign findings.\nHer annual gynecologic exam with her PCP on April 6, 2017 was unremarkable.\n\nDue to her history of mammographically occult disease, she underwent a surveillance breast MRI with contrast on September 10, 2017, revealing stable post-treatment changes of the right breast, no abnormality of the left breast, and enhancement of of two internal mammary lymph nodes of the right breast, measuring 1.5 cm by 1.0 cm and 1.8 cm by 1.0 cm.\n\nCT of the chest with contrast September 20, 2017 revealed four indeterminate pulmonary nodules, 4 to 5 mm in diameter, in the right lung and postsurgical changes in the right breast and axilla. CT of the abdomen and pelvis with contrast on September 20, 2017 revealed two hypodensities in the left lobe of the liver that were consistent with benign cysts. A bone scan September 28, 2017 was negative for skeletal metastases.\n\nCytologic examination of a biopsy specimen of an enlarged internal mammary lymph node of the right breast, obtained September 20, 2017 on CT-guided fine-needle aspiration, revealed tumor cells that histologically resembled cells from the patient’s prior breast cancer. The hormone receptor status of these metastatic cells was ER-negative, PR-positive, and HER2-positive.\n\nTamoxifen was stopped September 27, 2017.\n\nA Port-A-Cath was replaced on October 10, 2017.\nShe underwent induction chemotherapy with trastuzumab and paclitaxel due to low volume of metastatic disease, beginning on October 17, 2017.\n\nASSESSMENT:\nAlthough her #disease status is #stable #as of #1/30/2018, recommending to halt after 5 cycles due to #toxicity #Grade 3 #myalgia and #toxicity #Grade 3 #peripheral motor neuropathy attributed to paclitaxel.",
         "EntryId": "1085",
         "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith", 
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -6064,14 +6064,15 @@
         
     },
     {
-        "date": "17 Jul 2018",
+        "signedOn": "17 Jul 2018",
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "signed": true,
         "subject": "Treatment Check-in",
         "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with @condition[[Gastrointestinal stromal tumor]]. He was feeling sharp pains in his stomach. A @procedure[[CT scan]] showed a mass in his stomach measuring 1.6 cm.\nA @procedure[[biopsy]] was performed identifying malignant epithelioid gastrointestinal stromal tumor. @procedure[[Surgery]] was performed on 7 Apr 2016 by Dr. Ford which resulted in a complete resection. Stage IA pT1N0 disease with mitotic count score of 1. KIT testing was positive, PDGFRA testing was negative.\n\nPt began taking Imatinib (one 400mg tablet per day) on May 15, 2016 as adjuvant therapy, which will continue for one year after surgery.\n\nASSESSMENT:\nAlthough his #disease status is #stable #as of #2/28/2018, he is experiencing #toxicity #Grade 2 #Stomach pain and #toxicity #Grade 2 #Rash maculo-papular.",
         "EntryId": "1085",
         "hospital": "Hospital X",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith", 
+        "signedBy": "Dr. Smith",
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
         },

--- a/src/model/core/FluxClinicalNote.js
+++ b/src/model/core/FluxClinicalNote.js
@@ -20,10 +20,11 @@ class FluxClinicalNote {
         this._entryInfo.lastUpdated.instant = today;
         this._entryInfo.personOfRecord = new PersonOfRecord();
         this._entryInfo.personOfRecord.value = json['PersonOfRecord'];
-        if (json.date) this._date = json.date;
+        if (json.signedOn) this._signedOn = json.signedOn;
         if (json.subject) this._subject = json.subject;
         if (json.hospital) this._hospital = json.hospital;
-        if (json.clinician) this._clinician = json.clinician;
+        if (json.createdBy) this._createdBy = json.createdBy;
+        if (json.signedBy) this._signedBy = json.signedBy;
         // Ensures even empty strings result in content definition
         if (json.content || json.content === "") this._content = json.content;
         if (!Lang.isUndefined(json.signed)) this._signed = json.signed;
@@ -42,12 +43,20 @@ class FluxClinicalNote {
         this._entryInfo = entryVal;
     }
     
-    get date() {
-        return this._date;
+    get signedOn() {
+        return this._signedOn;
     }
 
-    set date(val) {
-        this._date = val;
+    set signedOn(val) {
+        this._signedOn = val;
+    }
+
+    get signedBy() {
+        return this._signedBy;
+    }
+
+    set signedBy(val) {
+        this._signedBy = val;
     }
 
     get subject() {
@@ -66,12 +75,12 @@ class FluxClinicalNote {
         this._hospital = val;
     }
 
-    get clinician() {
-        return this._clinician;
+    get createdBy() {
+        return this._createdBy;
     }
 
-    set clinician(val) {
-        this._clinician = val;
+    set createdBy(val) {
+        this._createdBy = val;
     }
 
     get content() {
@@ -96,10 +105,10 @@ class FluxClinicalNote {
         clinicalNoteJSON.EntryId = this.entryInfo.entryId;
         clinicalNoteJSON.EntryType = this.entryInfo.entryType;
         clinicalNoteJSON.PersonOfRecord = this.entryInfo.personOfRecord;
-        clinicalNoteJSON.date = this.date;
+        clinicalNoteJSON.signedOn = this.signedOn;
         clinicalNoteJSON.subject = this.subject;
         clinicalNoteJSON.hospital = this.hospital;
-        clinicalNoteJSON.clinician = this.clinician;
+        clinicalNoteJSON.createdBy = this.createdBy;
         clinicalNoteJSON.content = this.content;
         clinicalNoteJSON.CreationTime = this.entryInfo.creationTime;
         clinicalNoteJSON.LastUpdated = this.entryInfo.lastUpdated;

--- a/src/model/core/FluxClinicalNote.js
+++ b/src/model/core/FluxClinicalNote.js
@@ -25,6 +25,7 @@ class FluxClinicalNote {
         if (json.hospital) this._hospital = json.hospital;
         if (json.createdBy) this._createdBy = json.createdBy;
         if (json.signedBy) this._signedBy = json.signedBy;
+        if (json.CreationTime) this._entryInfo.creationTime = json.CreationTime;
         // Ensures even empty strings result in content definition
         if (json.content || json.content === "") this._content = json.content;
         if (!Lang.isUndefined(json.signed)) this._signed = json.signed;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1272,6 +1272,8 @@ class FluxNotesEditor extends React.Component {
         // Preset note header information
         let noteTitle = "New Note";
         let date = Moment(new Date()).format('DD MMM YYYY');
+        let authorString = "";
+        let dateString = "";
         let signedString = "not signed";
         let source = "Dana Farber";
         let signed = false;
@@ -1285,8 +1287,12 @@ class FluxNotesEditor extends React.Component {
             if(this.props.selectedNote.signed) {
                 signed = true;
                 signedString = this.props.selectedNote.clinician;
+                authorString = "Signed by: ";
+                dateString = "Signed date: "
             } else {
                 signedString = "not signed";
+                authorString = "Created by: ";
+                dateString = "Created date: ";
             }
         }
 
@@ -1302,11 +1308,11 @@ class FluxNotesEditor extends React.Component {
                             </Row>
                             <Row >
                                 <Col xs={7}>
-                                    <p className="note-description-detail"><span className="note-description-detail-name">Signed By: </span><span className="note-description-detail-value">{signedString}</span></p>
+                                    <p className="note-description-detail"><span className="note-description-detail-name">{authorString}</span><span className="note-description-detail-value">{signedString}</span></p>
                                     <p className="note-description-detail"><span className="note-description-detail-name">Source: </span><span className="note-description-detail-value">{source}</span></p>
                                 </Col>
                                 <Col xs={5}>
-                                    <p className="note-description-detail"><span className="note-description-detail-name">Signed Date: </span><span className="note-description-detail-value">{date}</span></p>
+                                    <p className="note-description-detail"><span className="note-description-detail-name">{dateString}</span><span className="note-description-detail-value">{date}</span></p>
                                 </Col>
                             </Row>
                         </Col>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Slate from '../lib/slate';
-import Moment from 'moment'
 import Lang from 'lodash';
 import FontAwesome from 'react-fontawesome';
 import ContextPortal from '../context/ContextPortal';
@@ -1271,26 +1270,27 @@ class FluxNotesEditor extends React.Component {
     renderNoteDescriptionContent = () => { 
         // Preset note header information
         let noteTitle = "New Note";
-        let date = Moment(new Date()).format('DD MMM YYYY');
+        let date;
         let authorString = "";
         let dateString = "";
-        let signedString = "not signed";
+        let clinicianName;
         let source = "Dana Farber";
         let signed = false;
 
         // If a note is selected, update the note header with information from the selected note
         if (this.props.selectedNote) {
             noteTitle = this.props.selectedNote.subject;
-            date = this.props.selectedNote.date;
             source = this.props.selectedNote.hospital;
 
             if(this.props.selectedNote.signed) {
                 signed = true;
-                signedString = this.props.selectedNote.clinician;
+                date = this.props.selectedNote.signedOn;
+                clinicianName = this.props.selectedNote.signedBy;
                 authorString = "Signed by: ";
                 dateString = "Signed date: "
             } else {
-                signedString = "not signed";
+                date = this.props.selectedNote.entryInfo.creationTime.value;
+                clinicianName = this.props.selectedNote.createdBy;
                 authorString = "Created by: ";
                 dateString = "Created date: ";
             }
@@ -1308,7 +1308,7 @@ class FluxNotesEditor extends React.Component {
                             </Row>
                             <Row >
                                 <Col xs={7}>
-                                    <p className="note-description-detail"><span className="note-description-detail-name">{authorString}</span><span className="note-description-detail-value">{signedString}</span></p>
+                                    <p className="note-description-detail"><span className="note-description-detail-name">{authorString}</span><span className="note-description-detail-value">{clinicianName}</span></p>
                                     <p className="note-description-detail"><span className="note-description-detail-name">Source: </span><span className="note-description-detail-value">{source}</span></p>
                                 </Col>
                                 <Col xs={5}>

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -65,10 +65,25 @@ export default class NoteAssistant extends Component {
         }
     }
 
-    // Sorts the lab results in chronological order with the most recent first (so that it shows up first in the clinical notes list)
+    // Sorts the notes in chronological order with the most recent first (so that it shows up first in the clinical notes list)
     notesTimeSorter(a, b) {
-        const a_startTime = new moment(a.date, "D MMM YYYY");
-        const b_startTime = new moment(b.date, "D MMM YYYY");
+        let a_date;
+        let b_date;
+
+        if (Lang.isUndefined(a.signedOn) || Lang.isNull(a.signedOn)) {
+            a_date = a.entryInfo.creationTime.value;
+        } else {
+            a_date = a.signedOn;
+        }
+
+        if (Lang.isUndefined(b.signedOn) || Lang.isNull(b.signedOn)) {
+            b_date = b.entryInfo.creationTime.value;
+        } else {
+            b_date = b.signedOn;
+        }
+
+        const a_startTime = new moment(a_date, "D MMM YYYY");
+        const b_startTime = new moment(b_date, "D MMM YYYY");
         if (a_startTime > b_startTime) {
             return -1;
         }
@@ -318,7 +333,7 @@ export default class NoteAssistant extends Component {
                 this.openNote(true, note)
             }}>
                 <div className="in-progress-text">In progress note</div>
-                <div className="existing-note-date">{note.date}</div>
+                <div className="existing-note-date">{note.entryInfo.creationTime.value}</div>
                 <div className="existing-note-subject">{note.subject}</div>
                 {this.renderMetaDataText(note, 30)}
             </div>
@@ -385,7 +400,7 @@ export default class NoteAssistant extends Component {
             <div className={`note existing-note${selected ? " selected" : ""}`} key={i} onClick={() => {
                 this.openNote(false, item)
             }}>
-                <div className="existing-note-date">{item.date}</div>
+                <div className="existing-note-date">{item.signedOn}</div>
                 <div className="existing-note-subject">{item.subject}</div>
 
                 {this.renderMetaDataText(item)}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -195,7 +195,7 @@ export default class NotesPanel extends Component {
     // Create and open a blank note
     openNewNote = () => {
         // Create info to be set for new note
-        const date = new moment().format("D MMM YYYY");
+        const signedOn = new moment().format("D MMM YYYY");
         const hospital = "Dana Farber";
         const clinician = this.props.loginUser;
         const subject = `${clinician}-${new moment().format("YYYYDDMM-hhmm")}`;
@@ -203,7 +203,7 @@ export default class NotesPanel extends Component {
         const signed = false;
 
         // Add new unsigned note to patient record
-        const currentlyEditingEntryId = this.props.patient.addClinicalNote(date, subject, hospital, clinician, content, signed);
+        const currentlyEditingEntryId = this.props.patient.addClinicalNote(signedOn, subject, hospital, clinician, null, content, signed);
 
         const newNote = this.props.patient.getNotes().find(function (curNote) {
             return Lang.isEqual(curNote.entryInfo.entryId, currentlyEditingEntryId);
@@ -265,6 +265,7 @@ export default class NotesPanel extends Component {
         // Set signed attribute on the selected note to be true
         const tempNote = this.state.selectedNote;
         tempNote.signed = true;
+        tempNote.signedBy = this.props.loginUser;
         this.setState({selectedNote: tempNote});
         let inProg = this.props.patient.getInProgressNotes();
         inProg.forEach((a) => {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -427,15 +427,16 @@ class PatientRecord {
     }
 
     // Add initial unsigned note to patient record
-    addClinicalNote(date, subject, hospital, clinician, content, signed) {
+    addClinicalNote(signedOn, subject, hospital, createdBy, signedBy, content, signed) {
 
         // Generate the clinical note json from passed in values
         let clinicalNote = new FluxClinicalNote(
             {
-                "date": date,
+                "signedOn": signedOn,
                 "subject": subject,
                 "hospital": hospital,
-                "clinician": clinician,
+                "createdBy": createdBy,
+                "signedBy": signedBy,
                 "content": content,
                 "signed": signed
             }

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -30,7 +30,8 @@ class PatientSearch extends React.Component {
         const newSuggestion = this.createNewSuggestion(inputValue, note);
         const regex = this.createRegexForSearching(inputValue)
         const relevantNoteMetadata = (
-            note.date + ' ' +
+            note.signedOn + ' ' + 
+            note.entryInfo.creationTime.value + ' ' +
             note.subject + ' ' +
             note.hospital
         ).toLowerCase();
@@ -39,7 +40,14 @@ class PatientSearch extends React.Component {
         if(metadataMatches) {
             // Determine what we matched with -- track that in suggestions metadata.
             let matchedMetaData; 
-            if (note.date && note.date.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) {
+            let date;
+            if (note.signedOn) {
+                date = note.signedOn;
+            } else {
+                date = note.entryInfo.creationTime.value;
+            }
+
+            if (date && date.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) {
                 matchedMetaData = "date";
             } else if (note.subject && note.subject.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) {
                 matchedMetaData = "subject";
@@ -58,8 +66,14 @@ class PatientSearch extends React.Component {
 
     // basic template for creating a newSuggestion
     createNewSuggestion = (inputValue, note) => { 
+        let date;
+        if (note.signedOn) {
+            date = note.signedOn;
+        } else {
+            date = note.entryInfo.creationTime.value;
+        }
         return { 
-            date: note.date,
+            date: date,
             subject: note.subject,
             hospital: note.hospital,
             inputValue: inputValue,

--- a/test/TestPatient.json
+++ b/test/TestPatient.json
@@ -410,10 +410,10 @@
                 "EntryId": "1"
             }
         },
-        "date": "02 AUG 2015",
+        "signedOn": "02 AUG 2015",
         "subject": "Clinical follow-up",
         "hospital": "Dana Farber",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith", "signedBy": "Dr. Smith",
         "content": "@name[[Debra Hernandez672]] is a @age[[49]] year old @gender[[Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nDisease #disease status #Stable based on #Pathology and #Symptoms #as of #08/02/2015.",
         "CreationTime": {
             "EntryType": {
@@ -447,10 +447,11 @@
                 "EntryId": "1"
             }
         },
-        "date": "12 JUL 2012",
+        "signedOn": "12 JUL 2012",
         "subject": "Consult",
         "hospital": "Dana Farber",
-        "clinician": "Dr. Zheng",
+        "createdBy": "Dr. Zheng", 
+        "signedBy": "Dr. Zheng",
         "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nPathology report indicates @name[[Debra Hernandez672]] has staging values T1 N1 and M0, corresponding to stage IIA.",
         "CreationTime": {
             "EntryType": {
@@ -484,10 +485,11 @@
                 "EntryId": "1"
             }
         },
-        "date": "20 JUN 2012",
+        "signedOn": "20 JUN 2012",
         "subject": "Clinical post-op",
         "hospital": "Brigham and Women's",
-        "clinician": "Dr. Smith",
+        "createdBy": "Dr. Smith", 
+        "signedBy": "Dr. Smith",
         "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\nToxicity Grade 4 Anemia related to Treatment",
         "CreationTime": {
             "EntryType": {
@@ -521,10 +523,11 @@
                 "EntryId": "1"
             }
         },
-        "date": "16 MAY 2012",
+        "signedOn": "16 MAY 2012",
         "subject": "Clinical follow-up",
         "hospital": "Dana Farber",
-        "clinician": "Dr. Strauss",
+        "createdBy": "Dr. Strauss", 
+        "signedBy": "Dr. Strauss",
         "content": "@patient[[Debra Hernandez672 is a 46 year old Female]] presenting with @condition[[Invasive ductal carcinoma of breast]].\n@name[[Debra Hernandez672]] is enrolled in the clinical trial PATINA on 12/24/2017.",
         "CreationTime": {
             "EntryType": {


### PR DESCRIPTION
This PR addresses jira 1300. Following the latest mockups, when a note is in progress, the note header displays "created by" and "created date". When a note is signed, the note header displays "signed by" and "signed date"

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- N/A Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- N/A Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added Enzyme-UI tests for slim mode 
- N/A Added Enzyme-UI tests for full mode
- N/A Added backend tests for new functionality added
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
