### PR TITLE
Template redesign

### DIFF
--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -176,7 +176,7 @@ class ContextManager {
     }
 
     // Clears all non active contexts from this.contexts
-    // Only used after picking options from template modal
+    // Only used after picking options from template
     // When choosing options, many unncessary contexts get added
     clearNonActiveContexts() {
         this.contexts = this.contexts.filter((context) => {

--- a/src/context/TemplateViewModeContent.jsx
+++ b/src/context/TemplateViewModeContent.jsx
@@ -8,7 +8,7 @@ export default class TemplateViewModeContent extends Component {
     templates = [
         { name: 'progress note', content: 'REASON FOR VISIT:\n@reason for next visit @condition\n\nHISTORY OF PRESENT ILLNESS:\n@HPI\n\nREVIEW OF SYSTEMS:\n\nALLERGIES:\n@ALLERGIES\n\nMEDICATIONS:\n@active medications\n\nPHYSICAL EXAM:\n\nASSESSMENT:\n\nPLAN:\n\n' },
         { name: 'op note', content: 'op note' },
-        { name: 'follow-up', content: 'FOLLOW UP:\nPatient is showing signs of @condition @condition\n\nMEDICATIONS:\n@medication\n\nProcedures:\n@procedure' },
+        { name: 'follow-up', content: 'FOLLOW UP:\nPatient is showing signs of @condition @HPI @condition @HPI\n\nMEDICATIONS:\n@medication\n\nProcedures:\n@procedure' },
         { name: 'consult note', content: '@patient presenting with ' }
     ];
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1338,7 +1338,7 @@ class FluxNotesEditor extends React.Component {
                             <Row>
                             {this.renderNoteNameEditor(noteTitle, signed)}
                             </Row>
-                            <Row >
+                            <Row>
                                 <Col xs={7}>
                                     <p className="note-description-detail"><span className="note-description-detail-name">{authorString}</span><span className="note-description-detail-value">{clinicianName}</span></p>
                                     <p className="note-description-detail"><span className="note-description-detail-name">Source: </span><span className="note-description-detail-value">{source}</span></p>
@@ -1349,29 +1349,27 @@ class FluxNotesEditor extends React.Component {
                             </Row>
                         </Col>
                         <Col xs={3}>
-                            {!this.props.inModal &&
-                                <Button
-                                    raised 
-                                    className="close-note-btn"
-                                    disabled={this.context_disabled}
-                                    onClick={this.closeNote}
+                            <Button
+                                raised
+                                className="close-note-btn"
+                                disabled={this.props.noteAssistantMode === 'pick-list-options-panel' || this.context_disabled}
+                                onClick={this.closeNote}
+                                style={{
+                                    float: "right",
+                                    lineHeight: "2.1rem"
+                                }}
+                            >
+                                <FontAwesome
+                                    name="times"
                                     style={{
-                                        float: "right",
-                                        lineHeight: "2.1rem"
+                                        color: "red",
+                                        marginRight: "5px"
                                     }}
-                                >
-                                    <FontAwesome 
-                                        name="times"
-                                        style={{
-                                            color: "red",
-                                            marginRight: "5px"
-                                        }}
-                                    /> 
-                                    <span>
-                                        Close
-                                    </span>
-                                </Button>
-                            }
+                                />
+                                <span>
+                                    Close
+                                </span>
+                            </Button>
                         </Col>
                     </Row>
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -520,9 +520,23 @@ class FluxNotesEditor extends React.Component {
     }
 
     closeNote = () => {
-        const documentText = this.getNoteText(this.state.state);
-        this.props.saveNote(documentText)
-        this.props.closeNote();
+        if (this.props.noteAssistantMode === 'pick-list-options-panel') {
+            this.closeNoteWithTemplate();
+        } else {
+            const documentText = this.getNoteText(this.state.state);
+            this.props.saveNote(documentText)
+            this.props.closeNote();
+        }
+    }
+
+    closeNoteWithTemplate = () => {
+        this.setState({ state: this.previousState }, () => {
+            this.props.setUndoTemplateInsertion(false);
+            this.refs.editor.focus();
+            const documentText = this.getNoteText(this.state.state);
+            this.props.saveNote(documentText)
+            this.props.closeNote();
+        });
     }
 
     onFocus = () => {
@@ -644,10 +658,7 @@ class FluxNotesEditor extends React.Component {
 
         // If the user clicks cancel button, change editor state back to what it was before they clicked the template
         if (nextProps.shouldRevertTemplate) {
-            this.setState({ state: this.previousState }, () => {
-                this.props.setUndoTemplateInsertion(false);
-                this.refs.editor.focus();
-            });
+            this.revertTemplate();
         }
 
         // Update pick list selection in real time during template insertion
@@ -725,6 +736,13 @@ class FluxNotesEditor extends React.Component {
             this.props.contextManager.clearNonActiveContexts();
             this.props.setNoteViewerEditable(true);
         }
+    }
+
+    revertTemplate = () => {
+        this.setState({ state: this.previousState }, () => {
+            this.props.setUndoTemplateInsertion(false);
+            this.refs.editor.focus();
+        });
     }
 
     insertNewLine = (transform) => {
@@ -1366,7 +1384,7 @@ class FluxNotesEditor extends React.Component {
                             <Button
                                 raised
                                 className="close-note-btn"
-                                disabled={this.props.noteAssistantMode === 'pick-list-options-panel' || this.context_disabled}
+                                disabled={this.context_disabled}
                                 onClick={this.closeNote}
                                 style={{
                                     float: "right",

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -521,22 +521,15 @@ class FluxNotesEditor extends React.Component {
 
     closeNote = () => {
         if (this.props.noteAssistantMode === 'pick-list-options-panel') {
-            this.closeNoteWithTemplate();
+            const documentText = this.getNoteText(this.previousState);
+            this.revertTemplate();
+            this.props.saveNote(documentText)
+            this.props.closeNote();
         } else {
             const documentText = this.getNoteText(this.state.state);
             this.props.saveNote(documentText)
             this.props.closeNote();
         }
-    }
-
-    closeNoteWithTemplate = () => {
-        this.setState({ state: this.previousState }, () => {
-            this.props.setUndoTemplateInsertion(false);
-            this.refs.editor.focus();
-            const documentText = this.getNoteText(this.state.state);
-            this.props.saveNote(documentText)
-            this.props.closeNote();
-        });
     }
 
     onFocus = () => {
@@ -713,6 +706,9 @@ class FluxNotesEditor extends React.Component {
 
        // Check if the updatedEditorNote property has been updated
         if (nextProps.shouldEditorContentUpdate && this.props.updatedEditorNote !== nextProps.updatedEditorNote && !Lang.isNull(nextProps.updatedEditorNote)) {
+            if (this.props.noteAssistantMode === 'pick-list-options-panel') {
+                this.revertTemplate();
+            }
 
             // If the updated editor note is an empty string, then add a new blank note. Call method to
             // re initialize editor state and reset updatedEditorNote state in parent to be null

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -666,11 +666,6 @@ class FluxNotesEditor extends React.Component {
             this.previousState = this.state.state;
         }
 
-        // If the user clicks cancel button, change editor state back to what it was before they clicked the template
-        if (nextProps.shouldRevertTemplate) {
-            this.revertTemplate();
-        }
-
         // Update pick list selection in real time during template insertion
         if (this.props.noteAssistantMode === 'pick-list-options-panel') {
             if (nextProps.shouldHighlightShortcut) {
@@ -758,6 +753,10 @@ class FluxNotesEditor extends React.Component {
             this.adjustActiveContexts(this.state.state.selection, this.state.state); 
             this.props.contextManager.clearNonActiveContexts();
             this.props.setNoteViewerEditable(true);
+             // If the user clicks cancel button, change editor state back to what it was before they clicked the template
+            if (nextProps.shouldRevertTemplate) {
+                this.revertTemplate();
+            }
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -703,6 +703,8 @@ class FluxNotesEditor extends React.Component {
                             // Force shortcut to re-render with updated data
                             transform = this.resetShortcutData(shortcut, transform);
                             let state = transform.apply();
+                            let node = state.document.getParent(shortcut.getKey());
+                            Slate.findDOMNode(node).scrollIntoView();
                             this.setState({ state });
                         }
                     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -647,8 +647,14 @@ class FluxNotesEditor extends React.Component {
                         shortcut.setText(picklist.selectedOption);
                         if (shortcut.isContext()) {
                             shortcut.setValueObject(object);
-                            this.props.setNoteViewerEditable(this.state.shouldUpdateTemplateShortcuts);
-                            this.setState({ shouldUpdateTemplateShortcuts: !this.state.shouldUpdateTemplateShortcuts });
+                            const key = shortcut.getKey();
+                            let transform = this.state.state.transform();
+                            let state = transform.setNodeByKey(key, {
+                                data: {
+                                    shortcut
+                                }
+                            }).apply();
+                            this.setState({ state });
                         }
                     }
                 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -632,6 +632,16 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
+    resetShortcutData = (shortcut, transform) => {
+        const key = shortcut.getKey();
+        transform = transform.setNodeByKey(key, {
+            data: {
+                shortcut
+            }
+        });
+        return transform;
+    }
+
     // When the editor in the modal first is triggered, insert the contextTrayItem when it mounts.
     componentDidMount = () => {
         if (this.props.inModal) {
@@ -682,21 +692,12 @@ class FluxNotesEditor extends React.Component {
                                 // Set the text, then change the data of the shortcut to trigger a re-render.
                                 const text = childShortcut.determineText(this.contextManager);
                                 childShortcut.setText(text);
-                                const key = childShortcut.getKey();
-                                transform = transform.setNodeByKey(key, {
-                                    data: {
-                                        shortcut: childShortcut
-                                    }
-                                });
+                                transform = this.resetShortcutData(childShortcut, transform);
                             });
 
                             // Force shortcut to re-render with updated data
-                            const key = shortcut.getKey();
-                            let state = transform.setNodeByKey(key, {
-                                data: {
-                                    shortcut
-                                }
-                            }).apply();
+                            transform = this.resetShortcutData(shortcut, transform);
+                            let state = transform.apply();
                             this.setState({ state });
                         }
                     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -761,6 +761,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     revertTemplate = () => {
+        this.props.highlightShortcut(null, false, null);
         this.setState({ state: this.previousState }, () => {
             this.props.setUndoTemplateInsertion(false);
             this.refs.editor.focus();

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -624,7 +624,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     updateTemplateWithPickListOptions = (nextProps) => {
-        if (nextProps.shouldHighlightShortcut) {
+        if (nextProps.shouldUpdateShortcutType) {
             let transform = this.state.state.transform();
             let state = transform.setNodeByKey(nextProps.shortcutKey, nextProps.shortcutType).apply();
             this.setState({ state });
@@ -744,7 +744,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     revertTemplate = () => {
-        this.props.highlightShortcut(null, false, null);
+        this.props.changeShortcutType(null, false, null);
         this.setState({ state: this.previousState }, () => {
             this.props.setUndoTemplateInsertion(false);
             this.refs.editor.focus();

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -635,16 +635,9 @@ class FluxNotesEditor extends React.Component {
         return transform;
     }
 
-    // When the editor in the modal first is triggered, insert the contextTrayItem when it mounts.
-    componentDidMount = () => {
-        if (this.props.inModal) {
-            this.insertContextTrayItem(this.props.contextTrayItemToInsert);
-        }
-    }
-
     // This gets called before the component receives new properties
     componentWillReceiveProps = (nextProps) => {
-        // Only update text if the shouldEditorContentUpdate is true. For example, this will be false in the main editor if the modal is also open.
+        // Only update text if the shouldEditorContentUpdate is true. For example, this will be false if the user is inserting a template
 
         // Check if the item to be inserted is updated
         if (nextProps.shouldEditorContentUpdate && this.props.summaryItemToInsert !== nextProps.summaryItemToInsert && nextProps.summaryItemToInsert.length > 0) {
@@ -1479,7 +1472,6 @@ class FluxNotesEditor extends React.Component {
         }
 
         const callback = {}
-        let editorClassName = this.props.inModal ? 'editor-content-modal' : 'editor-content';
         /**
          * Render the editor, toolbar, dropdown and description for note
          */
@@ -1487,19 +1479,17 @@ class FluxNotesEditor extends React.Component {
             <div id="clinical-notes" className="dashboard-panel">
                 {this.renderNoteDescriptionContent()}
                 <div className="MyEditor-root" onClick={(event) => { this.refs.editor.focus(); }}>
-                    { !this.props.inModal &&
-                        <EditorToolbar
-                            contextManager={this.props.contextManager}
-                            isReadOnly={!this.props.isNoteViewerEditable}
-                            loadingTimeWarrantsWarning={this.state.loadingTimeWarrantsWarning}
-                            onBlockCheck={this.handleBlockCheck}
-                            onBlockUpdate={this.handleBlockUpdate}
-                            onMarkCheck={this.handleMarkCheck}
-                            onMarkUpdate={this.handleMarkUpdate}
-                            patient={this.props.patient}
-                        />
-                    }
-                    <div className={editorClassName}>
+                    <EditorToolbar
+                        contextManager={this.props.contextManager}
+                        isReadOnly={!this.props.isNoteViewerEditable}
+                        loadingTimeWarrantsWarning={this.state.loadingTimeWarrantsWarning}
+                        onBlockCheck={this.handleBlockCheck}
+                        onBlockUpdate={this.handleBlockUpdate}
+                        onMarkCheck={this.handleMarkCheck}
+                        onMarkUpdate={this.handleMarkUpdate}
+                        patient={this.props.patient}
+                    />
+                    <div className='editor-content'>
                         <Slate.Editor
                             className="editor-panel"
                             placeholder={'Enter your clinical note here or choose a template to start from...'}
@@ -1565,7 +1555,6 @@ FluxNotesEditor.propTypes = {
     errors: PropTypes.array.isRequired,
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
-    inModal: PropTypes.bool.isRequired,
     itemInserted: PropTypes.func.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     noteAssistantMode: PropTypes.string.isRequired,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1070,15 +1070,8 @@ class FluxNotesEditor extends React.Component {
             this.props.setNoteViewerEditable(false);
             // Switch note assistant view to the pick list options panel
             this.props.updateNoteAssistantMode('pick-list-options-panel');
-            if (this.props.inModal) {
-                this.resetEditorState();
-                this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false, "Selection from pick list (modal)");
-            }
-        } else if (this.props.noteAssistantMode === 'pick-list-options-panel') {
-            if (this.props.inModal) {
-                this.resetEditorState();
-                this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false, "Template");
-            }
+            // Insert content by default
+            this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false, "Template");
         } else { // If the text to be inserted does not contain any pick lists, insert the text
             this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, true, "Shortcuts in Context");
             this.props.updateContextTrayItemToInsert(null);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -673,6 +673,11 @@ class FluxNotesEditor extends React.Component {
 
         // Update pick list selection in real time during template insertion
         if (this.props.noteAssistantMode === 'pick-list-options-panel') {
+            if (nextProps.shouldHighlightShortcut) {
+                let transform = this.state.state.transform();
+                let state = transform.setNodeByKey(nextProps.shortcutKey, nextProps.shortcutType).apply();
+                this.setState({ state });
+            }
             nextProps.selectedPickListOptions.forEach(picklist => {
                 if (picklist.selectedOption) {
                     const { shortcut } = picklist;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1038,7 +1038,7 @@ class FluxNotesEditor extends React.Component {
         let pickListCount = 0;
 
         if (!Lang.isNull(triggers)) {
-            triggers.forEach((trigger, i) => {
+            triggers.forEach((trigger) => {
 
                 start = remainder.indexOf(trigger.trigger);
                 if (start > 0) {
@@ -1134,7 +1134,7 @@ class FluxNotesEditor extends React.Component {
                     {
                         'trigger': pickList.trigger,
                         'options': shortcutOptions,
-                        shortcut: tempShortcut
+                        'shortcut': tempShortcut
                     }
                 )
             });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -980,6 +980,7 @@ class FluxNotesEditor extends React.Component {
         }
 
         const triggers = this.noteParser.getListOfTriggersFromText(textToBeInserted)[0];
+        let pickListCount = 0;
 
         if (!Lang.isNull(triggers)) {
             triggers.forEach((trigger, i) => {
@@ -1017,8 +1018,9 @@ class FluxNotesEditor extends React.Component {
                     after = "";
                 }
 
-                if (arrayOfPickLists) {
-                    transform = this.insertExistingShortcut(arrayOfPickLists[i].shortcut, transform);
+                if (arrayOfPickLists && this.noteParser.isPickList(trigger)) {
+                    transform = this.insertExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform);
+                    pickListCount++;
                 } else {
                     transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, shouldPortalOpen, source);
                 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -222,6 +222,7 @@ class FluxNotesEditor extends React.Component {
             isFetchingAsyncData: false,
             loadingTimeWarrantsWarning: false,
             fetchTimeout: null,
+            shouldUpdateTemplateShortcuts: true
         };
     }
 
@@ -642,9 +643,13 @@ class FluxNotesEditor extends React.Component {
                     const { object } = shortcut.getValueSelectionOptions().find(opt => {
                         return opt.context === picklist.selectedOption;
                     });
-                    shortcut.setText(picklist.selectedOption);
-                    if (shortcut.isContext()) {
-                        shortcut.setValueObject(object);
+                    if (shortcut.getText() !== picklist.selectedOption) {
+                        shortcut.setText(picklist.selectedOption);
+                        if (shortcut.isContext()) {
+                            shortcut.setValueObject(object);
+                            this.props.setNoteViewerEditable(this.state.shouldUpdateTemplateShortcuts);
+                            this.setState({ shouldUpdateTemplateShortcuts: !this.state.shouldUpdateTemplateShortcuts });
+                        }
                     }
                 }
             });
@@ -691,18 +696,11 @@ class FluxNotesEditor extends React.Component {
         }
 
         // Check if mode is changing from 'pick-list-options-panel' to 'context-tray'
-        // This means user either clicked the OK or Cancel button on the modal
+        // This means user either clicked the OK or Cancel button on the pick list options panel
         if (this.props.noteAssistantMode === 'pick-list-options-panel' && nextProps.noteAssistantMode === 'context-tray') {
             this.adjustActiveContexts(this.state.state.selection, this.state.state); 
             this.props.contextManager.clearNonActiveContexts();
-            // User clicked cancel button
-            if (nextProps.contextTrayItemToInsert === null) {
-                this.props.setNoteViewerEditable(true);   
-            } else { // User clicked OK button so insert text
-                this.insertTextWithStructuredPhrases(this.props.contextTrayItemToInsert, undefined, true, true, "pick list/template");
-                this.props.updateContextTrayItemToInsert(null);
-                this.props.setNoteViewerEditable(true);
-            }
+            this.props.setNoteViewerEditable(true);
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -636,7 +636,14 @@ class FluxNotesEditor extends React.Component {
         }
         nextProps.selectedPickListOptions.forEach(picklist => {
             if (picklist.selectedOption) {
-                picklist.shortcut.setText(picklist.selectedOption)
+                const { shortcut } = picklist;
+                const { object } = shortcut.getValueSelectionOptions().find(opt => {
+                    return opt.context === picklist.selectedOption;
+                });
+                shortcut.setText(picklist.selectedOption);
+                if (shortcut.isContext()) {
+                    shortcut.setValueObject(object);
+                }
             }
         });
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -691,9 +691,13 @@ class FluxNotesEditor extends React.Component {
                             // Force shortcut to re-render with updated data
                             transform = this.resetShortcutData(shortcut, transform);
                             let state = transform.apply();
-                            let node = state.document.getParent(shortcut.getKey());
-                            Slate.findDOMNode(node).scrollIntoView();
-                            this.setState({ state });
+                            this.setState({ state }, () => {
+                                const node = state.document.getParent(shortcut.getKey());
+                                const el = Slate.findDOMNode(node);
+                                if (el && el.scrollIntoView) {
+                                    el.scrollIntoView();
+                                }
+                            });
                         }
                     }
                 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -740,6 +740,10 @@ class FluxNotesEditor extends React.Component {
             if (nextProps.shouldRevertTemplate) {
                 this.revertTemplate();
             }
+            const anchorEl = Slate.findDOMNode(this.state.state.anchorBlock);
+            if (anchorEl && anchorEl.scrollIntoView) {
+                anchorEl.scrollIntoView();
+            }
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -329,7 +329,7 @@ class FluxNotesEditor extends React.Component {
         return this.insertPlaceholder(suggestion.value, transformBeforeInsert).apply();
     }
 
-    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, shouldPortalOpen = true, source) => {
+    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, source) => {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
@@ -405,18 +405,7 @@ class FluxNotesEditor extends React.Component {
         return this.lastPosition;
     }
 
-    openPortalToSelectValueForShortcut(shortcut, needToDelete, transform, shouldPortalOpen = true) {
-        // If the portal should not open, insert the plain text trigger instead. Will eventually be replaced.
-        if (!shouldPortalOpen) {
-            this.setState({
-                openedPortal: null,
-                needToDelete: needToDelete,
-            });
-            this.selectingForShortcut = null;
-            this.insertPlainText(transform, shortcut.initiatingTrigger);
-            return transform.blur();
-        }
-        
+    openPortalToSelectValueForShortcut(shortcut, needToDelete, transform) {
         let portalOptions = shortcut.getValueSelectionOptions();
 
         this.setState({
@@ -561,7 +550,7 @@ class FluxNotesEditor extends React.Component {
             focusOffset: data.focusOffset
         }).delete()
 
-        this.insertTextWithStructuredPhrases(data.newText, nextState, true, true, "dictation");
+        this.insertTextWithStructuredPhrases(data.newText, nextState, true, "dictation");
     }
 
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
@@ -641,7 +630,7 @@ class FluxNotesEditor extends React.Component {
         // Check if the item to be inserted is updated
         if (nextProps.shouldEditorContentUpdate && this.props.summaryItemToInsert !== nextProps.summaryItemToInsert && nextProps.summaryItemToInsert.length > 0) {
             if (this.props.isNoteViewerEditable) {
-                this.insertTextWithStructuredPhrases(nextProps.summaryItemToInsert, undefined, true, true, nextProps.summaryItemToInsertSource);
+                this.insertTextWithStructuredPhrases(nextProps.summaryItemToInsert, undefined, true, nextProps.summaryItemToInsertSource);
                 this.props.itemInserted();
             }
         }
@@ -717,9 +706,7 @@ class FluxNotesEditor extends React.Component {
             else {
 
                 this.resetEditorAndContext();
-
-                let shouldPortalOpen = this.props.noteAssistantMode !== 'pick-list-options-panel';
-                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content, undefined, false, shouldPortalOpen, "loaded note");
+                this.insertTextWithStructuredPhrases(nextProps.updatedEditorNote.content, undefined, false, "loaded note");
 
                 // If the note is in progress, set isNoteViewerEditable to true. If the note is an existing note, set isNoteViewerEditable to false
                 if (nextProps.updatedEditorNote.signed) {
@@ -1030,7 +1017,7 @@ class FluxNotesEditor extends React.Component {
     /*
      * Handle updates when we have a new insert text with structured phrase
      */
-    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true, shouldPortalOpen = true, source, arrayOfPickLists) => {
+    insertTextWithStructuredPhrases = (textToBeInserted, currentTransform = undefined, updatePatient = true, source, arrayOfPickLists) => {
         const currentState = this.state.state;
 
         let transform = (currentTransform) ? currentTransform : currentState.transform();
@@ -1086,7 +1073,7 @@ class FluxNotesEditor extends React.Component {
                     transform = this.updateExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform);
                     pickListCount++;
                 } else {
-                    transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, shouldPortalOpen, source);
+                    transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, source);
                 }
             });
         }
@@ -1153,9 +1140,9 @@ class FluxNotesEditor extends React.Component {
             // Switch note assistant view to the pick list options panel
             this.props.updateNoteAssistantMode('pick-list-options-panel');
             // Insert content by default
-            this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, false, "Picklist", localArrayOfPickListsWithOptions);
+            this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, "Picklist", localArrayOfPickListsWithOptions);
         } else { // If the text to be inserted does not contain any pick lists, insert the text
-            this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, true, "Shortcuts in Context");
+            this.insertTextWithStructuredPhrases(contextTrayItem, undefined, true, "Shortcuts in Context");
             this.props.updateContextTrayItemToInsert(null);
             this.props.updateNoteAssistantMode('context-tray');
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -343,7 +343,6 @@ class FluxNotesEditor extends React.Component {
         return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
     }
 
-    // TODO: explain
     updateExistingShortcut = (shortcut, transform = undefined) => {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
@@ -523,11 +522,11 @@ class FluxNotesEditor extends React.Component {
         if (this.props.noteAssistantMode === 'pick-list-options-panel') {
             const documentText = this.getNoteText(this.previousState);
             this.revertTemplate();
-            this.props.saveNote(documentText)
+            this.props.saveNote(documentText);
             this.props.closeNote();
         } else {
             const documentText = this.getNoteText(this.state.state);
-            this.props.saveNote(documentText)
+            this.props.saveNote(documentText);
             this.props.closeNote();
         }
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1538,6 +1538,8 @@ class FluxNotesEditor extends React.Component {
 }
 
 FluxNotesEditor.propTypes = {
+    arrayOfPickLists: PropTypes.array.isRequired,
+    changeShortcutType: PropTypes.func.isRequired,
     closeNote: PropTypes.func.isRequired,
     contextManager: PropTypes.object.isRequired,
     contextTrayItemToInsert: PropTypes.string,
@@ -1551,11 +1553,17 @@ FluxNotesEditor.propTypes = {
     patient: PropTypes.object.isRequired,
     saveNote: PropTypes.func.isRequired,
     selectedNote: PropTypes.object,
+    selectedPickListOptions: PropTypes.array.isRequired,
     setForceRefresh: PropTypes.func,
     setLayout: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,
+    setUndoTemplateInsertion: PropTypes.func.isRequired,
+    shortcutKey: PropTypes.string,
     shortcutManager: PropTypes.object.isRequired,
+    shortcutType: PropTypes.string,
     shouldEditorContentUpdate: PropTypes.bool.isRequired,
+    shouldUpdateShortcutType: PropTypes.bool.isRequired,
+    shouldRevertTemplate: PropTypes.bool.isRequired,
     structuredFieldMapManager: PropTypes.object.isRequired,
     summaryItemToInsert: PropTypes.string.isRequired,
     updatedEditorNote: PropTypes.object,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -674,9 +674,24 @@ class FluxNotesEditor extends React.Component {
                         if (shortcut.isContext()) {
                             shortcut.setValueObject(object);
 
+                            let transform = this.state.state.transform();
+
+                            // Update the children of the shortcut whose values just got selected.
+                            const childShortcuts = shortcut.getChildren();
+                            childShortcuts.forEach(childShortcut => {
+                                // Set the text, then change the data of the shortcut to trigger a re-render.
+                                const text = childShortcut.determineText(this.contextManager);
+                                childShortcut.setText(text);
+                                const key = childShortcut.getKey();
+                                transform = transform.setNodeByKey(key, {
+                                    data: {
+                                        shortcut: childShortcut
+                                    }
+                                });
+                            });
+
                             // Force shortcut to re-render with updated data
                             const key = shortcut.getKey();
-                            let transform = this.state.state.transform();
                             let state = transform.setNodeByKey(key, {
                                 data: {
                                     shortcut

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -636,6 +636,7 @@ class FluxNotesEditor extends React.Component {
             }
         }
 
+        // Update pick list selection in real time during template insertion
         if (this.props.noteAssistantMode === 'pick-list-options-panel') {
             nextProps.selectedPickListOptions.forEach(picklist => {
                 if (picklist.selectedOption) {
@@ -647,6 +648,8 @@ class FluxNotesEditor extends React.Component {
                         shortcut.setText(picklist.selectedOption);
                         if (shortcut.isContext()) {
                             shortcut.setValueObject(object);
+
+                            // Force shortcut to re-render with updated data
                             const key = shortcut.getKey();
                             let transform = this.state.state.transform();
                             let state = transform.setNodeByKey(key, {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -623,10 +623,19 @@ class FluxNotesEditor extends React.Component {
         return transform;
     }
 
+    scrollToShortcut = (document, shortcutKey) => {
+        const node = document.getParent(shortcutKey);
+        const el = Slate.findDOMNode(node);
+        if (el && el.scrollIntoView) {
+            el.scrollIntoView();
+        }
+    }
+
     updateTemplateWithPickListOptions = (nextProps) => {
         if (nextProps.shouldUpdateShortcutType) {
             let transform = this.state.state.transform();
             let state = transform.setNodeByKey(nextProps.shortcutKey, nextProps.shortcutType).apply();
+            this.scrollToShortcut(state.document, nextProps.shortcutKey);
             this.setState({ state });
         }
         nextProps.selectedPickListOptions.forEach(picklist => {
@@ -655,11 +664,7 @@ class FluxNotesEditor extends React.Component {
                         transform = this.resetShortcutData(shortcut, transform);
                         let state = transform.apply();
                         this.setState({ state }, () => {
-                            const node = state.document.getParent(shortcut.getKey());
-                            const el = Slate.findDOMNode(node);
-                            if (el && el.scrollIntoView) {
-                                el.scrollIntoView();
-                            }
+                            this.scrollToShortcut(state.document, shortcut.getKey());
                         });
                     }
                 }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -634,18 +634,21 @@ class FluxNotesEditor extends React.Component {
                 this.props.itemInserted();
             }
         }
-        nextProps.selectedPickListOptions.forEach(picklist => {
-            if (picklist.selectedOption) {
-                const { shortcut } = picklist;
-                const { object } = shortcut.getValueSelectionOptions().find(opt => {
-                    return opt.context === picklist.selectedOption;
-                });
-                shortcut.setText(picklist.selectedOption);
-                if (shortcut.isContext()) {
-                    shortcut.setValueObject(object);
+
+        if (this.props.noteAssistantMode === 'pick-list-options-panel') {
+            nextProps.selectedPickListOptions.forEach(picklist => {
+                if (picklist.selectedOption) {
+                    const { shortcut } = picklist;
+                    const { object } = shortcut.getValueSelectionOptions().find(opt => {
+                        return opt.context === picklist.selectedOption;
+                    });
+                    shortcut.setText(picklist.selectedOption);
+                    if (shortcut.isContext()) {
+                        shortcut.setValueObject(object);
+                    }
                 }
-            }
-        });
+            });
+        }
 
         if (nextProps.shouldEditorContentUpdate && this.props.contextTrayItemToInsert !== nextProps.contextTrayItemToInsert && !Lang.isNull(nextProps.contextTrayItemToInsert) && nextProps.contextTrayItemToInsert.length > 0) {
             this.insertContextTrayItem(nextProps.contextTrayItemToInsert);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -87,6 +87,7 @@ class FluxNotesEditor extends React.Component {
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
         this.plugins = [];
+        this.previousState = {};
 
         // Set the initial state when the app is first constructed.
         this.resetEditorState();
@@ -634,6 +635,19 @@ class FluxNotesEditor extends React.Component {
                 this.insertTextWithStructuredPhrases(nextProps.summaryItemToInsert, undefined, true, true, nextProps.summaryItemToInsertSource);
                 this.props.itemInserted();
             }
+        }
+
+        // When the user selects a template, save the state of the editor before it is inserted in case they want to cancel
+        if (this.props.contextTrayItemToInsert === null && nextProps.contextTrayItemToInsert !== null) {
+            this.previousState = this.state.state;
+        }
+
+        // If the user clicks cancel button, change editor state back to what it was before they clicked the template
+        if (nextProps.shouldRevertTemplate) {
+            this.setState({ state: this.previousState }, () => {
+                this.props.setUndoTemplateInsertion(false);
+                this.refs.editor.focus();
+            });
         }
 
         // Update pick list selection in real time during template insertion

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -342,7 +342,7 @@ class FluxNotesEditor extends React.Component {
     }
 
     // TODO: explain
-    insertExistingShortcut = (shortcut, transform = undefined) => {
+    updateExistingShortcut = (shortcut, transform = undefined) => {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
@@ -1019,7 +1019,7 @@ class FluxNotesEditor extends React.Component {
                 }
 
                 if (arrayOfPickLists && this.noteParser.isPickList(trigger)) {
-                    transform = this.insertExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform);
+                    transform = this.updateExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform);
                     pickListCount++;
                 } else {
                     transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, shouldPortalOpen, source);

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1134,16 +1134,17 @@ class FluxNotesEditor extends React.Component {
             let shortcutOptions = [];
 
             localArrayOfPickLists.forEach((pickList) => {
-                // Temporarily create shortcut from trigger to get selectionOptions
-                let tempShortcut = this.props.shortcutManager.createShortcut(pickList.definition, pickList.trigger, this.props.patient, '', false);
-                tempShortcut.initialize(this.props.contextManager, pickList.trigger, false);
+                // Create shortcut from trigger to be inserted before selection chosen. Also uses to get shortcutOptions.
+                let shortcut = this.props.shortcutManager.createShortcut(pickList.definition, pickList.trigger, this.props.patient, '', false);
+                shortcut.setSource("pick list/template");
+                shortcut.initialize(this.props.contextManager, pickList.trigger, false);
 
-                shortcutOptions = tempShortcut.getValueSelectionOptions();
+                shortcutOptions = shortcut.getValueSelectionOptions();
                 localArrayOfPickListsWithOptions.push(
                     {
                         'trigger': pickList.trigger,
                         'options': shortcutOptions,
-                        'shortcut': tempShortcut
+                        'shortcut': shortcut
                     }
                 )
             });

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -121,6 +121,10 @@
 // ******** StructuredFieldPlugin.jsx uses this
 .structured-field {
     background-color: #d9ebf9;
+
+    &-highlighted {
+        font-weight: bold;
+    }
 }
 
 .placeholder {

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -110,14 +110,6 @@
     text-align: left;
 }
 
-.editor-content-modal {
-    /* 80vh for the modal height, 40px for modal padding, 40px for note-description */
-    max-height: calc(80vh - 40px - 40px);
-    overflow-y: auto;
-    overflow-x: hidden;
-    text-align: left;
-}
-
 // ******** StructuredFieldPlugin.jsx uses this
 .structured-field {
     background-color: #d9ebf9;

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -265,6 +265,7 @@ export default class NoteAssistant extends Component {
                 updateContextTrayItemWithSelectedPickListOptions={this.props.updateContextTrayItemWithSelectedPickListOptions}
                 updateNoteAssistantMode={this.props.updateNoteAssistantMode}
                 setUndoTemplateInsertion={this.props.setUndoTemplateInsertion}
+                highlightShortcut={this.props.highlightShortcut}
             />
         );
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -539,6 +539,7 @@ export default class NoteAssistant extends Component {
 
 NoteAssistant.propTypes = {
     arrayOfPickLists: PropTypes.array.isRequired,
+    changeShortcutType: PropTypes.func.isRequired,
     closeNote: PropTypes.func.isRequired,
     currentlyEditingEntryId: PropTypes.number.isRequired,
     contextManager: PropTypes.object.isRequired,
@@ -563,6 +564,7 @@ NoteAssistant.propTypes = {
     setNoteViewerVisible: PropTypes.func.isRequired,
     setOpenClinicalNote: PropTypes.func.isRequired,
     setSearcbSelectedItem: PropTypes.func,
+    setUndoTemplateInsertion: PropTypes.func.isRequired,
     shortcutManager: PropTypes.object.isRequired,
     shouldEditorContentUpdate: PropTypes.bool.isRequired,
     structuredFieldMapManager: PropTypes.object.isRequired,

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -249,6 +249,7 @@ export default class NoteAssistant extends Component {
                 updateContextTrayItemToInsert={this.props.updateContextTrayItemToInsert}
                 updateContextTrayItemWithSelectedPickListOptions={this.props.updateContextTrayItemWithSelectedPickListOptions}
                 updateNoteAssistantMode={this.props.updateNoteAssistantMode}
+                setUndoTemplateInsertion={this.props.setUndoTemplateInsertion}
             />
         );
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -265,7 +265,7 @@ export default class NoteAssistant extends Component {
                 updateContextTrayItemWithSelectedPickListOptions={this.props.updateContextTrayItemWithSelectedPickListOptions}
                 updateNoteAssistantMode={this.props.updateNoteAssistantMode}
                 setUndoTemplateInsertion={this.props.setUndoTemplateInsertion}
-                highlightShortcut={this.props.highlightShortcut}
+                changeShortcutType={this.props.changeShortcutType}
             />
         );
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -49,7 +49,9 @@ export default class NoteAssistant extends Component {
             this.onNotesToggleButtonClicked();
         }
 
-        if (!nextProps.isNoteViewerEditable || nextProps.noteAssistantMode === "pick-list-options-panel") {
+        if (nextProps.noteAssistantMode === "pick-list-options-panel") {
+            this.disableAllButtons();
+        } else if (!nextProps.isNoteViewerEditable) {
             this.disableContextToggleButton();
         }
     }
@@ -144,6 +146,19 @@ export default class NoteAssistant extends Component {
         this.notes_btn_classname = "toggle-button-selected";
         this.notes_stroke = "#FFFFFF";
         this.notes_disabled = false;
+        this.context_btn_classname = "toggle-button-disabled";
+        this.context_disabled = true;
+        this.context_fill = "#FFFFFF";
+        this.poc_btn_classname = 'toggle-button-disabled';
+        this.poc_stroke = "#FFFFFF";
+        this.poc_fill = "#666666"
+        this.poc_disabled = true;
+    }
+
+    disableAllButtons() {
+        this.notes_btn_classname = "toggle-button-disabled";
+        this.notes_stroke = "#FFFFFF";
+        this.notes_disabled = true;
         this.context_btn_classname = "toggle-button-disabled";
         this.context_disabled = true;
         this.context_fill = "#FFFFFF";

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -262,7 +262,7 @@ export default class NoteAssistant extends Component {
                 insertingTemplate={this.state.insertingTemplate}
                 setInsertingTemplate={this.setInsertingTemplate}
                 updateContextTrayItemToInsert={this.props.updateContextTrayItemToInsert}
-                updateContextTrayItemWithSelectedPickListOptions={this.props.updateContextTrayItemWithSelectedPickListOptions}
+                updateSelectedPickListOptions={this.props.updateSelectedPickListOptions}
                 updateNoteAssistantMode={this.props.updateNoteAssistantMode}
                 setUndoTemplateInsertion={this.props.setUndoTemplateInsertion}
                 changeShortcutType={this.props.changeShortcutType}
@@ -571,7 +571,7 @@ NoteAssistant.propTypes = {
     updateNoteAssistantMode: PropTypes.func.isRequired,
     updateSelectedNote: PropTypes.func.isRequired,
     updateContextTrayItemToInsert: PropTypes.func.isRequired,
-    updateContextTrayItemWithSelectedPickListOptions: PropTypes.func.isRequired,
+    updateSelectedPickListOptions: PropTypes.func.isRequired,
     updatedEditorNote: PropTypes.object,
     updateErrors: PropTypes.func.isRequired,
     updateShowTemplateView: PropTypes.func.isRequired

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import Select from 'material-ui/Select';
 import MenuItem from 'material-ui/Menu/MenuItem';
 import MaterialButton from 'material-ui/Button';
-import Modal from 'material-ui/Modal';
-import FluxNotesEditor from './FluxNotesEditor';
-import { Grid, Row, Col } from 'react-flexbox-grid';
 import Lang from 'lodash';
 import FontAwesome from 'react-fontawesome';
 import ContextTray from '../context/ContextTray';
@@ -234,60 +231,12 @@ export default class NoteAssistant extends Component {
 
             // Render the pick list options panel which allows users to select options for the pick lists
             case "pick-list-options-panel": {
-                if (this.state.insertingTemplate) return this.renderPickListOptionsModal(noteAssistantMode);
                 return this.renderPickListOptions();
             }
             default:
                 console.error(`note assistant mode ${noteAssistantMode} is not a valid mode`);
                 return "";
         }
-    }
-
-    renderPickListOptionsModal(noteAssistantMode) {
-        return (
-            <Modal open={noteAssistantMode === 'pick-list-options-panel'}>
-                <Grid id="pick-list-options-modal">
-                    <Row center="xs">
-                        <Col sm={7} md={8} lg={9}>
-                            <FluxNotesEditor
-                                closeNote={this.props.closeNote}
-                                contextManager={this.props.contextManager}
-                                currentViewMode={'pre-encounter'}
-                                errors={this.props.errors}
-                                handleUpdateEditorWithNote={this.props.handleUpdateEditorWithNote}
-                                isNoteViewerEditable={false}
-                                inModal={true}
-                                itemInserted={this.props.itemInserted}
-                                newCurrentShortcut={this.props.newCurrentShortcut}
-                                noteAssistantMode={this.props.noteAssistantMode}
-                                patient={this.props.patient}
-                                saveNote={this.props.saveNote}
-                                selectedNote={this.props.selectedNote}
-                                setLayout={this.props.setLayout}
-                                setNoteViewerEditable={this.props.setNoteViewerEditable}
-                                shortcutManager={this.props.shortcutManager}
-                                shouldEditorContentUpdate={this.props.shouldEditorContentUpdate}
-                                structuredFieldMapManager={this.props.structuredFieldMapManager}
-                                summaryItemToInsert={this.props.summaryItemToInsert}
-                                contextTrayItemToInsert={this.props.contextTrayItemToInsert}
-                                // Pass in note that the editor is to be updated with
-                                updatedEditorNote={this.props.updatedEditorNote}
-                                updateErrors={this.props.updateErrors}
-                                updateLocalDocumentText={this.props.updateLocalDocumentText}
-                                updateSelectedNote={this.props.updateSelectedNote}
-                                updateNoteAssistantMode={this.props.updateNoteAssistantMode}
-                                arrayOfPickLists={this.props.arrayOfPickLists}
-                                handleUpdateArrayOfPickLists={this.props.handleUpdateArrayOfPickLists}
-                                updateContextTrayItemToInsert={this.props.updateContextTrayItemToInsert}
-                            />
-                        </Col>
-                        <Col sm={5} md={4} lg={3}>
-                            {this.renderPickListOptions()}
-                        </Col>
-                    </Row>
-                </Grid>
-            </Modal>
-        );
     }
 
     renderPickListOptions() {

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -192,17 +192,6 @@ $note-assitant-width-3: 160px;
     }  
 }
 
-#pick-list-options-modal {
-    height: 80%;
-    width: 80%;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    position: absolute;
-    background: $background;
-    padding: 20px;
-}
-
 @media only screen and (min-width: 1200px) and (max-width: 1300px) {
     .note-assistant-wrapper {
         width: $note-assitant-width-2;

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -59,6 +59,10 @@ function StructuredFieldPlugin(opts) {
                 let shortcut = props.node.get('data').get('shortcut');
                 return <span contentEditable={false} className='structured-field' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
             },
+            highlighted_structured_field: props => {
+                let shortcut = props.node.get('data').get('shortcut');
+                return <span contentEditable={false} className='structured-field structured-field-highlighted' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+            },
             placeholder: props => {
                 const placeholder = props.node.get('data').get('placeholder');
                 return <span contentEditable={false} className='placeholder'>{placeholder.getTextToDisplayInNote()}</span>;

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -93,37 +93,6 @@ export default class NotesPanel extends Component {
     }
 
     updateContextTrayItemWithSelectedPickListOptions = (selectedPickListOptions) => {
-        let contextTrayItemToInsert = this.state.contextTrayItemToInsert;
-        
-        // Clear old selections
-        while (contextTrayItemToInsert.indexOf('[[') >= 0) {
-            let indexStart = contextTrayItemToInsert.indexOf('[[');
-            let indexEnd = contextTrayItemToInsert.indexOf(']]');
-            contextTrayItemToInsert = contextTrayItemToInsert.slice(0, indexStart) + contextTrayItemToInsert.slice(indexEnd + 2);
-        }
-
-        if (!Lang.isNull(this.state.contextTrayItemToInsert) && selectedPickListOptions.length > 0) {
-            // Loop through selectedPickListOptions and replace in contextTrayItem
-            let searchIndex = 0;
-            selectedPickListOptions.forEach((option) => {
-                const triggerLength = option.trigger.length;
-                // Skip selections that have not been made yet
-                if (option.selectedOption === undefined) {
-                    // update searchIndex to start searching the string after the trigger we are skipping over
-                    searchIndex = contextTrayItemToInsert.indexOf(option.trigger, searchIndex) + triggerLength;
-                    return;
-                }
-
-                let index = contextTrayItemToInsert.indexOf(option.trigger, searchIndex) + triggerLength;
-                // Search for next instance of trigger if bracketed notation is already provided
-                while (contextTrayItemToInsert.substring(index).startsWith("[[")) {
-                    index = contextTrayItemToInsert.indexOf(option.trigger, searchIndex + index + 1) + triggerLength;
-                }
-                // Replace instance of shortcut with bracketed notation
-                contextTrayItemToInsert = contextTrayItemToInsert.slice(0, index) + `[[${option.selectedOption}]]` + contextTrayItemToInsert.slice(index);
-            });
-        }
-
         this.setState({ selectedPickListOptions });
     }
 

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -26,7 +26,8 @@ export default class NotesPanel extends Component {
             arrayOfPickLists: [],
             contextTrayItemToInsert: null,
             localDocumentText: '',
-            showTemplateView: false
+            showTemplateView: false,
+            selectedPickListOptions: []
         };
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
@@ -117,7 +118,7 @@ export default class NotesPanel extends Component {
             });
         }
 
-        this.setState({contextTrayItemToInsert: contextTrayItemToInsert});
+        this.setState({ selectedPickListOptions });
     }
 
     // Handle when the editor needs to be updated with a note. The note can be a new blank note or a pre existing note
@@ -388,7 +389,8 @@ export default class NotesPanel extends Component {
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
                     setLayout={this.props.setLayout}
                     shortcutManager={this.props.shortcutManager}
-                    shouldEditorContentUpdate={true}
+                    shouldEditorContentUpdate={this.state.noteAssistantMode !== 'pick-list-options-panel'}
+                    selectedPickListOptions={this.state.selectedPickListOptions}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
                     summaryItemToInsert={this.props.summaryItemToInsert}
                     summaryItemToInsertSource={this.props.summaryItemToInsertSource}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -393,7 +393,6 @@ export default class NotesPanel extends Component {
                     errors={this.props.errors}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
-                    inModal={false}
                     itemInserted={this.props.itemInserted}
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     noteAssistantMode={this.state.noteAssistantMode}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -38,6 +38,7 @@ export default class NotesPanel extends Component {
         // Logic to handle switching notes
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
             this.saveNote(this.state.localDocumentText);
+            this.updateContextTrayItemToInsert(null);
             this.handleUpdateEditorWithNote(nextProps.openClinicalNote);
         }
     }
@@ -179,6 +180,7 @@ export default class NotesPanel extends Component {
 
     // Close a note
     closeNote = () => {
+        this.updateContextTrayItemToInsert(null);
         this.props.setOpenClinicalNote(null);
         this.setState({
             updatedEditorNote: null,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -424,6 +424,7 @@ export default class NotesPanel extends Component {
                     shouldHighlightShortcut={this.state.shouldHighlightShortcut}
                     shortcutKey={this.state.shortcutKey}
                     shortcutType={this.state.shortcutType}
+                    highlightShortcut={this.setHighlightShortcut}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -388,7 +388,7 @@ export default class NotesPanel extends Component {
                     setNoteViewerEditable={this.props.setNoteViewerEditable}
                     setLayout={this.props.setLayout}
                     shortcutManager={this.props.shortcutManager}
-                    shouldEditorContentUpdate={this.state.noteAssistantMode !== 'pick-list-options-panel'}
+                    shouldEditorContentUpdate={true}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
                     summaryItemToInsert={this.props.summaryItemToInsert}
                     summaryItemToInsertSource={this.props.summaryItemToInsertSource}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -37,8 +37,10 @@ export default class NotesPanel extends Component {
     componentWillReceiveProps = (nextProps) => {
         // Logic to handle switching notes
         if (!Lang.isNull(nextProps.openClinicalNote) && this.props.openClinicalNote !== nextProps.openClinicalNote) {
+            if (!Lang.isNull(this.props.openClinicalNote)) {
+                this.updateContextTrayItemToInsert(null);
+            }
             this.saveNote(this.state.localDocumentText);
-            this.updateContextTrayItemToInsert(null);
             this.handleUpdateEditorWithNote(nextProps.openClinicalNote);
         }
     }

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -27,7 +27,8 @@ export default class NotesPanel extends Component {
             contextTrayItemToInsert: null,
             localDocumentText: '',
             showTemplateView: false,
-            selectedPickListOptions: []
+            selectedPickListOptions: [],
+            shouldRevertTemplate: false
         };
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
@@ -281,6 +282,10 @@ export default class NotesPanel extends Component {
         this.closeNote();
     }
 
+    setUndoTemplateInsertion = (shouldRevertTemplate) => {
+        this.setState({ shouldRevertTemplate });
+    }
+
     renderSignButton = () => {
         return (
             <div id="finish-sign-component">
@@ -404,6 +409,8 @@ export default class NotesPanel extends Component {
                     arrayOfPickLists={this.arrayOfPickLists}
                     handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
                     updateContextTrayItemToInsert={this.updateContextTrayItemToInsert}
+                    shouldRevertTemplate={this.state.shouldRevertTemplate}
+                    setUndoTemplateInsertion={this.setUndoTemplateInsertion}
                 />
             </div>
         );
@@ -455,6 +462,7 @@ export default class NotesPanel extends Component {
                     updatedEditorNote={this.state.updatedEditorNote}
                     updateErrors={this.props.updateErrors}
                     updateShowTemplateView={this.updateShowTemplateView}
+                    setUndoTemplateInsertion={this.setUndoTemplateInsertion}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -29,7 +29,7 @@ export default class NotesPanel extends Component {
             showTemplateView: false,
             selectedPickListOptions: [],
             shouldRevertTemplate: false,
-            shouldHighlightShortcut: false,
+            shouldUpdateShortcutType: false,
             shortcutKey: -1
         };
 
@@ -261,8 +261,8 @@ export default class NotesPanel extends Component {
         this.setState({ shouldRevertTemplate });
     }
 
-    setHighlightShortcut = (shortcutKey, shouldHighlightShortcut, shortcutType) => {
-        this.setState({ shortcutKey, shouldHighlightShortcut, shortcutType });
+    changeShortcutType = (shortcutKey, shouldUpdateShortcutType, shortcutType) => {
+        this.setState({ shortcutKey, shouldUpdateShortcutType, shortcutType });
     }
 
     renderSignButton = () => {
@@ -389,10 +389,10 @@ export default class NotesPanel extends Component {
                     updateContextTrayItemToInsert={this.updateContextTrayItemToInsert}
                     shouldRevertTemplate={this.state.shouldRevertTemplate}
                     setUndoTemplateInsertion={this.setUndoTemplateInsertion}
-                    shouldHighlightShortcut={this.state.shouldHighlightShortcut}
+                    shouldUpdateShortcutType={this.state.shouldUpdateShortcutType}
                     shortcutKey={this.state.shortcutKey}
                     shortcutType={this.state.shortcutType}
-                    highlightShortcut={this.setHighlightShortcut}
+                    changeShortcutType={this.changeShortcutType}
                 />
             </div>
         );
@@ -445,7 +445,7 @@ export default class NotesPanel extends Component {
                     updateErrors={this.props.updateErrors}
                     updateShowTemplateView={this.updateShowTemplateView}
                     setUndoTemplateInsertion={this.setUndoTemplateInsertion}
-                    highlightShortcut={this.setHighlightShortcut}
+                    changeShortcutType={this.changeShortcutType}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -30,7 +30,8 @@ export default class NotesPanel extends Component {
             selectedPickListOptions: [],
             shouldRevertTemplate: false,
             shouldUpdateShortcutType: false,
-            shortcutKey: -1
+            shortcutKey: null,
+            shortcutType: null,
         };
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -93,7 +93,7 @@ export default class NotesPanel extends Component {
         this.setState({showTemplateView: false});
     }
 
-    updateContextTrayItemWithSelectedPickListOptions = (selectedPickListOptions) => {
+    updateSelectedPickListOptions = (selectedPickListOptions) => {
         this.setState({ selectedPickListOptions });
     }
 
@@ -441,7 +441,7 @@ export default class NotesPanel extends Component {
                     updateSelectedNote={this.updateSelectedNote}
                     arrayOfPickLists={this.state.arrayOfPickLists}
                     updateContextTrayItemToInsert={this.updateContextTrayItemToInsert}
-                    updateContextTrayItemWithSelectedPickListOptions={this.updateContextTrayItemWithSelectedPickListOptions}
+                    updateSelectedPickListOptions={this.updateSelectedPickListOptions}
                     updatedEditorNote={this.state.updatedEditorNote}
                     updateErrors={this.props.updateErrors}
                     updateShowTemplateView={this.updateShowTemplateView}

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -28,7 +28,9 @@ export default class NotesPanel extends Component {
             localDocumentText: '',
             showTemplateView: false,
             selectedPickListOptions: [],
-            shouldRevertTemplate: false
+            shouldRevertTemplate: false,
+            shouldHighlightShortcut: false,
+            shortcutKey: -1
         };
 
         this.noteParser = new NoteParser(this.props.shortcutManager, this.props.contextManager);
@@ -290,6 +292,10 @@ export default class NotesPanel extends Component {
         this.setState({ shouldRevertTemplate });
     }
 
+    setHighlightShortcut = (shortcutKey, shouldHighlightShortcut, shortcutType) => {
+        this.setState({ shortcutKey, shouldHighlightShortcut, shortcutType });
+    }
+
     renderSignButton = () => {
         return (
             <div id="finish-sign-component">
@@ -410,11 +416,14 @@ export default class NotesPanel extends Component {
                     updateErrors={this.props.updateErrors}
                     updateSelectedNote={this.updateSelectedNote}
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
-                    arrayOfPickLists={this.arrayOfPickLists}
+                    arrayOfPickLists={this.state.arrayOfPickLists}
                     handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
                     updateContextTrayItemToInsert={this.updateContextTrayItemToInsert}
                     shouldRevertTemplate={this.state.shouldRevertTemplate}
                     setUndoTemplateInsertion={this.setUndoTemplateInsertion}
+                    shouldHighlightShortcut={this.state.shouldHighlightShortcut}
+                    shortcutKey={this.state.shortcutKey}
+                    shortcutType={this.state.shortcutType}
                 />
             </div>
         );
@@ -467,6 +476,7 @@ export default class NotesPanel extends Component {
                     updateErrors={this.props.updateErrors}
                     updateShowTemplateView={this.updateShowTemplateView}
                     setUndoTemplateInsertion={this.setUndoTemplateInsertion}
+                    highlightShortcut={this.setHighlightShortcut}
                 />
             </div>
         );

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -15,14 +15,16 @@ export default class PickListOptionsPanel extends Component {
         this.arrayOfPickLists = this.props.arrayOfPickLists.map((pickList, i) => {
             return {
                 trigger: pickList.trigger + `_${i}`,
-                options: pickList.options
+                options: pickList.options,
+                shortcut: pickList.shortcut
             }
         });
         // triggerSelections are the selections made by the user for each pick List
         // pushing the trigger value first so that order of shortcuts remain the same
         let triggerSelections = this.arrayOfPickLists.map((pickList) => {
             return {
-                trigger: pickList.trigger
+                trigger: pickList.trigger,
+                shortcut:  pickList.shortcut
             };
         });
 
@@ -79,7 +81,8 @@ export default class PickListOptionsPanel extends Component {
                 : triggerSelection.selectedOption;
             return {
                 trigger: triggerSelection.trigger.slice(0, underScoreIndex),
-                selectedOption: selectedOption
+                selectedOption: selectedOption,
+                shortcut: triggerSelection.shortcut
             }
         });
 
@@ -87,9 +90,9 @@ export default class PickListOptionsPanel extends Component {
     }
 
     handleOkButtonClick = () => {
-        this.toggleView('context-tray');
+        this.props.updateContextTrayItemToInsert(null);
         this.props.setInsertingTemplate(false);
-        this.handleInsertChosenOption();
+        this.toggleView('context-tray');
     }
 
     handleOptionButtonClick(option, trigger) {

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -63,6 +63,7 @@ export default class PickListOptionsPanel extends Component {
         this.props.setUndoTemplateInsertion(true);
         this.props.updateContextTrayItemToInsert(null);
         this.props.setInsertingTemplate(false);
+        this.props.highlightShortcut(null, false, null);
         this.toggleView('context-tray');
     }
 

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -235,12 +235,12 @@ export default class PickListOptionsPanel extends Component {
                 </div>
 
                 <div id="pickList-action-buttons">
-                    <MaterialButton
+                    {/* <MaterialButton
                         raised
                         id="cancel-btn"
                         onClick={this.handleCancelButtonClick}>
                         Cancel
-                    </MaterialButton>
+                    </MaterialButton> */}
 
                     {this.state.isAllSelected ?
                         <MaterialButton

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -63,7 +63,6 @@ export default class PickListOptionsPanel extends Component {
         this.props.setUndoTemplateInsertion(true);
         this.props.updateContextTrayItemToInsert(null);
         this.props.setInsertingTemplate(false);
-        this.props.highlightShortcut(null, false, null);
         this.toggleView('context-tray');
     }
 

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -268,11 +268,13 @@ export default class PickListOptionsPanel extends Component {
     }
 }
 
-PickListOptionsPanel.proptypes = {
+PickListOptionsPanel.propTypes = {
     arrayOfPickLists: PropTypes.array.isRequired,
+    changeShortcutType: PropTypes.func.isRequired,
     contextManager: PropTypes.object.isRequired,
     insertingTemplate: PropTypes.bool.isRequired,
     setInsertingTemplate: PropTypes.func.isRequired,
+    setUndoTemplateInsertion: PropTypes.func.isRequired,
     updateContextTrayItemToInsert: PropTypes.func.isRequired,
     updateContextTrayItemWithSelectedPickListOptions: PropTypes.func.isRequired,
     updateNoteAssistantMode: PropTypes.func.isRequired,

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -125,8 +125,10 @@ export default class PickListOptionsPanel extends Component {
     }
 
     highlightShortcut(shortcut, type, e) {
-        e.persist();
-        this.props.highlightShortcut(shortcut.getKey(), true, type);
+        if (this.props.insertingTemplate) {
+            e.persist();
+            this.props.highlightShortcut(shortcut.getKey(), true, type);
+        }
     }
 
     // Render pick list options

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -60,9 +60,10 @@ export default class PickListOptionsPanel extends Component {
 
     // Cancels insertion of text and clears any context
     handleCancelButtonClick = () => {
+        this.props.setUndoTemplateInsertion(true);
         this.props.updateContextTrayItemToInsert(null);
         this.props.setInsertingTemplate(false);
-        this.toggleView('context-tray')
+        this.toggleView('context-tray');
     }
 
     // Pass array of select of pick list options to be used in updating the contextTrayItem to be inserted
@@ -235,12 +236,12 @@ export default class PickListOptionsPanel extends Component {
                 </div>
 
                 <div id="pickList-action-buttons">
-                    {/* <MaterialButton
+                    <MaterialButton
                         raised
                         id="cancel-btn"
                         onClick={this.handleCancelButtonClick}>
                         Cancel
-                    </MaterialButton> */}
+                    </MaterialButton>
 
                     {this.state.isAllSelected ?
                         <MaterialButton

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -124,6 +124,11 @@ export default class PickListOptionsPanel extends Component {
         }
     }
 
+    highlightShortcut(shortcut, type, e) {
+        e.persist();
+        this.props.highlightShortcut(shortcut.getKey(), true, type);
+    }
+
     // Render pick list options
     renderOptions(pickLists, i) {
         // Loop through each shortcut in the array and render the options
@@ -133,7 +138,9 @@ export default class PickListOptionsPanel extends Component {
                 let shortcutName = shortcut.trigger.slice(1, underScoreIndex);
                 shortcutName = shortcutName.charAt(0).toUpperCase() + shortcutName.slice(1);
                 return (
-                    <div key={i} className="shortcut-options-container">
+                    <div id={i} key={i}className="shortcut-options-container"
+                        onMouseEnter={(e) => this.highlightShortcut(shortcut.shortcut, 'highlighted_structured_field', e)}
+                        onMouseLeave={(e) => this.highlightShortcut(shortcut.shortcut, 'structured_field', e)}>
                         {shortcutName}
                         {this.renderShortcutOptions(shortcut, i)}
                     </div>

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -87,7 +87,7 @@ export default class PickListOptionsPanel extends Component {
             }
         });
 
-        this.props.updateContextTrayItemWithSelectedPickListOptions(triggerSelections);
+        this.props.updateSelectedPickListOptions(triggerSelections);
     }
 
     handleOkButtonClick = () => {
@@ -276,6 +276,6 @@ PickListOptionsPanel.propTypes = {
     setInsertingTemplate: PropTypes.func.isRequired,
     setUndoTemplateInsertion: PropTypes.func.isRequired,
     updateContextTrayItemToInsert: PropTypes.func.isRequired,
-    updateContextTrayItemWithSelectedPickListOptions: PropTypes.func.isRequired,
+    updateSelectedPickListOptions: PropTypes.func.isRequired,
     updateNoteAssistantMode: PropTypes.func.isRequired,
 };

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -93,6 +93,7 @@ export default class PickListOptionsPanel extends Component {
     handleOkButtonClick = () => {
         this.props.updateContextTrayItemToInsert(null);
         this.props.setInsertingTemplate(false);
+        this.props.changeShortcutType(null, false, null);
         this.toggleView('context-tray');
     }
 
@@ -124,10 +125,10 @@ export default class PickListOptionsPanel extends Component {
         }
     }
 
-    highlightShortcut(shortcut, type, e) {
+    changeShortcutType(shortcut, type, e) {
         if (this.props.insertingTemplate) {
             e.persist();
-            this.props.highlightShortcut(shortcut.getKey(), true, type);
+            this.props.changeShortcutType(shortcut.getKey(), true, type);
         }
     }
 
@@ -141,8 +142,8 @@ export default class PickListOptionsPanel extends Component {
                 shortcutName = shortcutName.charAt(0).toUpperCase() + shortcutName.slice(1);
                 return (
                     <div id={i} key={i}className="shortcut-options-container"
-                        onMouseEnter={(e) => this.highlightShortcut(shortcut.shortcut, 'highlighted_structured_field', e)}
-                        onMouseLeave={(e) => this.highlightShortcut(shortcut.shortcut, 'structured_field', e)}>
+                        onMouseEnter={(e) => this.changeShortcutType(shortcut.shortcut, 'highlighted_structured_field', e)}
+                        onMouseLeave={(e) => this.changeShortcutType(shortcut.shortcut, 'structured_field', e)}>
                         {shortcutName}
                         {this.renderShortcutOptions(shortcut, i)}
                     </div>

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -222,6 +222,8 @@ export default class InsertValue extends Shortcut {
         if (result && !Lang.isUndefined(this.parentContext) && this.metadata.parentAttribute) {
             this.parentContext.setAttributeValue(this.metadata.parentAttribute, null, false);
             this.parentContext.removeChild(this);
+        } else if (result && !Lang.isUndefined(this.parentContext)) {
+            this.parentContext.removeChild(this);
         }
         return result;
     }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -13,6 +13,10 @@ export default class InsertValue extends Shortcut {
         super.initialize(contextManager, trigger, updatePatient);
         super.determineParentContext(contextManager, this.metadata["knownParentContexts"], this.metadata["parentAttribute"]);
 
+        if (!Lang.isUndefined(this.parentContext)) {
+            this.parentContext.addChild(this);
+        }
+
         let text = this.determineText(contextManager);
         if (Lang.isArray(text)) {
             this.flagForTextSelection(text);
@@ -129,14 +133,14 @@ export default class InsertValue extends Shortcut {
         } else if (callObject === "parent") {
             //   "getData": {"object": "parent", "attribute": "stage"},
             const attribute = callSpec["attribute"];
-            return this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getAttributeValue(attribute);
+            return this.parentContext.getAttributeValue(attribute);
         } else if (callObject === "$parentValueObject") {
-            const patient = this.contextManager.getPatient();
-            if (!this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getValueObject()) {
+            const patient = contextManager.getPatient();
+            if (!this.parentContext || !this.parentContext.getValueObject()) {
                 // Returns text if the parent context is not set.
                 return this.getText();
             }
-            return this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getValueObject()[callSpec["method"]](patient);
+            return this.parentContext.getValueObject()[callSpec["method"]](patient);
         } else {
             console.error("not support yet " + callSpec.object + " / " + callSpec.method);
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -170,7 +170,7 @@ export default class InsertValue extends Shortcut {
     }
 
     getText() {
-        return this.text;
+        return this.text ? this.text : this.initiatingTrigger;
     }
 
     getResultText() {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -132,6 +132,10 @@ export default class InsertValue extends Shortcut {
             return this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getAttributeValue(attribute);
         } else if (callObject === "$parentValueObject") {
             const patient = this.contextManager.getPatient();
+            if (!this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getValueObject()) {
+                // Returns text if the parent context is not set.
+                return this.getText();
+            }
             return this.contextManager.getActiveContextOfType(this.metadata.knownParentContexts).getValueObject()[callSpec["method"]](patient);
         } else {
             console.error("not support yet " + callSpec.object + " / " + callSpec.method);

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -319,7 +319,7 @@ class ShortcutManager {
             // valid if it is set!
             contextValueObjectEntryTypes = this.shortcuts[shortcutId]["contextValueObjectEntryTypes"];
 
-            if (Lang.isUndefined(contextValueObjectEntryTypes) || contextValueObjectEntryTypes.includes(context.getValueObject().entryInfo.entryType.value)) {
+            if (Lang.isUndefined(contextValueObjectEntryTypes) || (!Lang.isUndefined(context.getValueObject()) && contextValueObjectEntryTypes.includes(context.getValueObject().entryInfo.entryType.value))) {
                 parentAttribute = this.shortcuts[shortcutId]["parentAttribute"];
                 if (Lang.isUndefined(parentAttribute)) return true;
                 parentVOAs = this.shortcuts[currentContextId]["valueObjectAttributes"];

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -326,7 +326,6 @@ describe('6 FluxNotesEditor', function() {
             setNoteViewerVisible={jest.fn()}
             currentViewMode={''}
             errors={[]}
-            inModal={false}
             itemInserted={jest.fn()}
             noteAssistantMode={''}
             patient={{}}
@@ -578,7 +577,6 @@ describe('6 FluxNotesEditor', function() {
             setNoteViewerVisible={jest.fn()}
             currentViewMode={''}
             errors={[]}
-            inModal={false}
             itemInserted={jest.fn()}
             noteAssistantMode={''}
             patient={{}}
@@ -642,7 +640,6 @@ describe('6 FluxNotesEditor', function() {
             setNoteViewerVisible={jest.fn()}
             currentViewMode={''}
             errors={[]}
-            inModal={false}
             itemInserted={jest.fn()}
             noteAssistantMode={''}
             patient={{}}
@@ -710,7 +707,6 @@ describe('6 FluxNotesEditor', function() {
             setNoteViewerVisible={jest.fn()}
             currentViewMode={''}
             errors={[]}
-            inModal={false}
             itemInserted={jest.fn()}
             noteAssistantMode={''}
             patient={{}}
@@ -1038,7 +1034,6 @@ describe('6 FluxNotesEditor', function() {
             setNoteViewerVisible={jest.fn()}
             currentViewMode={''}
             errors={[]}
-            inModal={false}
             itemInserted={jest.fn()}
             noteAssistantMode={''}
             patient={{}}

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -524,7 +524,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenClinicalNote={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
-        />);
+        />, { attachTo: document.body });
         expect(notesPanelWrapper.find(FluxNotesEditor)).to.have.lengthOf(1);
         expect(notesPanelWrapper.find(NoteAssistant)).to.have.lengthOf(1);
 


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Worked with @jafeltra. 

For Jira ASCODCP-1252.

- Eliminated modal during template insertion. Happens directly in the editor now.
    - Made template text appear in editor before any selections are made
    - Pick list selections now update the text of the existing shortcuts in the editor rather than creating new ones
- Implemented an association between pick list option buttons and editor shortcuts by bolding the corresponding shortcuts when the user hovers over the buttons on the right. This is designed to show the user where the text will be inserted if they click
- Added programatic scrolling to insertion of data, so that the editor will navigate to the updated shortcut regardless of what is currently in the editor.
- Cancelling a template will revert the editor to its state before the template was inserted. The template text will be removed from the editor.
    - Closing a note or opening a source note while inserting a template will result in the same behavior as cancellation

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
