### PR TITLE
Added GIST-specific data to GIST @HPI, tabular view for labs, and updated sarcoma patient

### DIFF
--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -1430,7 +1430,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     },
-                    "Value": "Mr. Tnfinity6 had a Gastrointerstinal Stromal Tumor follow up."
+                    "Value": "Mr. Tnfinity6 requested a follow up."
                 }
             ],
             "Status": {
@@ -1494,7 +1494,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     },
-                    "Value": "Mr. Tnfinity6 requested a GIST follow up."
+                    "Value": "Mr. Tnfinity6 requested a follow up."
                 }
             ],
             "Status": {
@@ -1550,7 +1550,7 @@
             "Value": "3 SEP 2018"
         },
         "LastUpdated": {
-            "EntryType": {
+            "EntryType": {  
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
             "Value": "3 SEP 2018"
@@ -1822,7 +1822,7 @@
             },
             "Value": "3 SEP 2018"
         },
-        "Value": true,
+        "Value": false,
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
@@ -1874,7 +1874,7 @@
             },
             "Value": "3 SEP 2018"
         },
-        "Value": false,
+        "Value": true,
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
@@ -1895,7 +1895,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "headache"
+                        "Value": "headaches"
                     }
                 }
             ]
@@ -1947,7 +1947,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 5"
+                        "Value": "bloody stools"
                     }
                 }
             ]
@@ -1999,7 +1999,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 6"
+                        "Value": "stomach aches"
                     }
                 }
             ]
@@ -2051,7 +2051,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Abdominal pain"
+                        "Value": "abdominal pains"
                     }
                 }
             ]
@@ -2103,7 +2103,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Vertigo"
+                        "Value": "vertigo"
                     }
                 }
             ]
@@ -2155,7 +2155,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Chest pain - cardiac"
+                        "Value": "chest pains"
                     }
                 }
             ]
@@ -2207,7 +2207,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "uncomfortable sensation of difficulty breathing"
+                        "Value": "uncomfortable sensations of difficulty breathing"
                     }
                 }
             ]
@@ -2259,7 +2259,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Cough"
+                        "Value": "coughing"
                     }
                 }
             ]
@@ -2311,7 +2311,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Fever"
+                        "Value": "fevers"
                     }
                 }
             ]
@@ -2363,7 +2363,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Hot flashes"
+                        "Value": "hot flashes"
                     }
                 }
             ]
@@ -2415,7 +2415,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Nausea"
+                        "Value": "nausea"
                     }
                 }
             ]
@@ -2446,7 +2446,7 @@
             },
             "Value": "3 SEP 2018"
         },
-        "Value": false,
+        "Value": true,
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
@@ -2467,7 +2467,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "rash"
+                        "Value": "rashes"
                     }
                 }
             ]

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -409,13 +409,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "15 FEB 2016"
+            "Value": "15 MAR 2016"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "15 FEB 2016"
+            "Value": "7 APR 2016"
         },
         "Value": {
             "EntryType": {
@@ -564,6 +564,13 @@
             },
             {
                 "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "_EntryId": "2190",
+                "_EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
+                }
+            },
+            {
+                "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                 "_EntryId": "2200",
                 "_EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
@@ -586,6 +593,13 @@
             {
                 "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                 "_EntryId": "2310",
+                "_EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+                }
+            },
+            {
+                "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "_EntryId": "2500",
                 "_EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
                 }
@@ -657,7 +671,7 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/GeneralizedDateTime"
                 },
-                "Value": "15 FEB 2016"
+                "Value": "15 MAR 2016"
             }
          },
          "RelatedEncounter": {
@@ -666,9 +680,9 @@
             },
              "Value": {
                  "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                 "_EntryId": "10",
+                 "_EntryId": "5150",
                  "_EntryType": {
-                     "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterPerformed"
+                     "Value": "http://standardhealthrecord.org/spec/shr/encounter/Encounter"
                  }
              }
          },
@@ -682,633 +696,11 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Informant"
             },
-             "Value": "Dr. Joseph Burn234"
+             "Value": "Dr. X123 Y987"
          }
     },
 
 
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterPerformed"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "10",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/PerformedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": "Mr. Martinez45 complaining of stomach pain."
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "finished"
-            },
-            "OccurrenceTimeOrPeriod": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/OccurrencePeriod"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "15 FEB 2016 15:00 -0500"
-                    }
-                }
-            }
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        }
-    },
-
-
-
-
-
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationChange"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "11",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. XYZ987"
-        },
-        "Type": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "reduced",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Dose Reduced"
-                        }
-                    }
-                ]
-            }
-        },
-        "MedicationBeforeChange": { 
-            "EntryType": { 
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationBeforeChange"
-            },
-            "Value": {
-                "EntryType": { 
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                "EntryId": "14"
-            }
-        },
-        "MedicationAfterChange": { 
-            "EntryType": { 
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationAfterChange"
-            },
-            "Value": {
-                "EntryType": { 
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-                },
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                "EntryId": "19"
-            }
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/PerformedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "side_effect",
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "Side Effect"
-                                }
-                            }
-                        ]
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "16",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "15 FEB 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "316077",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "ibuprofen 600mg tablet"
-                        }
-                    }
-                ]
-            }
-        },
-        "Dosage": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
-            },
-            "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
-                    },
-                    "Value": 1,
-                    "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "tablet"
-                        }
-                    }
-                }
-            },
-            "TimingOfDoses": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
-                    },
-                    "TimingCode": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
-                            "Coding": [
-                                {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                    },
-                                    "Value": "TID",
-                                    "CodeSystem": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation"
-                                    },
-                                    "DisplayText": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "TID"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": true
-            },
-            "AdditionalDoseInstruction": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/medication/AdditionalDoseInstruction"
-                    },
-                    "Value": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                        },
-                        "Coding": [
-                            {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                },
-                                "Value": "311504000",
-                                "CodeSystem": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                    },
-                                    "Value": "http://snomed.info/sct"
-                                },
-                                "DisplayText": {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                    },
-                                    "Value": "With or after food"
-                                }
-                            }
-                        ]
-                    }
-                }
-            ],
-            "RouteIntoBody": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "26643006",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Oral route"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    },   
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "17",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "15 FEB 2016"
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "ActionContext": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
-            },
-            "Reason": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
-                    },
-                    "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                        "_EntryId": "8",
-                        "_EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
-                        }
-                    }
-                }
-            ],
-            "Status": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
-                },
-                "Value": "completed"
-            },
-            "ExpectedPerformanceTime": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
-                    },
-                    "TimePeriodStart": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
-                        },
-                        "Value": "15 FEB 2016"
-                    }
-                }
-            }
-        },
-        "MedicationOrCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "310891",
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "hydrocortisone 2.5% ointment"
-                        }
-                    }
-                ]
-            }
-        },
-        "Dosage": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
-            },
-            "DoseAmount": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
-                    },
-                    "Value": 1,
-                    "Units": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "g"
-                        }
-                    }
-                }
-            },
-            "TimingOfDoses": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
-                    },
-                    "TimingCode": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
-                        },
-                        "Value": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                            },
-                            "Coding": [
-                                {
-                                    "EntryType": {
-                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                                    },
-                                    "Value": "BID",
-                                    "CodeSystem": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                        },
-                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation"
-                                    },
-                                    "DisplayText": {
-                                        "EntryType": {
-                                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                        },
-                                        "Value": "BID"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }
-            },
-            "AsNeededIndicator": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
-                },
-                "Value": true
-            },
-            "RouteIntoBody": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
-                },
-                "Value": {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                    },
-                    "Coding": [
-                        {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                            },
-                            "Value": "6064005",
-                            "CodeSystem": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                                },
-                                "Value": "http://snomed.info/sct"
-                            },
-                            "DisplayText": {
-                                "EntryType": {
-                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                                },
-                                "Value": "Topical route"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    },
     {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
@@ -1326,19 +718,19 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "15 FEB 2018"
+            "Value": "16 May 2016"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "15 FEB 2018"
+            "Value": "16 May 2016"
         },
         "Author": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
             },
