### PR TITLE
added next button and multiple select wording

### DIFF
--- a/src/notes/FillPlaceholder.css
+++ b/src/notes/FillPlaceholder.css
@@ -75,3 +75,21 @@
 .divider {
     width: 100%;
 }
+
+.multi-select {
+    font-size: 12px;
+}
+
+.attribute-title {
+    text-align: center;
+}
+
+.poc-next-item-btn {
+    float: right;
+    line-height: 2.1rem;
+    text-transform: none;
+    background-color: white !important;
+    padding-top: 20px; }
+    .poc-next-item-btn:hover {
+      background-color: #E6E6E6 !important;    
+}

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -220,7 +220,7 @@ export default class FillPlaceholder extends Component {
             return <ButtonSetFillFieldForPlaceholder attributeSpec={attributeSpec} value={value} updateValue={this.onSetValue.bind(this, "click/touch", attributeSpec, entryIndex)} />;
         }
         if (attributeSpec.type === 'checkboxes') {
-            return <MultiButtonSetFillFieldForPlaceholder attributeSpec={attributeSpec} value={value} updateValue={this.onSetValue.bind(this, "click/touch", attributeSpec, entryIndex)} nextField={expanded ? null : this.nextField.bind(this, entryIndex)} />;
+            return <MultiButtonSetFillFieldForPlaceholder attributeSpec={attributeSpec} value={value} updateValue={this.onSetValue.bind(this, "click/touch", attributeSpec, entryIndex)} />;
         }
         if (attributeSpec.type === 'searchableList') {
             return <SearchableListForPlaceholder attributeSpec={attributeSpec} backgroundColor={backgroundColor} value={value} updateValue={this.onSetValue.bind(this, "click/touch", attributeSpec, entryIndex)} />;
@@ -262,6 +262,28 @@ export default class FillPlaceholder extends Component {
         const { done, expanded } = this.state;
         const { placeholder } = this.props;
         let currentFieldRowInSummary = '';
+        let multiSelect = "";
+        let nextButton = "";
+
+        if (attribute.type === 'checkboxes') {
+            multiSelect = 
+                <span className = "multi-select"> (select multiple) </span>
+            nextButton =
+            <Grid item xs={2}>
+                <Button
+                    raised
+                    classes={{
+                        root:"poc-next-item-btn"
+                    }}
+                    onClick={expanded ? null : this.nextField.bind(this, entryIndex)}
+                >
+                    <span>
+                        Next
+                    </span>
+                </Button>
+            </Grid>
+
+        }
 
         const value = placeholder.getAttributeValue(attribute.name, entryIndex);
         if (expanded || !done) {
@@ -269,17 +291,20 @@ export default class FillPlaceholder extends Component {
                 <Grid container key={attribute.name}>
                     <Grid item xs={1} />
                     <Grid item xs={2} style={{ display: 'flex', alignItems: 'center' }}>
-                        <span>
-                            {attribute.title}
+                        <span className = "attribute-title">
+                            {attribute.title} <br/>
+                            {multiSelect}
                         </span>
                     </Grid>
-                    <Grid item xs={9}>
+                    <Grid item xs={7}>
                         <span>
                             {this.createFillFieldForPlaceholder(attribute, value, entryIndex)}
                         </span>
                     </Grid>
+                    {nextButton}
                 </Grid>
             );
+
         }
 
         return currentFieldRowInSummary;

--- a/src/notes/fillFieldComponents/MultiButtonSetFillFieldForPlaceholder.jsx
+++ b/src/notes/fillFieldComponents/MultiButtonSetFillFieldForPlaceholder.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import Lang from 'lodash';
-import ChevronRightIcon from 'material-ui-icons/ChevronRight';
 import ValueSetManager from '../../lib/ValueSetManager';
 import MultiChoiceButton from '../../forms/MultiChoiceButton';
 
@@ -35,10 +34,7 @@ class MultiButtonSetFillFieldForPlaceholder extends Component {
     };
 
     render() {
-        let nextButton = "";
-        if (this.props.nextField) {
-            nextButton = <ChevronRightIcon onClick={this.props.nextField} />;
-        }
+
         return (
             <div>
                 <div className="btn-group-status-progression">
@@ -47,7 +43,6 @@ class MultiButtonSetFillFieldForPlaceholder extends Component {
                             return this.renderButtonGroup(option, i)
                         })
                     }
-                    {nextButton}
                 </div>
             </div>
         );


### PR DESCRIPTION
Reference invo design. This PR adds a next button when you can select multiple in POC and also adds wording to let the user know that you can select multiple. Best way to test is to select disease status in POC view and look at the rationale where you can select multiple.


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
