### PR TITLE
Check for a selected trigger

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1085,7 +1085,7 @@ class FluxNotesEditor extends React.Component {
                     after = "";
                 }
 
-                if (arrayOfPickLists && this.noteParser.isPickList(trigger)) {
+                if (arrayOfPickLists && this.noteParser.isPickList(trigger) && !trigger.selectedValue) {
                     transform = this.updateExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform);
                     pickListCount++;
                 } else {


### PR DESCRIPTION
Adds a check for if a trigger is already selected.

This fixes JIRA 1351. Templates with a condition already selected (ex: "@condition[[Fracture]]") are correctly inserted now. This also fixes the copy and pasting bug we noticed in the sprint burndown meeting today.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