-            "Value": "Dr. ABC123"
+            "Value": "Dr. X123 Y987"
         },
         "ActionContext": {
             "EntryType": {
@@ -1376,7 +768,13 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
                         },
-                        "Value": "15 May 2016"
+                        "Value": "16 May 2016"
+                    },
+                    "TimePeriodEnd": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodEnd"
+                        },
+                        "Value": "16 May 2019"
                     }
                 }
             }
@@ -1540,147 +938,7 @@
                 }
             }
         }
-    },    
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
-            }
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "25",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "23 FEB 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "23 FEB 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10042112",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://www.meddra.org"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Upset stomach"
-                    }
-                }
-            ]
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "AdverseEventGrade": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C1519275",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Grade 2"
-                        }
-                    }
-                ]
-            }
-        },
-        "CauseCategory": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "treatment",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "AttributionCategoryCS"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "treatment"
-                        }
-                    }
-                ]
-            }
-        },
-        "SourceClinicalNote": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1085",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-            }
-        }
     },
-
-
     {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "74",
@@ -1702,7 +960,7 @@
         },
         "Annotation": [
             {
-                "Value": "revealed 6cm mass in stomach",
+                "Value": "showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greater curvature",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
                 }
@@ -1785,7 +1043,109 @@
     },
     {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "50",
+        "EntryId": "48",
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/procedure/ProcedureRequested"
+        },
+        "LastUpdated": {
+            "Value": "27 Feb 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "Annotation": [
+            {
+                "Value": "was non-diagnostic",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
+        "CreationTime": {
+            "Value": "27 Feb 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "Type": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Type"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "53767003",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "CodeSystem": {
+                            "Value": "http://snomed.info/sct",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            }
+                        },
+                        "DisplayText": {
+                            "Value": "Endoscopic Biopsy",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "Value": "27 Feb 2016",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                }
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "49",
         "Subject": {
             "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
             "_EntryId": "1",
@@ -1804,7 +1164,7 @@
         },
         "Annotation": [
             {
-                "Value": "indicated diagnosis of malignant epithelioid gastrointestinal stromal tumor",
+                "Value": "confirmed GIST with 15 mitoses/50 HPF",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
                 }
@@ -1823,7 +1183,7 @@
             "Value": {
                 "Coding": [
                     {
-                        "Value": "86273004",
+                        "Value": "277591006",
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                         },
@@ -1834,7 +1194,7 @@
                             }
                         },
                         "DisplayText": {
-                            "Value": "Biopsy",
+                            "Value": "CT-guided biopsy",
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                             }
@@ -1906,7 +1266,7 @@
         },
         "Annotation": [
             {
-                "Value": "revealed 8cm tumor",
+                "Value": "confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
                 }
@@ -1992,663 +1352,6 @@
 
     {
         "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
-            }
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "79",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10037868",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://www.meddra.org"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Skin rash"
-                    }
-                }
-            ]
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "AdverseEventGrade": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C1519275",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Grade 2"
-                        }
-                    }
-                ]
-            }
-        },
-        "CauseCategory": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "treatment",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "AttributionCategoryCS"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "treatment"
-                        }
-                    }
-                ]
-            }
-        },
-        "SourceClinicalNote": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1085",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
-            }
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "80",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "30 JAN 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "30 JAN 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "10034580",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://www.meddra.org"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Peripheral motor neuropathy"
-                    }
-                }
-            ]
-        },
-        "Author": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
-            },
-            "Value": "Dr. ABC123"
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "AdverseEventGrade": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C1519275",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Grade 3"
-                        }
-                    }
-                ]
-            }
-        },
-        "CauseCategory": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "treatment",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "AttributionCategoryCS"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "treatment"
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "90",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "02 MAR 2016"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "02 MAR 2016"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C1546960",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Worsening, disease progressing"
-                    }
-                }
-            ]
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
-            }
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [],
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0421176",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
-                        }
-                    }
-                ]
-            }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "02 MAR 2018"
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "91",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "27 MAR 2017"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "27 MAR 2017"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205360",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Stable, neither improving nor worsening"
-                    }
-                }
-            ]
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
-            }
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [],
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0421176",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
-                        }
-                    }
-                ]
-            }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "27 JUN 2017"
-        }
-    },
-    {
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
-        },
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "EntryId": "92",
-        "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "CreationTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            },
-            "Value": "28 FEB 2018"
-        },
-        "LastUpdated": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            },
-            "Value": "28 FEB 2018"
-        },
-        "Value": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "C0205360",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://ncimeta.nci.nih.gov"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Stable, neither improving nor worsening"
-                    }
-                }
-            ]
-        },
-        "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-            }
-        },
-        "FocalSubjectReference": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "8",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
-            }
-        },
-        "FindingStatus": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-            },
-            "Coding": [
-                {
-                    "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                    },
-                    "Value": "final",
-                    "CodeSystem": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                        },
-                        "Value": "http://hl7.org/fhir/observation-status"
-                    },
-                    "DisplayText": {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                        },
-                        "Value": "Final"
-                    }
-                }
-            ]
-        },
-        "Evidence": [],
-        "ObservationCode": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
-            },
-            "Value": {
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
-                },
-                "Coding": [
-                    {
-                        "EntryType": {
-                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
-                        },
-                        "Value": "C0421176",
-                        "CodeSystem": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
-                            },
-                            "Value": "http://ncimeta.nci.nih.gov"
-                        },
-                        "DisplayText": {
-                            "EntryType": {
-                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
-                            },
-                            "Value": "Progression"
-                        }
-                    }
-                ]
-            }
-        },
-        "ClinicallyRelevantTime": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
-            },
-            "Value": "28 FEB 2018"
-        },
-        "SourceClinicalNote": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-            "_EntryId": "1085",
-            "_EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-            }
-        }
-    },
-    {
-        "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/allergy/NoKnownAllergy"
         },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
@@ -2710,13 +1413,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "12 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "12 FEB 2018"
+            "Value": "3 SEP 2018"
         },
         "ActionContext": {
             "EntryType": {
@@ -2727,7 +1430,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     },
-                    "Value": "Mr. Martinez45 had a Gastrointerstinal Stromal Tumor. Surgery resulting in complete resection"
+                    "Value": "Mr. Tnfinity6 had a Gastrointerstinal Stromal Tumor follow up."
                 }
             ],
             "Status": {
@@ -2746,7 +1449,7 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
                 },
