### PR TITLE
finished new edit-title button

### DIFF
--- a/public/icons/angled-pencil.svg
+++ b/public/icons/angled-pencil.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="17px" height="16px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+    <title>angled pencil</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" opacity="0.6">
+        <g id="7" transform="translate(-533.000000, -403.000000)" fill="#969696" fill-rule="nonzero">
+            <g id="angled-pencil" transform="translate(533.000000, 403.000000)">
+                <rect id="Rectangle" x="1" y="15" width="16" height="1"></rect>
+                <g id="Group-2" transform="translate(7.000000, 8.500000) rotate(51.000000) translate(-7.000000, -8.500000) translate(-1.000000, 6.000000)">
+                    <rect id="Rectangle-5" x="0" y="0.185028843" width="12" height="4.12132034"></rect>
+                    <polygon id="Path-2" points="13 0.185028843 13 4.30634919 15.8955395 2.24568901"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1248,7 +1248,7 @@ class FluxNotesEditor extends React.Component {
             noteTag = <p className="note-name" id="note-title">{noteTitle}</p>;
         } else {
             noteTag = (
-                <p className="note-name" id="note-title">
+                <p className="note-name" id="note-title" onClick={this.enableNoteNameEditing}>
                     { this.editNoteTitleButton() }
                     {noteTitle}
                 </p>);
@@ -1355,7 +1355,7 @@ class FluxNotesEditor extends React.Component {
 
     editNoteTitleButton = () => { 
         return ( 
-            <svg width="15px" height="15px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn" onClick={this.enableNoteNameEditing}>
+            <svg width="15px" height="15px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn">
                 <title>Click to edit note title</title>
                 <defs></defs>
                 <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" opacity="0.6">

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1247,7 +1247,13 @@ class FluxNotesEditor extends React.Component {
         if (signed) {
             noteTag = <p className="note-name" id="note-title">{noteTitle}</p>;
         } else {
-            noteTag = <p className="note-name" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
+            // noteTag = <p className="note-name" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
+            noteTag = (
+                <p className="note-name" id="note-title">
+                    {/* <FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} /> */}
+                    { this.EditNoteTitleButton() }
+                    {noteTitle}
+                </p>);
         }
         if (this.state.isEditingNoteName) {
             return (
@@ -1347,6 +1353,26 @@ class FluxNotesEditor extends React.Component {
                 </div>
             );
         }
+    }
+
+    EditNoteTitleButton = () => { 
+        return ( 
+            <svg width="17px" height="16px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn" onClick={this.enableNoteNameEditing}>
+                <title>Edit title</title>
+                <defs></defs>
+                <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" opacity="0.6">
+                    <g id="7" transform="translate(-533.000000, -403.000000)" fill="#969696" fill-rule="nonzero">
+                        <g id="angled-pencil" transform="translate(533.000000, 403.000000)">
+                            <rect id="Rectangle" x="1" y="15" width="16" height="1"></rect>
+                            <g id="Group-2" transform="translate(7.000000, 8.500000) rotate(51.000000) translate(-7.000000, -8.500000) translate(-1.000000, 6.000000)">
+                                <rect id="Rectangle-5" x="0" y="0.185028843" width="12" height="4.12132034"></rect>
+                                <polygon id="Path-2" points="13 0.185028843 13 4.30634919 15.8955395 2.24568901"></polygon>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </svg>
+        )
     }
     
     render = () => {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1357,7 +1357,7 @@ class FluxNotesEditor extends React.Component {
 
     EditNoteTitleButton = () => { 
         return ( 
-            <svg width="17px" height="16px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn" onClick={this.enableNoteNameEditing}>
+            <svg width="15px" height="15px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn" onClick={this.enableNoteNameEditing}>
                 <title>Click to edit note title</title>
                 <defs></defs>
                 <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" opacity="0.6">

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1307,7 +1307,7 @@ class FluxNotesEditor extends React.Component {
         } else {
             return (
                 <div id="note-description">
-                    <Row>
+                    <Row start="xs">
                         <Col xs={9}>
                             <Row>
                             {this.renderNoteNameEditor(noteTitle, signed)}
@@ -1358,10 +1358,10 @@ class FluxNotesEditor extends React.Component {
     EditNoteTitleButton = () => { 
         return ( 
             <svg width="17px" height="16px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn" onClick={this.enableNoteNameEditing}>
-                <title>Edit title</title>
+                <title>Click to edit note title</title>
                 <defs></defs>
-                <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" opacity="0.6">
-                    <g id="7" transform="translate(-533.000000, -403.000000)" fill="#969696" fill-rule="nonzero">
+                <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" opacity="0.6">
+                    <g id="7" transform="translate(-533.000000, -403.000000)" fill="#969696" fillRule="nonzero">
                         <g id="angled-pencil" transform="translate(533.000000, 403.000000)">
                             <rect id="Rectangle" x="1" y="15" width="16" height="1"></rect>
                             <g id="Group-2" transform="translate(7.000000, 8.500000) rotate(51.000000) translate(-7.000000, -8.500000) translate(-1.000000, 6.000000)">

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1247,11 +1247,9 @@ class FluxNotesEditor extends React.Component {
         if (signed) {
             noteTag = <p className="note-name" id="note-title">{noteTitle}</p>;
         } else {
-            // noteTag = <p className="note-name" id="note-title"><FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} />&nbsp;{noteTitle}</p>;
             noteTag = (
                 <p className="note-name" id="note-title">
-                    {/* <FontAwesome id="edit-note-name-btn" name="pencil" onClick={this.enableNoteNameEditing} /> */}
-                    { this.EditNoteTitleButton() }
+                    { this.editNoteTitleButton() }
                     {noteTitle}
                 </p>);
         }
@@ -1355,7 +1353,7 @@ class FluxNotesEditor extends React.Component {
         }
     }
 
-    EditNoteTitleButton = () => { 
+    editNoteTitleButton = () => { 
         return ( 
             <svg width="15px" height="15px" viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" id="edit-note-name-btn" onClick={this.enableNoteNameEditing}>
                 <title>Click to edit note title</title>
@@ -1372,7 +1370,7 @@ class FluxNotesEditor extends React.Component {
                     </g>
                 </g>
             </svg>
-        )
+        );
     }
     
     render = () => {

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -32,8 +32,8 @@
             font-weight: bold;
             
             #edit-note-name-btn {
-                margin-left: -23px;
-                margin-right: 3px;
+                margin-left: -20px;
+                margin-right: 5px;
                 &:hover {
                     cursor: pointer;
                 }

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -2,6 +2,7 @@
 
 #clinical-notes {
     padding-left:25px;
+    align-self: flex-start;
     #note-description {
         .note-description-detail {
             margin: 0;

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -1,6 +1,7 @@
 @import '../styles/variables';
 
 #clinical-notes {
+    padding-left:25px;
     #note-description {
         .note-description-detail {
             margin: 0;
@@ -24,12 +25,17 @@
         p.note-name {
             text-align: left;
             padding-top:0;
-            font-size: .8rem;
-            margin: 0px 0px 0px 10px;
+            font-size: 0.8rem;
+            margin: 0px;
+            padding-left: 0.5rem;
             font-weight: bold;
             
-            #edit-note-name-btn:hover {
-                cursor: pointer;
+            #edit-note-name-btn {
+                margin-left: -23px;
+                margin-right: 3px;
+                &:hover {
+                    cursor: pointer;
+                }
             }
             
         }

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -30,14 +30,13 @@
             margin: 0px;
             padding-left: 0.5rem;
             font-weight: bold;
-            display: flex;
-            align-items: baseline;
             &:hover {
                 cursor: pointer;
             }
             #edit-note-name-btn {
                 margin-left: -20px;
                 margin-right: 5px;
+                margin-bottom: -1px;
             }
             
         }

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -30,13 +30,12 @@
             margin: 0px;
             padding-left: 0.5rem;
             font-weight: bold;
-            
+            &:hover {
+                cursor: pointer;
+            }
             #edit-note-name-btn {
                 margin-left: -20px;
                 margin-right: 5px;
-                &:hover {
-                    cursor: pointer;
-                }
             }
             
         }

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -30,6 +30,8 @@
             margin: 0px;
             padding-left: 0.5rem;
             font-weight: bold;
+            display: flex;
+            align-items: baseline;
             &:hover {
                 cursor: pointer;
             }


### PR DESCRIPTION
Modified the edit-note-button stylign to reflect the mockups. This not only included modifying the actual icon to match the mockups, but also modifying the alignment s.t. the icon-button is in the left gutter of the note panel, visually separating it from the text of the note description. 

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added Enzyme-UI tests for slim mode 
- **N/A** Added Enzyme-UI tests for full mode
- **N/A** Added backend tests for new functionality added
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
