### PR TITLE
special case when informant and author are same

### DIFF
--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1513,8 +1513,12 @@ export default class SummaryMetadata {
         if (entry.sourceClinicalNoteReference) return entry.sourceClinicalNoteReference;
         
         let result = "";
-        if (entry.author) result += "Recorded by " + entry.author;
-        if (entry.informant) result += (result.length > 0 ? " b" : "B") + "ased on information from " + entry.informant;
+        if (entry.author && entry.informant && entry.author === entry.informant) {
+            result += "Recorded and informed by " + entry.author;
+        } else {
+            if (entry.author) result += "Recorded by " + entry.author;
+            if (entry.informant) result += (result.length > 0 ? " b" : "B") + "ased on information from " + entry.informant;
+        }
         if (entry.relatedEncounterReference) {
             const relatedEncounter = patient.getEntryFromReference(entry.relatedEncounterReference);
             if (relatedEncounter instanceof EncounterPerformed) {


### PR DESCRIPTION
Resolves JIRA 1347. Now special cases when informant and author are same in view source message.

To test: Look at View Source for Staging and then for one of the recent visit items which have the same name for author and informant

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