-                "Value": "12 FEB 2018 15:00 -0500"
+                "Value": "3 SEP 2018 15:00 -0500"
             }
         },
         "Subject": {
@@ -2755,12 +1458,6 @@
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
             }
-        },
-        "ReferralDate": {
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/encounter/ReferralDate"
-            },
-            "Value": "01 JAN 2018"
         }
     },
     {
@@ -2780,13 +1477,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "02 JAN 2018"
+            "Value": "4 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "7 MAR 2018"
+            "Value": "4 SEP 2018"
         },
         "ActionContext": {
             "EntryType": {
@@ -2797,7 +1494,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     },
-                    "Value": "Mr. Martinez45 had a Gastrointerstinal Stromal Tumor follow up. Surgery resulting in complete resection"
+                    "Value": "Mr. Tnfinity6 requested a GIST follow up."
                 }
             ],
             "Status": {
@@ -2816,7 +1513,7 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
                 },
-                "Value": "7 MAR 2018 18:00 -0500"
+                "Value": "4 SEP 2018 18:00 -0500"
             }
         },
         "Subject": {
@@ -2850,13 +1547,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "ObservationCode": {
             "EntryType": {
@@ -3013,15 +1710,15 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
-        "Value": true,
+        "Value": false,
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
@@ -3031,18 +1728,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C50575",
+                    "Value": "10033371",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "alopecia"
+                        "Value": "pain"
                     }
                 }
             ]
@@ -3065,15 +1762,15 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
-        "Value": true,
+        "Value": false,
         "ObservationCode": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
@@ -3083,18 +1780,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C61443",
+                    "Value": "10012727",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "amenorrhea"
+                        "Value": "diarrhea"
                     }
                 }
             ]
@@ -3117,13 +1814,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": true,
         "ObservationCode": {
@@ -3135,18 +1832,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "C118263",
+                    "Value": "10047700",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "numbness or tingling in hands and feet"
+                        "Value": "vomiting"
                     }
                 }
             ]
@@ -3169,13 +1866,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3187,18 +1884,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10019211",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 4"
+                        "Value": "headache"
                     }
                 }
             ]
@@ -3221,13 +1918,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3244,7 +1941,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
@@ -3273,13 +1970,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3296,7 +1993,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
@@ -3325,13 +2022,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3343,18 +2040,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10000081",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 7"
+                        "Value": "Abdominal pain"
                     }
                 }
             ]
@@ -3377,13 +2074,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3395,18 +2092,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10047340",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 8"
+                        "Value": "Vertigo"
                     }
                 }
             ]
@@ -3429,13 +2126,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3447,18 +2144,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10008481",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 9"
+                        "Value": "Chest pain - cardiac"
                     }
                 }
             ]
@@ -3481,13 +2178,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3499,18 +2196,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10013963",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 10"
+                        "Value": "uncomfortable sensation of difficulty breathing"
                     }
                 }
             ]
@@ -3533,13 +2230,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3551,18 +2248,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10011224",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 11"
+                        "Value": "Cough"
                     }
                 }
             ]
@@ -3585,13 +2282,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3603,18 +2300,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10016558",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 12"
+                        "Value": "Fever"
                     }
                 }
             ]
@@ -3637,13 +2334,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3655,18 +2352,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10020407",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 13"
+                        "Value": "Hot flashes"
                     }
                 }
             ]
@@ -3689,13 +2386,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3707,18 +2404,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10028813",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 14"
+                        "Value": "Nausea"
                     }
                 }
             ]
@@ -3741,13 +2438,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "01 JAN 2018"
+            "Value": "3 SEP 2018"
         },
         "Value": false,
         "ObservationCode": {
@@ -3759,18 +2456,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "foo",
+                    "Value": "10037868",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://www.meddra.org"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Question 15"
+                        "Value": "rash"
                     }
                 }
             ]
@@ -5565,7 +4262,106 @@
             },
             "Value": "15 FEB 2018"
         }
-    }, 
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "2190",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "15 FEB 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 FEB 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 6,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "cm"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0475440",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Tumor Size"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "15 FEB 2016"
+        }
+    },
     {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
@@ -5583,13 +4379,13 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "7 APR 2018"
+            "Value": "7 APR 2016"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "7 APR 2018"
+            "Value": "7 APR 2016"
         },
         "Value": {
             "EntryType": {
@@ -5662,13 +4458,9 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
-            "Value": "7 APR 2018"
+            "Value": "7 APR 2016"
         }
     },
-
-
-
-
 
 
 
@@ -5678,7 +4470,7 @@
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
         "EntryId": "180",
         "Author": {
-            "Value": "Dr. ABC123",
+            "Value": "Dr. X123 Y987",
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
             }
@@ -5746,7 +4538,7 @@
                         "Value": {
                             "Coding": [
                                 {
-                                    "Value": "C1416655",
+                                    "Value": "C104668",
                                     "EntryType": {
                                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                                     },
@@ -5757,7 +4549,7 @@
                                         }
                                     },
                                     "DisplayText": {
-                                        "Value": "KIT Gene",
+                                        "Value": "KIT exon 11 mutation",
                                         "EntryType": {
                                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                                         }
@@ -5885,18 +4677,18 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "46333007",
+                    "Value": "261638004",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "urn:oid:2.16.840.1.113883.6.96"
+                        "Value": "http://snomed.info/sct"
                     },
                     "DisplayText": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "IB"
+                        "Value": "IIIA"
                     }
                 }
             ]
@@ -6080,55 +4872,36 @@
             },
             {
                 "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/oncology/MitoticCountScore"
+                    "Value": "http://standardhealthrecord.org/spec/shr/oncology/MitoticRate"
                 },
                 "Value": {
                     "EntryType": {
-                        "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
                     },
-                    "Value": 1
+                    "Coding": [
+                        {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "C35960",
+                            "CodeSystem": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                },
+                                "Value": "http://ncimeta.nci.nih.gov"
+                            },
+                            "DisplayText": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                },
+                                "Value": "high"
+                            }
+                        }
+                    ]
                 }
            }
         ]
         
