### PR TITLE
"@active medications" (and "@all medications") display startDate when inserted

### DIFF
--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -508,9 +508,6 @@ class PatientRecord {
         attributeList = attributeList.map((listItem) => {
             return listItem.split(".");
         });
-        // Start date to trail the text
-        let startDatePath = "expectedPerformanceTime.timePeriodStart";
-        startDatePath = startDatePath.split('.');
 
         const lastMedicationIndex = meds.length - 1;
         const lastAttributeIndex = attributeList.length - 1;
@@ -522,9 +519,6 @@ class PatientRecord {
                 // If there are more attributes, separate them with a space
                 if (attrIndex < lastAttributeIndex) strResult += " ";
             });
-            // Add startTime to the end of the string
-            strResult += " started on "
-            strResult += this._getValueUsingPath(item, startDatePath)
             // If there are more medications, separate with newline/carriage returns
             if (itemIndex < lastMedicationIndex) {
                 strResult += "\r\n";

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -49,6 +49,14 @@ class PatientRecord {
         }
     }
 
+    _getValueUsingPath(item, attributePath) {
+        let result = item, i;
+        for (i = 0; i < attributePath.length; i++) {
+            result = result[attributePath[i]];
+        }
+        return result;
+    }
+
     _calculateNextEntryId() {
         this.nextEntryId = Math.max.apply(Math, this.entries.map(function (o) {
             return o.entryInfo.entryId;
@@ -493,6 +501,38 @@ class PatientRecord {
         return this.getEntriesOfType(FluxMedicationRequested);
     }
 
+    getMedicationsAsText() { 
+        const meds = this.getMedications();
+        let attributeList =  ["medication", "amountPerDose.value", "amountPerDose.units", "timingOfDoses.value", "timingOfDoses.units"];
+        
+        attributeList = attributeList.map((listItem) => {
+            return listItem.split(".");
+        });
+        let startDatePath = "expectedPerformanceTime.timePeriodStart";
+        startDatePath = startDatePath.split('.');
+
+        const numMedications = meds.length - 1;
+        const numAttributes = attributeList.length - 1;
+        let strResult = "";
+        meds.forEach((item, itemIndex) => {
+            console.log("---item")
+            console.log(item)
+            attributeList.forEach((itemKey, attrIndex) => {
+                let nextSubstring = this._getValueUsingPath(item, itemKey);
+                if (!Lang.isUndefined(nextSubstring) && !Lang.isNull(nextSubstring)) strResult += nextSubstring;
+                if (attrIndex < numAttributes) strResult += " ";
+            });
+            // Add startTime to the 
+            strResult += " started on "
+            strResult += this._getValueUsingPath(item, startDatePath)
+            if (itemIndex < numMedications) {
+                strResult += "\r\n";
+            }
+        });
+        
+        return strResult
+    }
+
     getMedicationsChronologicalOrder() {
         let list = this.getMedications();
         list.sort(this._medsTimeSorter);
@@ -522,6 +562,38 @@ class PatientRecord {
 
             return med.isActiveAsOf(today) && !stopMedicationFound;
         });
+    }
+
+    getActiveMedicationsAsText() { 
+        const activeMeds = this.getActiveMedications(); 
+        let attributeList =  ["medication", "amountPerDose.value", "amountPerDose.units", "timingOfDoses.value", "timingOfDoses.units"];
+        
+        attributeList = attributeList.map((listItem) => {
+            return listItem.split(".");
+        });
+        let startDatePath = "expectedPerformanceTime.timePeriodStart";
+        startDatePath = startDatePath.split('.');
+
+        const numMedications = activeMeds.length - 1;
+        const numAttributes = attributeList.length - 1;
+        let strResult = "";
+        activeMeds.forEach((item, itemIndex) => {
+            console.log("---item")
+            console.log(item)
+            attributeList.forEach((itemKey, attrIndex) => {
+                let nextSubstring = this._getValueUsingPath(item, itemKey);
+                if (!Lang.isUndefined(nextSubstring) && !Lang.isNull(nextSubstring)) strResult += nextSubstring;
+                if (attrIndex < numAttributes) strResult += " ";
+            });
+            // Add startTime to the 
+            strResult += " started on "
+            strResult += this._getValueUsingPath(item, startDatePath)
+            if (itemIndex < numMedications) {
+                strResult += "\r\n";
+            }
+        });
+        
+        return strResult
     }
 
     getActiveAndRecentlyStoppedMedications() {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -503,29 +503,30 @@ class PatientRecord {
 
     getMedicationsAsText() { 
         const meds = this.getMedications();
+        // Basic attributes to be listed in order
         let attributeList =  ["medication", "amountPerDose.value", "amountPerDose.units", "timingOfDoses.value", "timingOfDoses.units"];
-        
         attributeList = attributeList.map((listItem) => {
             return listItem.split(".");
         });
+        // Start date to trail the text
         let startDatePath = "expectedPerformanceTime.timePeriodStart";
         startDatePath = startDatePath.split('.');
 
-        const numMedications = meds.length - 1;
-        const numAttributes = attributeList.length - 1;
+        const lastMedicationIndex = meds.length - 1;
+        const lastAttributeIndex = attributeList.length - 1;
         let strResult = "";
         meds.forEach((item, itemIndex) => {
-            console.log("---item")
-            console.log(item)
             attributeList.forEach((itemKey, attrIndex) => {
                 let nextSubstring = this._getValueUsingPath(item, itemKey);
                 if (!Lang.isUndefined(nextSubstring) && !Lang.isNull(nextSubstring)) strResult += nextSubstring;
-                if (attrIndex < numAttributes) strResult += " ";
+                // If there are more attributes, separate them with a space
+                if (attrIndex < lastAttributeIndex) strResult += " ";
             });
-            // Add startTime to the 
+            // Add startTime to the end of the string
             strResult += " started on "
             strResult += this._getValueUsingPath(item, startDatePath)
-            if (itemIndex < numMedications) {
+            // If there are more medications, separate with newline/carriage returns
+            if (itemIndex < lastMedicationIndex) {
                 strResult += "\r\n";
             }
         });
@@ -566,29 +567,31 @@ class PatientRecord {
 
     getActiveMedicationsAsText() { 
         const activeMeds = this.getActiveMedications(); 
+
+        // Basic attributes to be listed in order
         let attributeList =  ["medication", "amountPerDose.value", "amountPerDose.units", "timingOfDoses.value", "timingOfDoses.units"];
-        
         attributeList = attributeList.map((listItem) => {
             return listItem.split(".");
         });
+        // Start date to trail the text
         let startDatePath = "expectedPerformanceTime.timePeriodStart";
         startDatePath = startDatePath.split('.');
-
-        const numMedications = activeMeds.length - 1;
-        const numAttributes = attributeList.length - 1;
+        
+        const lastMedicationIndex = activeMeds.length - 1;
+        const lastAttributeIndex = attributeList.length - 1;
         let strResult = "";
         activeMeds.forEach((item, itemIndex) => {
-            console.log("---item")
-            console.log(item)
             attributeList.forEach((itemKey, attrIndex) => {
                 let nextSubstring = this._getValueUsingPath(item, itemKey);
                 if (!Lang.isUndefined(nextSubstring) && !Lang.isNull(nextSubstring)) strResult += nextSubstring;
-                if (attrIndex < numAttributes) strResult += " ";
+                // If there are more attributes, separate them with a space
+                if (attrIndex < lastAttributeIndex) strResult += " ";
             });
-            // Add startTime to the 
+            // Add startTime to the end of the string
             strResult += " started on "
             strResult += this._getValueUsingPath(item, startDatePath)
-            if (itemIndex < numMedications) {
+            // If there are more medications, separate with newline/carriage returns
+            if (itemIndex < lastMedicationIndex) {
                 strResult += "\r\n";
             }
         });

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -99,26 +99,31 @@ export default class InsertValue extends Shortcut {
                             date: item[dateLabel]
                         };
                     });
-                } else {
-                    let listItems = callSpec["listItems"];
-                    listItems = listItems.map((listItem) => {
-                        return listItem.split(".");
-                    });
-                    const numMedications = result.length - 1;
-                    const numListItems = listItems.length - 1;
-                    let strResult = "";
-                    result.forEach((item, itemIndex) => {
-                        listItems.forEach((itemKey, attrIndex) => {
-                            let nextSubstring = this._getValueUsingPath(item, itemKey);
-                            if (!Lang.isUndefined(nextSubstring) && !Lang.isNull(nextSubstring)) strResult += nextSubstring;
-                            if (attrIndex < numListItems) strResult += " ";
-                        });
-                        if (itemIndex < numMedications) {
-                            strResult += "\r\n";
-                        }
-                    });
-                    result = strResult;
-                }
+                } 
+                // NOTE: We left this in in case we needed to add the listItems functionality back into shortcuts.json
+                // At the time of commenting we had modified the only instances of this 'getData' format from Shortcuts.json, @all medications' and '@active medications'
+                // else {
+                //     let listItems = callSpec["listItems"];
+                //     listItems = listItems.map((listItem) => {
+                //         return listItem.split(".");
+                //     });
+                //     const numMedications = result.length - 1;
+                //     const numListItems = listItems.length - 1;
+                //     let strResult = "";
+                //     result.forEach((item, itemIndex) => {
+                //         console.log("---item")
+                //         console.log(item)
+                //         listItems.forEach((itemKey, attrIndex) => {
+                //             let nextSubstring = this._getValueUsingPath(item, itemKey);
+                //             if (!Lang.isUndefined(nextSubstring) && !Lang.isNull(nextSubstring)) strResult += nextSubstring;
+                //             if (attrIndex < numListItems) strResult += " ";
+                //         });
+                //         if (itemIndex < numMedications) {
+                //             strResult += "\r\n";
+                //         }
+                //     });
+                //     result = strResult;
+                // }
             }
             return result;
         } else if (callObject === "parent") {

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -405,14 +405,14 @@
   },
   { "type": "InsertValue",
     "id": "AllMedicationsInserter",
-    "getData": {"object": "patient", "method": "getMedications", "listItems": ["medication", "amountPerDose.value", "amountPerDose.units", "timingOfDoses.value", "timingOfDoses.units"]},
+    "getData": {"object": "patient", "method": "getMedicationsAsText"},
     "isContext": false,
     "stringTriggers": [{"name":"@all medications", "description": "Insert a summary of patient medications"}],
     "knownParentContexts": "Patient"
   },
   { "type": "InsertValue",
     "id": "ActiveMedicationsInserter",
-    "getData": {"object": "patient", "method": "getActiveMedications", "listItems": ["medication", "amountPerDose.value", "amountPerDose.units", "timingOfDoses.value", "timingOfDoses.units"]},
+    "getData": {"object": "patient", "method": "getActiveMedicationsAsText"},
     "isContext": false,
     "stringTriggers": [{"name":"@active medications", "description": "Insert a summary of the active (currently being taken) patient medications"}],
     "knownParentContexts": "Patient"


### PR DESCRIPTION
Updated both active medications and all medications to display the startDate of the medication when inserted into a note. 


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- **N/A** This pull request describes why these changes were made
- **N/A** Recognizes any potential shortcomings/bugs in the description 
- **N/A** Cheat sheet is updated
- **N/A** Demo script is updated 
- **N/A** Documentation on Wiki has been updated 
- **N/A** Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- **N/A** Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added Enzyme-UI tests for slim mode 
- **N/A** Added Enzyme-UI tests for full mode
- **N/A** Added backend tests for new functionality added
- **N/A** Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
