### PR TITLE
no more expansion/collapse when a placeholder is marked done.

### DIFF
--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -115,7 +115,7 @@ export default class FillPlaceholder extends Component {
 
         done = event.target.checked;
         placeholder.done = event.target.checked;
-        this.setState({ done });
+        this.setState({ done, expanded: false });
     };
 
     onExpand = (event) => {
@@ -444,13 +444,14 @@ export default class FillPlaceholder extends Component {
     }
 
     renderSingleEntryPlaceholder = () => {
-        const { currentField, expanded } = this.state;
+        const { currentField, expanded, done } = this.state;
         const { backgroundColor, placeholder } = this.props;
         const attribute = placeholder.attributes[currentField[0]];
+        const expandIcon = done ? "" : <ExpandMoreIcon onClick={this.onExpand} />; // remove expand icon if done
 
         return (
             <ExpansionPanel expanded={expanded} className="expanded-style">
-                <ExpansionPanelSummary style={{ backgroundColor, cursor: 'default' }} expandIcon={<ExpandMoreIcon onClick={this.onExpand} />}>
+                <ExpansionPanelSummary style={{ backgroundColor, cursor: 'default' }} expandIcon={expandIcon}>
                     <Grid container>
                         {this.renderCheckbox()}
                         <Grid item xs={9}>
@@ -470,7 +471,7 @@ export default class FillPlaceholder extends Component {
     }
 
     renderMultipleEntriesPlaceholder = () => {
-        const { currentField, expanded } = this.state;
+        const { currentField, expanded, done } = this.state;
         const { backgroundColor, placeholder } = this.props;
 
         // Loop through all entries and render summaries
@@ -531,10 +532,11 @@ export default class FillPlaceholder extends Component {
                 {allRowsAndColumns}
             </Grid>
         );
+        const expandIcon = done ? "" : <ExpandMoreIcon onClick={this.onExpand} />; // remove expand icon if done
 
         return (
             <ExpansionPanel expanded={expanded} className="expanded-style">
-                <ExpansionPanelSummary style={{ backgroundColor, cursor: 'default' }} expandIcon={<ExpandMoreIcon onClick={this.onExpand} />}>
+                <ExpansionPanelSummary style={{ backgroundColor, cursor: 'default' }} expandIcon={expandIcon}>
                     {expansionSummary}
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails style={{ backgroundColor }}>


### PR DESCRIPTION
Addresses JIRA 1306. If a placeholder is done in POC, no expansion/collapse allowed.

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