-    },
-    {
-        "signedOn": "17 Jul 2018",
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-        "signed": true,
-        "subject": "Treatment Check-in",
-        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with @condition[[Gastrointestinal stromal tumor]]. He was feeling sharp pains in his stomach. A @procedure[[CT scan]] showed a mass in his stomach measuring 1.6 cm.\nA @procedure[[biopsy]] was performed identifying malignant epithelioid gastrointestinal stromal tumor. @procedure[[Surgery]] was performed on 7 Apr 2016 by Dr. Ford which resulted in a complete resection. Stage IB pT3N0 w/ mitotic count score 1. KIT testing was positive, PDGFRA testing was negative.\n\nPt began taking Imatinib (one 400mg tablet per day) on May 15, 2016 as adjuvant therapy, which will continue for one year after surgery.\n\nASSESSMENT:\nAlthough his #disease status is #stable #as of #2/28/2018, he is experiencing #toxicity #Grade 2 #Stomach pain and #toxicity #Grade 2 #Rash maculo-papular.",
-        "EntryId": "1085",
-        "hospital": "Hospital X",
-        "createdBy": "Dr. Smith", 
-        "signedBy": "Dr. Smith",
-        "EntryType": {
-            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
-        },
-        "LastUpdated": {
-            "Value": "15 Oct 2018",
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
-            }
-        },
-        "CreationTime": {
-            "Value": "15 Oct 2018",
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
-            }
-        },
-        "PersonOfRecord": {
-            "Value": {
-                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
-                "EntryId": "1",
-                "EntryType": {
-                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
-                }
-            },
-            "EntryType": {
-                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
-            }
-        }
     },
     {
         "EntryType": {
@@ -6211,7 +4984,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://snomed.info/sct"
                     },
                     "DisplayText": {
                         "EntryType": {
@@ -6310,7 +5083,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
                         },
-                        "Value": "http://ncimeta.nci.nih.gov"
+                        "Value": "http://snomed.info/sct"
                     },
                     "DisplayText": {
                         "EntryType": {
@@ -6326,6 +5099,4590 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
             "Value": "13 Apr 2016"
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorMargins"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "2500",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "7 Apr 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "7 Apr 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205160",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Negative"
+                    }
+                }
+            ]
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "395536008",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://snomed.info/sct"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Surgical Margin"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "7 Apr 2016"
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "3000",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "2 FEB 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 FEB 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Mr. Tnfinity6 is having abdominal pains."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "15 FEB 2016 15:00 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "3010",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "7 APR 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "16 May 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Mr. Tnfinity6 just had surgery for his GIST. High-risk GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "16 May 2016 14:00 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "15 Feb 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Primary Care Check-up",
+        "content": "REASON FOR VISIT:\nCheck-up\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature.\n\nASSESSMENT:\nHe is experiencing #toxicity #Grade 3 #Stomach pain.\n\nPHYSICAL EXAM:\nVitals normal. Slight firmess in upper abdomen. No sensitivty to pressure.\n\nPLAN:\nOrder EGD with EUS.",
+        "EntryId": "5000",
+        "hospital": "Smith952 Practice",
+        "createdBy": "Dr. Smith952", 
+        "signedBy": "Dr. Smith952",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "15 Feb 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 Feb 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5010",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "15 Feb 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 Feb 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10042112",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stomach pain"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. Smith952"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1519275",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 3"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "disease",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "disease"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5000",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5100",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "3 Mar 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "3 Mar 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Consult for abdominal pains."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "3 Mar 2016 16:20 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "3 Mar 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Consult",
+        "content": "REASON FOR VISIT:\nMed Onc Consult\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy.\n\nASSESSMENT:\nEndoscopic biopsy which was non-deterministic.\n\nPLAN:\nOrder CT-guided biopsy.",
+        "EntryId": "5110",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987", 
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "3 Mar 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "3 Mar 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5150",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "19 Mar 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "19 Mar 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up after biopsy."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "19 Mar 2016 9:50 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "19 Mar 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic.\n\nHISTORY OF PRESENT ILLNESS:\nCT-guided biopsy peformed.\n\nASSESSMENT:\nCT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgical consult w/ Dr. Cheung564.\n\nPLAN:\nScheduling for surgery.",
+        "EntryId": "5160",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987", 
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "19 Mar 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Mar 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "signedOn": "7 Apr 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Post-Op",
+        "content": "REASON FOR VISIT:\nSurgery\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf.\n\nHISTORY OF PRESENT ILLNESS:\nSurgery to remove GIST from stomach.\n\nASSESSMENT:\nconfirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm.",
+        "EntryId": "5200",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. Cheung564", 
+        "signedBy": "Dr. Cheung564",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "7 Apr 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "7 Apr 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "signedOn": "16 May 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf.\n\nHISTORY OF PRESENT ILLNESS:\nSurgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm.\n\nASSESSMENT:\nSurgery successful.\n\nPLAN:\nDetermined to have high risk GIST. Primary KIT exon 11 mutation at the 557/558 position. Placed on Imatinib 400 mg/day starting on 16 May. Plan for 3 years total of adjuvant therapy.",
+        "EntryId": "5250",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987", 
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "16 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "16 May 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    }
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5300",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "15 June 2016 9:20 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "15 Jun 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches. Follow-up in a month.",
+        "EntryId": "5310",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "15 Jun 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 Jun 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5320",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5310",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5330",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "15 Jun 2016"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5310",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "5340",
+        "Author": {
+            "Value": "Dr. X123 Y987",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            }
+        },
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "LastUpdated": {
+            "Value": "15 Jun 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "15 Jun 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "Dosage": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
+            },
+            "DoseAmount": {
+                "Value": {
+                    "Value": 1,
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
+                    },
+                    "Units": {
+                        "Value": {
+                            "Value": "tablet",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            }
+                        },
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        }
+                    }
+                },
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                }
+            },
+            "AsNeededIndicator": {
+                "Value": true,
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                }
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                },
+                "Value": {
+                    "Coding": [
+                        {
+                            "Value": "26643006",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "CodeSystem": {
+                                "Value": "http://snomed.info/sct",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                }
+                            },
+                            "DisplayText": {
+                                "Value": "Oral route",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                }
+                            }
+                        }
+                    ],
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    }
+                }
+            },
+            "TimingOfDoses": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
+                    },
+                    "TimingCode": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
+                        },
+                        "Value": {
+                            "Coding": [
+                                {
+                                    "Value": "TID",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                    },
+                                    "CodeSystem": {
+                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation",
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                        }
+                                    },
+                                    "DisplayText": {
+                                        "Value": "TID",
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                        }
+                                    }
+                                }
+                            ],
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            }
+                        }
+                    }
+                }
+            },
+            "AdditionalDoseInstruction": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/medication/AdditionalDoseInstruction"
+                    },
+                    "Value": {
+                        "Coding": [
+                            {
+                                "Value": "311504000",
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                },
+                                "CodeSystem": {
+                                    "Value": "http://snomed.info/sct",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                    }
+                                },
+                                "DisplayText": {
+                                    "Value": "With or after food",
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                    }
+                                }
+                            }
+                        ],
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                        }
+                    }
+                }
+            ]
+        },
+        "ActionContext": {
+            "Status": {
+                "Value": "completed",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    },
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    }
+                }
+            ],
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodStart": {
+                        "Value": "15 Jun 2016",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        }
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "Coding": [
+                    {
+                        "Value": "316077",
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "DisplayText": {
+                            "Value": "ibuprofen 600mg tablet",
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            }
+                        }
+                    }
+                ],
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                }
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5400",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST. Experiencing skin rashes."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "19 Jul 2016 9:20 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "19 Jul 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches and skin rashes.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #toxicity #Rash maculo-papular #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches. Use hydrocortizone as needed for rashses. Follow-up in a month.",
+        "EntryId": "5410",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "19 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "19 Jul 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5420",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5410",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5425",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10037868",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Rash maculo-papular"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5410",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5430",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5410",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/medication/MedicationRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5440",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "19 Jul 2016"
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": {
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                        "_EntryId": "8",
+                        "_EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
+                        }
+                    }
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriod"
+                    },
+                    "TimePeriodStart": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimePeriodStart"
+                        },
+                        "Value": "19 Jul 2016"
+                    }
+                }
+            }
+        },
+        "MedicationOrCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/MedicationOrCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "310891",
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "hydrocortisone 2.5% ointment"
+                        }
+                    }
+                ]
+            }
+        },
+        "Dosage": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/medication/Dosage"
+            },
+            "DoseAmount": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/DoseAmount"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/SimpleQuantity"
+                    },
+                    "Value": 1,
+                    "Units": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        },
+                        "Value": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "g"
+                        }
+                    }
+                }
+            },
+            "TimingOfDoses": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/TimingOfDoses"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Timing"
+                    },
+                    "TimingCode": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/TimingCode"
+                        },
+                        "Value": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                            },
+                            "Coding": [
+                                {
+                                    "EntryType": {
+                                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                                    },
+                                    "Value": "BID",
+                                    "CodeSystem": {
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                        },
+                                        "Value": "http://hl7.org/fhir/v3/GTSAbbreviation"
+                                    },
+                                    "DisplayText": {
+                                        "EntryType": {
+                                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                        },
+                                        "Value": "BID"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "AsNeededIndicator": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/AsNeededIndicator"
+                },
+                "Value": true
+            },
+            "RouteIntoBody": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/medication/RouteIntoBody"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "Coding": [
+                        {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "6064005",
+                            "CodeSystem": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                },
+                                "Value": "http://snomed.info/sct"
+                            },
+                            "DisplayText": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                },
+                                "Value": "Topical route"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5500",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "22 Oct 2016 9:30 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "22 Oct 2016",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches still but ibuprofen helps. Experiencing mild skin rashes but hydrocortisone helps.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #toxicity #Rash maculo-papular #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches and use hyrdrocortizone for rashes. Follow-up in 3 months.",
+        "EntryId": "5510",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "22 Oct 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 Oct 2016",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5520",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5510",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5525",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10037868",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Rash maculo-papular"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5510",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5530",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "22 Oct 2016"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5510",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    }
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5600",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "22 Jan 2017 10:20 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "22 Jan 2017",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches and skin rashes.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #toxicity #Rash maculo-papular #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches and use hyrdrocortizone for rashes. Follow-up in 6 months.",
+        "EntryId": "5610",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "22 Jan 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 Jan 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5620",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5610",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5625",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10037868",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Rash maculo-papular"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5610",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5630",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "22 Jan 2017"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5610",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    }
+
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5700",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "14 Jul 2017 10:00 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "14 Jul 2017",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches and skin rashes.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #toxicity #Rash maculo-papular #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches and use hyrdrocortizone for rashes. Follow-up in 6 months.",
+        "EntryId": "5710",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "14 Jul 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "14 Jul 2017",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5720",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5710",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5725",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10037868",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Rash maculo-papular"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5710",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5730",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "14 Jul 2017"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5710",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    }
+
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5800",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "22 Jan 2018 9:00 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "22 Jan 2018",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches and skin rashes.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #toxicity #Rash maculo-papular #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches and use hyrdrocortizone for rashes. Follow-up in 6 months.",
+        "EntryId": "5810",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "22 Jan 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "22 Jan 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5820",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5810",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5825",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10037868",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Rash maculo-papular"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5810",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5830",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "22 Jan 2018"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5810",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    }
+
+
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/encounter/EncounterRequested"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5900",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "ActionContext": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/action/RequestedContext"
+            },
+            "Reason": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
+                    },
+                    "Value": "Follow up during adjuvant for GIST."
+                }
+            ],
+            "Status": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/Status"
+                },
+                "Value": "completed"
+            },
+            "RequestIntent": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/RequestIntent"
+                },
+                "Value": "plan"
+            },
+            "ExpectedPerformanceTime": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/action/ExpectedPerformanceTime"
+                },
+                "Value": "17 Jul 2018 13:45 -0500"
+            }
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        }
+    },
+    {
+        "signedOn": "17 Jul 2018",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "signed": true,
+        "subject": "Med Onc Follow-up",
+        "content": "REASON FOR VISIT:\nFollow-up for @Condition[[Gastrointestinal stromal tumor]]\n\nONCOLOGY HISTORY:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature. Underwent endoscopic biopsy which was non-deterministic. CT-guided biopsy revealed GIST with 15 mitosis/50 hpf. Surgery confirmed GIST. 20 mitoses/50 HPF. Surgical margins negative. Final tumor size 8cm. Adjuvant imatinib starting 16 May 2016.\n\nHISTORY OF PRESENT ILLNESS:\nExperiencing mild headaches and skin rashes.\n\nASSESSMENT:\n#toxicity #headache #grade 2. #toxicity #Rash maculo-papular #grade 2. #disease status #stable\n\nPLAN:\nContinue imatinib. Take ibuprofen as needed for headaches and use hyrdrocortizone for rashes. Follow-up in 6 months.",
+        "EntryId": "5910",
+        "hospital": "Hospital X",
+        "createdBy": "Dr. X123 Y987",
+        "signedBy": "Dr. X123 Y987",
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+        },
+        "LastUpdated": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            }
+        },
+        "CreationTime": {
+            "Value": "17 Jul 2018",
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            }
+        },
+        "PersonOfRecord": {
+            "Value": {
+                "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "EntryId": "1",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+                }
+            },
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5920",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10019211",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Headache"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5910",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5925",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "10037868",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://www.meddra.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Rash maculo-papular"
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/Author"
+            },
+            "Value": "Dr. X123 Y987"
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "AdverseEventGrade": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/AdverseEventGrade"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C1513374",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Grade 2"
+                        }
+                    }
+                ]
+            }
+        },
+        "CauseCategory": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/adverse/CauseCategory"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "treatment",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "AttributionCategoryCS"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "treatment"
+                        }
+                    }
+                ]
+            }
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5910",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/condition/DiseaseProgression"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "5930",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "C0205360",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Stable, neither improving nor worsening"
+                    }
+                }
+            ]
+        },
+        "Subject": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "Evidence": [],
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ObservationCode"
+            },
+            "Value": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                },
+                "Coding": [
+                    {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                        },
+                        "Value": "C0421176",
+                        "CodeSystem": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                            },
+                            "Value": "http://ncimeta.nci.nih.gov"
+                        },
+                        "DisplayText": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                            },
+                            "Value": "Progression"
+                        }
+                    }
+                ]
+            }
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "17 Jul 2018"
+        },
+        "SourceClinicalNote": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "5910",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
+            }
         }
     }
 ]

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -940,10 +940,10 @@
         }
     },
     {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "74",
         "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1003,7 +1003,7 @@
             }
         },
         "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1022,7 +1022,7 @@
             "Reason": [
                 {
                     "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
@@ -1042,10 +1042,10 @@
         }
     },
     {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "48",
         "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1105,7 +1105,7 @@
             }
         },
         "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1124,7 +1124,7 @@
             "Reason": [
                 {
                     "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
@@ -1144,10 +1144,10 @@
         }
     },
     {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "49",
         "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1207,7 +1207,7 @@
             }
         },
         "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1226,7 +1226,7 @@
             "Reason": [
                 {
                     "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
@@ -1246,10 +1246,10 @@
         }
     },
     {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "65",
         "Subject": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1309,7 +1309,7 @@
             }
         },
         "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -1328,7 +1328,7 @@
             "Reason": [
                 {
                     "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"
@@ -4467,7 +4467,7 @@
 
 
     {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "180",
         "Author": {
             "Value": "Dr. X123 Y987",
@@ -4491,7 +4491,7 @@
             }
         },
         "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -6163,7 +6163,7 @@
         }
     },
     {
-        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "5340",
         "Author": {
             "Value": "Dr. X123 Y987",
@@ -6187,7 +6187,7 @@
             }
         },
         "PersonOfRecord": {
-            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
             "_EntryId": "1",
             "_EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
@@ -6341,7 +6341,7 @@
             "Reason": [
                 {
                     "Value": {
-                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+                        "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                         "_EntryId": "8",
                         "_EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/condition/Condition"

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -575,6 +575,20 @@
                 "_EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/TNMStage"
                 }
+            },
+            {
+                "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "_EntryId": "2300",
+                "_EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+                }
+            },
+            {
+                "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "_EntryId": "2310",
+                "_EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+                }
             }
         ],
         "Category": [
@@ -6114,6 +6128,204 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/PersonOfRecord"
             }
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "2300",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "22 Mar 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "22 Mar 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 15,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "per 50 hpf"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "7041004",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Mitosis"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "22 Mar 2016"
+        }
+    },
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/finding/Observation"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "2310",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "13 Apr 2016"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "13 Apr 2016"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 20,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "per 50 hpf"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "7041004",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://ncimeta.nci.nih.gov"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Mitosis"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "13 Apr 2016"
         }
     }
 ]

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -561,7 +561,14 @@
                 "_EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/oncology/HistologicGrade"
                 }
