### PR TITLE
Actions displaying in narrative

### DIFF
--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -209,9 +209,9 @@ class NarrativeNameValuePairsVisualizer extends Component {
 
     // renders Menu for snippet and associated actions as Menu items
     renderedMenu = (snippet, snippetId, snippetText, arrayIndex) => {
-        const onMenuItemClicked = (fn, element) => {
+        const onMenuItemClicked = (fn, element, item) => {
             const callback = () => {
-                fn(element);
+                fn(element, item);
             }
             this.closeInsertionMenu(callback);
         }
@@ -242,6 +242,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
                 onMenuItemClicked={onMenuItemClicked}
                 positionLeft={this.state.positionLeft}
                 positionTop={this.state.positionTop}
+                rowId={snippet.name}
                 unfilteredActions={this.props.actions}
             />
         );

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -281,7 +281,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
         let content = [];
         narrative.forEach((snippet, index) => {
             const isInsertable = (Lang.isNull(snippet.item) || Lang.isUndefined(snippet.item) ? false : (Lang.isUndefined(snippet.item.isInsertable) ? true : snippet.item.IsInsertable));
-            if ((snippet.type === 'structured-data' || snippet.type === "unsigned-data") && isInsertable) {
+            if ((snippet.type === 'narrative-structured-data' || snippet.type === "narrative-unsigned-data") && isInsertable) {
                 const snippetId = `${snippet.item.name}-${index}`
                 // const snippetValue = (Lang.isArray(snippet.item.value) ? snippet.item.value[0] : snippet.item.value);
                 content.push(

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -209,42 +209,42 @@ class NarrativeNameValuePairsVisualizer extends Component {
 
     // renders Menu for snippet and associated actions as Menu items
     renderedMenu = (snippet, snippetId, snippetText, arrayIndex) => {
-
         const onMenuItemClicked = (fn, element) => {
             const callback = () => {
-                // convert element to format action is expecting
-                const transformedElement = {
-                    shortcut: element.shortcut,
-                    value: [
-                        element.value,
-                        element.unsigned,
-                        element.sourceNote
-                    ]
-                };
-                fn(transformedElement);
+                fn(element);
             }
             this.closeInsertionMenu(callback);
         }
-        
         let isSigned = true;
         const checkSnippetUnsigned = Lang.isUndefined(snippet.unsigned) ? isSigned : !snippet.unsigned;
         isSigned = Lang.isArray(snippet.value) ? !snippet.value[1] : checkSnippetUnsigned;
-    
-       return( 
-         <VisualizerMenu
-            allowItemClick={this.props.allowItemClick}
-            arrayIndex={arrayIndex}
-            closeInsertionMenu={this.closeInsertionMenu}
-            element={snippet}
-            elementDisplayingMenu={this.state.snippetDisplayingMenu}
-            elementId={snippetId}
-            elementText={snippetText}
-            isSigned={isSigned}
-            onMenuItemClicked={onMenuItemClicked}
-            positionLeft={this.state.positionLeft}
-            positionTop={this.state.positionTop}
-            unfilteredActions={this.props.actions}
-       /> );
+
+        // convert snippet to format action is expecting
+        const transformedSnippet = {
+            shortcut: snippet.shortcut,
+            value: [
+                snippet.value,
+                snippet.unsigned,
+                snippet.sourceNote
+            ],
+        };
+
+        return (
+            <VisualizerMenu
+                allowItemClick={this.props.allowItemClick}
+                arrayIndex={arrayIndex}
+                closeInsertionMenu={this.closeInsertionMenu}
+                element={transformedSnippet}
+                elementDisplayingMenu={this.state.snippetDisplayingMenu}
+                elementId={snippetId}
+                elementText={snippetText}
+                isSigned={isSigned}
+                onMenuItemClicked={onMenuItemClicked}
+                positionLeft={this.state.positionLeft}
+                positionTop={this.state.positionTop}
+                unfilteredActions={this.props.actions}
+            />
+        );
     }
 
     // Opens the insertion menu for the given snippet id, based on cursor location

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -395,7 +395,6 @@ export default class TabularListVisualizer extends Component {
     // renders Menu for element and associated actions as Menu items
     // Will check whether an action should be rendered as a Menu item based on criteria of each action
     renderedMenu = (item, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex) => {
-        //(element, elementText);
         const { elementToDisplayMenu, positionLeft, positionTop } = this.state;
         // Item represents the name of the row/section of the current element.
         const onMenuItemClicked = (fn, element, item) => {
@@ -427,7 +426,8 @@ export default class TabularListVisualizer extends Component {
                 rowId={item}
                 subsectionName={subsectionName}
                 unfilteredActions={this.props.actions.concat(subsectionActions)}
-            />);
+            />
+        );
     }
 
     // Opens the insertion menu for the given element id, based on cursor location


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Actions displaying and working correctly in narrative:

- Fixed `if` condition checking for old class name.
- Passed additional prop to `VisualizerMenu` from `NarrativeNameValuePairsVisualizer`.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