-            },            
+            },
+            {
+                "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+                "_EntryId": "2200",
+                "_EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/oncology/TumorDimensions"
+                }
+            },
             {
                 "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
                 "_EntryId": "2210",
@@ -1681,7 +1688,7 @@
         },
         "Annotation": [
             {
-                "Value": "revealed 1.6cm mass in stomach",
+                "Value": "revealed 6cm mass in stomach",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
                 }
@@ -1783,7 +1790,7 @@
         },
         "Annotation": [
             {
-                "Value": "indicate diagnosis of malignant epithelioid gastrointestinal stromal tumor",
+                "Value": "indicated diagnosis of malignant epithelioid gastrointestinal stromal tumor",
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
                 }
@@ -1883,6 +1890,14 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             }
         },
+        "Annotation": [
+            {
+                "Value": "revealed 8cm tumor",
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Annotation"
+                }
+            }
+        ],
         "CreationTime": {
             "Value": "7 Apr 2016",
             "EntryType": {
@@ -5554,19 +5569,19 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
             },
-            "Value": "15 FEB 2018"
+            "Value": "7 APR 2018"
         },
         "LastUpdated": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
             },
-            "Value": "15 FEB 2018"
+            "Value": "7 APR 2018"
         },
         "Value": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
             },
-            "Value": 1.6,
+            "Value": 8,
             "Units": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
@@ -5633,7 +5648,7 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
-            "Value": "15 FEB 2018"
+            "Value": "7 APR 2018"
         }
     },
 
@@ -5647,7 +5662,7 @@
 
     {
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
-        "EntryId": "18",
+        "EntryId": "180",
         "Author": {
             "Value": "Dr. ABC123",
             "EntryType": {
@@ -5867,7 +5882,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "IA"
+                        "Value": "IB"
                     }
                 }
             ]
@@ -5896,7 +5911,7 @@
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                             },
-                            "Value": "AJCC Breast Carcinoma Version 7"
+                            "Value": "AJCC GIST Version 7"
                         }
                     }
                 ]
@@ -5972,7 +5987,7 @@
                             "EntryType": {
                                 "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                             },
-                            "Value": "39193015",
+                            "Value": "369918000",
                             "CodeSystem": {
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
@@ -5983,7 +5998,7 @@
                                 "EntryType": {
                                     "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                                 },
-                                "Value": "T1"
+                                "Value": "T3"
                             }
                         }
                     ]
@@ -6068,7 +6083,7 @@
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "signed": true,
         "subject": "Treatment Check-in",
-        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with @condition[[Gastrointestinal stromal tumor]]. He was feeling sharp pains in his stomach. A @procedure[[CT scan]] showed a mass in his stomach measuring 1.6 cm.\nA @procedure[[biopsy]] was performed identifying malignant epithelioid gastrointestinal stromal tumor. @procedure[[Surgery]] was performed on 7 Apr 2016 by Dr. Ford which resulted in a complete resection. Stage IA pT1N0 disease with mitotic count score of 1. KIT testing was positive, PDGFRA testing was negative.\n\nPt began taking Imatinib (one 400mg tablet per day) on May 15, 2016 as adjuvant therapy, which will continue for one year after surgery.\n\nASSESSMENT:\nAlthough his #disease status is #stable #as of #2/28/2018, he is experiencing #toxicity #Grade 2 #Stomach pain and #toxicity #Grade 2 #Rash maculo-papular.",
+        "content": "REASON FOR VISIT:\nTreatment Progress\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with @condition[[Gastrointestinal stromal tumor]]. He was feeling sharp pains in his stomach. A @procedure[[CT scan]] showed a mass in his stomach measuring 1.6 cm.\nA @procedure[[biopsy]] was performed identifying malignant epithelioid gastrointestinal stromal tumor. @procedure[[Surgery]] was performed on 7 Apr 2016 by Dr. Ford which resulted in a complete resection. Stage IB pT3N0 w/ mitotic count score 1. KIT testing was positive, PDGFRA testing was negative.\n\nPt began taking Imatinib (one 400mg tablet per day) on May 15, 2016 as adjuvant therapy, which will continue for one year after surgery.\n\nASSESSMENT:\nAlthough his #disease status is #stable #as of #2/28/2018, he is experiencing #toxicity #Grade 2 #Stomach pain and #toxicity #Grade 2 #Rash maculo-papular.",
         "EntryId": "1085",
         "hospital": "Hospital X",
         "createdBy": "Dr. Smith", 

--- a/src/model/finding/FluxObservation.js
+++ b/src/model/finding/FluxObservation.js
@@ -37,7 +37,7 @@ class FluxObservation extends FluxEntry {
     }
 
     get codeableConceptCode() { 
-        if (this._observation.observationCode.coding.length > 0) { 
+        if (this._observation.observationCode && this._observation.observationCode.coding && this._observation.observationCode.coding.length > 0) { 
             return this._observation.observationCode.coding[0].code;
         } else { 
             return null;

--- a/src/model/oncology/FluxBreastCancer.js
+++ b/src/model/oncology/FluxBreastCancer.js
@@ -48,10 +48,10 @@ class FluxBreastCancer extends FluxSolidTumorCancer {
         const tumorSize = this.getObservationsOfType(FluxTumorDimensions);
         const histologicGrade = this.getObservationsOfType(FluxHistologicGrade);
         if (tumorSize.length > 0) {
-            hpiText += ` Primary tumor size was ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
+            hpiText += ` Primary tumor size ${tumorSize[0].quantity.value} ${tumorSize[0].quantity.unit}.`;
         }
         if (histologicGrade.length > 0) {
-            hpiText += ` Histological grade was ${histologicGrade[0].grade}.`;
+            hpiText += ` Histological grade ${histologicGrade[0].grade}.`;
         }
 
         // ER, PR, HER2

--- a/src/model/oncology/FluxGastrointestinalStromalTumor.js
+++ b/src/model/oncology/FluxGastrointestinalStromalTumor.js
@@ -1,11 +1,69 @@
 import FluxSolidTumorCancer from './FluxSolidTumorCancer';
 import Condition from '../shr/condition/Condition';
+import FluxHistologicGrade from './FluxHistologicGrade';
+import FluxTumorDimensions from '../oncology/FluxTumorDimensions';
+import Lang from 'lodash';
 
 class FluxGastrointestinalStromalTumor extends FluxSolidTumorCancer {
     constructor(json, patientRecord) {
         super();
         this._patientRecord = patientRecord;
         this._condition = Condition.fromJSON(json);
+    }
+
+    /**
+     *  function to build HPI Narrative
+     *  Starts with initial summary of patient information
+     *  Then details chronological history of patient's procedures, medications, and most recent progression
+     */
+    buildHpiNarrative(patient) {
+        let hpiText = this.buildInitialPatientDiagnosisPreamble(patient);
+        
+        // Staging
+        const staging = this.getMostRecentStaging();
+        if (staging) {
+            if (staging.stage) {
+                hpiText += ` Stage ${staging.stage}`;
+            }
+            if (!Lang.isUndefined(staging.t_Stage) && !Lang.isNull(staging.t_Stage)) {
+                hpiText += ` ${staging.t_Stage}`;
+            }
+            if (!Lang.isUndefined(staging.n_Stage) && !Lang.isNull(staging.n_Stage)) {
+                hpiText += ` ${staging.n_Stage}`;
+            }
+            if (!Lang.isUndefined(staging.m_Stage) && !Lang.isNull(staging.m_Stage) && staging.m_Stage !== 'M0') { // don't show m if it is 0
+                hpiText += ` ${staging.m_Stage}`;
+            }
+            if (staging.mitoticCountScore) {
+                hpiText += `. Mitotic count score ${staging.mitoticCountScore}`;
+            }
+            hpiText += '.';
+        }
+
+        // Tumor Size and HistologicGrade
+        const tumorSize = this.getObservationsOfType(FluxTumorDimensions);
+        const histologicGrade = this.getObservationsOfType(FluxHistologicGrade);
+        if (tumorSize.length > 0) {
+            hpiText += ` Primary tumor size ${tumorSize[tumorSize.length - 1].quantity.value} ${tumorSize[tumorSize.length - 1].quantity.unit}.`;
+        }
+        if (histologicGrade.length > 0) {
+            hpiText += ` ${histologicGrade[0].grade}.`;
+        }
+
+        // genetics
+        const geneticpanels = patient.getGastrointestinalStromalTumorCancerGeneticAnalysisPanelsChronologicalOrder();
+        const geneticspanelMostRecent = geneticpanels[geneticpanels.length - 1];
+        if (geneticpanels && geneticpanels.length > 0) {
+            const panel = geneticpanels.pop();
+            hpiText += " " + panel.members.map((item) => {
+                const v = item.value === 'Positive' ? '+' : '-';
+                return item.abbreviatedName + v;
+            }).join(",");
+        }
+
+        hpiText = this.buildEventNarrative(hpiText, patient, this.code);
+        
+        return hpiText;
     }
 }
 export default FluxGastrointestinalStromalTumor;

--- a/src/model/oncology/FluxGastrointestinalStromalTumor.js
+++ b/src/model/oncology/FluxGastrointestinalStromalTumor.js
@@ -11,6 +11,12 @@ class FluxGastrointestinalStromalTumor extends FluxSolidTumorCancer {
         this._condition = Condition.fromJSON(json);
     }
 
+    getMostRecentMitosis() {
+        let results = this.getObservationsWithObservationCodeChronologicalOrder('7041004'); // code for mitosis observations
+        if (!results || results.length === 0) return null;
+        return results.pop();
+    }
+
     /**
      *  function to build HPI Narrative
      *  Starts with initial summary of patient information
@@ -34,8 +40,8 @@ class FluxGastrointestinalStromalTumor extends FluxSolidTumorCancer {
             if (!Lang.isUndefined(staging.m_Stage) && !Lang.isNull(staging.m_Stage) && staging.m_Stage !== 'M0') { // don't show m if it is 0
                 hpiText += ` ${staging.m_Stage}`;
             }
-            if (staging.mitoticCountScore) {
-                hpiText += `. Mitotic count score ${staging.mitoticCountScore}`;
+            if (staging.mitoticRate) {
+                hpiText += `. Mitotic rate ${staging.mitoticRate}`;
             }
             hpiText += '.';
         }
@@ -52,7 +58,7 @@ class FluxGastrointestinalStromalTumor extends FluxSolidTumorCancer {
 
         // genetics
         const geneticpanels = patient.getGastrointestinalStromalTumorCancerGeneticAnalysisPanelsChronologicalOrder();
-        const geneticspanelMostRecent = geneticpanels[geneticpanels.length - 1];
+        //const geneticspanelMostRecent = geneticpanels[geneticpanels.length - 1];
         if (geneticpanels && geneticpanels.length > 0) {
             const panel = geneticpanels.pop();
             hpiText += " " + panel.members.map((item) => {

--- a/src/model/oncology/FluxKITVariant.js
+++ b/src/model/oncology/FluxKITVariant.js
@@ -6,7 +6,7 @@ class FluxKITVariant {
     }
     
     get abbreviatedName() {
-        return 'KIT';
+        return this._kitVariant.focalSubject.value.coding[0].displayText.value || 'KIT';
     }
 
     get value() {

--- a/src/model/oncology/FluxMitoticRate.js
+++ b/src/model/oncology/FluxMitoticRate.js
@@ -1,0 +1,14 @@
+import ObservationComponent from '../shr/finding/ObservationComponent';
+
+class FluxMitoticRate {
+    constructor(json, patientRecord) {
+        this._patientRecord = patientRecord;
+        this._observationComponent = ObservationComponent.fromJSON(json);
+    }
+
+    get value() {
+        return this._observationComponent.value.coding[0].displayText.value;
+    }
+}
+
+export default FluxMitoticRate;

--- a/src/model/oncology/FluxOncologyObjectFactory.js
+++ b/src/model/oncology/FluxOncologyObjectFactory.js
@@ -9,7 +9,9 @@ import FluxHER2ReceptorStatus from './FluxHER2ReceptorStatus';
 import FluxProgesteroneReceptorStatus from './FluxProgesteroneReceptorStatus';
 import FluxHistologicGrade from './FluxHistologicGrade';
 import FluxTNMStage from './FluxTNMStage';
+import FluxMitoticRate from './FluxMitoticRate';
 import FluxTumorDimensions from './FluxTumorDimensions';
+import FluxTumorMargins from './FluxTumorMargins';
 import FluxGastrointestinalStromalTumor from './FluxGastrointestinalStromalTumor';
 import FluxGastrointestinalStromalTumorCancerGeneticAnalysisPanel from './FluxGastrointestinalStromalTumorCancerGeneticAnalysisPanel';
 import FluxKITVariant from './FluxKITVariant';
@@ -33,11 +35,12 @@ export default class FluxOncologyObjectFactory {
             case 'HistologicGrade': return new FluxHistologicGrade(json);
             case 'TNMStage': return new FluxTNMStage(json);
             case 'TumorDimensions': return new FluxTumorDimensions(json);
-
+            case 'TumorMargins': return new FluxTumorMargins(json, patientRecord);
             case 'GastrointestinalStromalTumor': return new FluxGastrointestinalStromalTumor(json, patientRecord);
             case 'GastrointestinalStromalTumorCancerGeneticAnalysisPanel': return new FluxGastrointestinalStromalTumorCancerGeneticAnalysisPanel(json, patientRecord);
             case 'KITVariant': return new FluxKITVariant(json, patientRecord);
             case 'PDGFRAVariant': return new FluxPDGFRAVariant(json, patientRecord);
+            case 'MitoticRate': return new FluxMitoticRate(json, patientRecord);
             default: return ShrOncologyObjectFactory.createInstance(json, type);
         }
     }

--- a/src/model/oncology/FluxTNMStage.js
+++ b/src/model/oncology/FluxTNMStage.js
@@ -3,10 +3,10 @@ import N_Stage from '../shr/oncology/N_Stage';
 import ClinicallyRelevantTime from '../shr/finding/ClinicallyRelevantTime';
 import TNMStage from '../shr/oncology/TNMStage';
 import T_Stage from '../shr/oncology/T_Stage';
-import MitoticCountScore from '../shr/oncology/MitoticCountScore'
 import Entry from '../shr/base/Entry';
 import EntryType from '../shr/base/EntryType';
 import FluxObservation from '../finding/FluxObservation';
+import FluxMitoticRate from './FluxMitoticRate';
 import lookup from '../../lib/tnmstage_lookup.jsx';
 import staging from '../../lib/staging.jsx';
 
@@ -134,12 +134,12 @@ class FluxTNMStage extends FluxObservation {
         this._calculateStage();
     }
 
-    get mitoticCountScore() {
-        const mitoticCountScore = this._observation._observationComponent.find(o => {
-            return o instanceof MitoticCountScore;
+    get mitoticRate() {
+        const mitoticRate = this._observation._observationComponent.find(o => {
+            return o instanceof FluxMitoticRate;
         });
-        if (!mitoticCountScore) return null;
-        return mitoticCountScore.value.decimal.toString();
+        if (!mitoticRate) return null;
+        return mitoticRate.value;
     }
 
     /*

--- a/src/model/oncology/FluxTumorMargins.js
+++ b/src/model/oncology/FluxTumorMargins.js
@@ -1,0 +1,18 @@
+import TumorMargins from '../shr/oncology/TumorMargins';
+
+class FluxTumorMargins {
+    constructor(json, patientRecord) {
+        this._patientRecord = patientRecord;
+        this._tumorMargins = TumorMargins.fromJSON(json);
+    }
+
+    get entryInfo() {
+        return this._tumorMargins.entryInfo;
+    }
+
+    get value() {
+        return this._tumorMargins.value.coding[0].displayText.value;
+    }
+}
+
+export default FluxTumorMargins;

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -75,6 +75,7 @@ class PatientRecord {
 
         if (entry.entryInfo.sourceClinicalNote) {
             let clinicalNote = this.getEntryFromReference(entry.entryInfo.sourceClinicalNote);
+            if (!clinicalNote) return true;
             return !clinicalNote.signed;
         }
         return false;
@@ -312,8 +313,12 @@ class PatientRecord {
         });
 
         result = `A complete ${members.length} point ROS was done and was unremarkable`;
-        if (trueAnswers.length > 0) {
+        if (trueAnswers.length >= 3) {
             result += ` except for ${trueAnswers.slice(0, -1).join(", ")}, and ${trueAnswers.slice(-1)[0]}`;
+        } else if (trueAnswers.length === 2) {
+            result += ` except for ${trueAnswers.join(" and ")}`;
+        } else if (trueAnswers.length === 1) {
+            result += ` except for ${trueAnswers[0]}`;
         }
 
         return result + ".";

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -778,22 +778,22 @@ export default class SummaryMetadata {
                                 ]
                             },
                             {
-                                defaultTemplate: "${Key Toxicities.Skin Rashes} skin rashes.",
-                                dataMissingTemplate: "no skin rashes.",
+                                defaultTemplate: "${Key Toxicities.Skin Rashes} skin rashes,",
+                                dataMissingTemplate: "no skin rashes,",
                                 useDataMissingTemplateCriteria: [
                                     "Key Toxicities.Skin Rashes"
                                 ]
                             },
                             {
-                                defaultTemplate: "${Key Toxicities.Vomiting} vomiting.",
-                                dataMissingTemplate: "no vomiting.",
+                                defaultTemplate: "${Key Toxicities.Vomiting} vomiting,",
+                                dataMissingTemplate: "no vomiting,",
                                 useDataMissingTemplateCriteria: [
                                     "Key Toxicities.Vomiting"
                                 ]
                             },
                             {
-                                defaultTemplate: "${Key Toxicities.Diarrhea} diarrhea.",
-                                dataMissingTemplate: "no diarrhea.",
+                                defaultTemplate: "${Key Toxicities.Diarrhea} diarrhea,",
+                                dataMissingTemplate: "no diarrhea,",
                                 useDataMissingTemplateCriteria: [
                                     "Key Toxicities.Diarrhea"
                                 ]

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -946,11 +946,6 @@ export default class SummaryMetadata {
                                     },
                                     {
                                         low: 3,
-                                        high: 5,
-                                        assessment: 'average'
-                                    },
-                                    {
-                                        low: 5,
                                         high: 10,
                                         assessment: 'good'
                                     },
@@ -976,11 +971,6 @@ export default class SummaryMetadata {
                                     },
                                     {
                                         low: 1,
-                                        high: 1.5,
-                                        assessment: 'average'
-                                    },
-                                    {
-                                        low: 1.5,
                                         high: 8,
                                         assessment: 'good'
                                     },

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -306,7 +306,7 @@ export default class TabularListVisualizer extends Component {
             // If this section has an associated formatFunction (that
             // returns a specific) CSS class, it is applied to elementText.
             if (formatFunction) {
-                itemClass += " " + formatFunction(elementText);
+                itemClass += " " + formatFunction(elementText, element, arrayIndex);
             }
             
 


### PR DESCRIPTION
… to have GIST-specific data

JIRA 1318. Added GIST-specific data to @HPI (which will become @ONCOHIST via another pull request)
JIRA 1328. Added tabular view for lab section. Actually supports tabular view for any section producing ValueOverTime formatted data.
JIRA 1329. Updated sarcoma patient, summary, @ROS, key toxicities, staging, ... lot of work started by @laclark22 

Added mitosis observations to be complete. Not currently visualized anywhere.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
