### PR TITLE
Vital signs

### DIFF
--- a/src/dataaccess/HardCodedPatientMidYearDemo18.json
+++ b/src/dataaccess/HardCodedPatientMidYearDemo18.json
@@ -9676,5 +9676,487 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
             }
         }
+    },
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/BloodPressure"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "6000",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "03 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "03 SEP 2018"
+        },
+        "ObservationComponent": [
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/vital/SystolicPressure"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+                    },
+                    "Value": 143,
+                    "Units": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        },
+                        "Value": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "mmHg"
+                        }
+                    }
+                },
+                "ObservationCode": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "Coding": [
+                        {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "8480-6",
+                            "CodeSystem": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                },
+                                "Value": "https://fhir.loinc.org"
+                            },
+                            "DisplayText": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                },
+                                "Value": "Systolic blood pressure"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/vital/DiastolicPressure"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+                    },
+                    "Value": 89,
+                    "Units": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        },
+                        "Value": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "mmHg"
+                        }
+                    }
+                },
+                "ObservationCode": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "Coding": [
+                        {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "8462-4",
+                            "CodeSystem": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                },
+                                "Value": "https://fhir.loinc.org"
+                            },
+                            "DisplayText": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                },
+                                "Value": "Diastolic blood pressure"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "55284-4",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Blood pressure"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "06 SEP 2018"
+        }
+    },
+
+   
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/BodyTemperature"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "6001",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 96.2,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "F"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "8310-5",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Body temperature"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "06 SEP 2018"
+        }
+    },
+
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/BodyWeight"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "6002",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 137,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "lbs"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "29463-7",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Body weight"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "06 SEP 2018"
+        }
+    },
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/HeartRate"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+        "EntryId": "6003",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7e",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 75,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "/min"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "8867-4",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Heart rate"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "06 SEP 2018"
+        }
     }
 ]

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -10204,4 +10204,185 @@
             }
         }
     }
+
+
+    ,
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/BloodPressure"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "6000",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "03 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "03 SEP 2018"
+        },
+        "ObservationComponent": [
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/vital/SystolicPressure"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+                    },
+                    "Value": 143,
+                    "Units": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        },
+                        "Value": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "mmHg"
+                        }
+                    }
+                },
+                "ObservationCode": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "Coding": [
+                        {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "8480-6",
+                            "CodeSystem": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                },
+                                "Value": "https://fhir.loinc.org"
+                            },
+                            "DisplayText": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                },
+                                "Value": "Systolic blood pressure"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/vital/DiastolicPressure"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+                    },
+                    "Value": 89,
+                    "Units": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                        },
+                        "Value": {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "mmHg"
+                        }
+                    }
+                },
+                "ObservationCode": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+                    },
+                    "Coding": [
+                        {
+                            "EntryType": {
+                                "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                            },
+                            "Value": "8462-4",
+                            "CodeSystem": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                                },
+                                "Value": "https://fhir.loinc.org"
+                            },
+                            "DisplayText": {
+                                "EntryType": {
+                                    "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                                },
+                                "Value": "Diastolic blood pressure"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "55284-4",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Blood pressure"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "05 SEP 2018"
+        }
+    }
 ]

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -10382,7 +10382,109 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
-            "Value": "05 SEP 2018"
+            "Value": "06 SEP 2018"
+        }
+    },
+
+   
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/BodyTemperature"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "6001",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 96.2,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "F"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "8310-5",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Body temperature"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "06 SEP 2018"
         }
     }
 ]

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -10203,10 +10203,7 @@
                 "Value": "http://standardhealthrecord.org/spec/shr/core/ClinicalNote"
             }
         }
-    }
-
-
-    ,
+    },
     {
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/vital/BloodPressure"

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -10484,6 +10484,107 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
+            "Value": "05 SEP 2018"
+        }
+    },
+
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/BodyWeight"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "6002",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 137,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "lbs"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "29463-7",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Body weight"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
             "Value": "06 SEP 2018"
         }
     }

--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -10484,7 +10484,7 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
             },
-            "Value": "05 SEP 2018"
+            "Value": "06 SEP 2018"
         }
     },
 
@@ -10577,6 +10577,106 @@
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
                         "Value": "Body weight"
+                    }
+                }
+            ]
+        },
+        "ClinicallyRelevantTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/finding/ClinicallyRelevantTime"
+            },
+            "Value": "06 SEP 2018"
+        }
+    },
+
+    {
+        "EntryType": {
+            "Value": "http://standardhealthrecord.org/spec/shr/vital/HeartRate"
+        },
+        "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+        "EntryId": "6003",
+        "PersonOfRecord": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "1",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/entity/Patient"
+            }
+        },
+        "CreationTime": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "LastUpdated": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+            },
+            "Value": "06 SEP 2018"
+        },
+        "Value": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/Quantity"
+            },
+            "Value": 75,
+            "Units": {
+                "EntryType": {
+                    "Value": "http://standardhealthrecord.org/spec/shr/core/Units"
+                },
+                "Value": {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "/min"
+                }
+            }
+        },
+        "FindingStatus": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "final",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "http://hl7.org/fhir/observation-status"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Final"
+                    }
+                }
+            ]
+        },
+        "ObservationCode": {
+            "EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept"
+            },
+            "Coding": [
+                {
+                    "EntryType": {
+                        "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
+                    },
+                    "Value": "8867-4",
+                    "CodeSystem": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
+                        },
+                        "Value": "https://fhir.loinc.org"
+                    },
+                    "DisplayText": {
+                        "EntryType": {
+                            "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
+                        },
+                        "Value": "Heart rate"
                     }
                 }
             ]

--- a/src/model/FluxObjectFactory.js
+++ b/src/model/FluxObjectFactory.js
@@ -12,6 +12,7 @@ import FluxMedicationObjectFactory from './medication/FluxMedicationObjectFactor
 import FluxProcedureObjectFactory from './procedure/FluxProcedureObjectFactory';
 import FluxAllergyObjectFactory from './allergy/FluxAllergyObjectFactory';
 import FluxOncologyObjectFactory from './oncology/FluxOncologyObjectFactory';
+import FluxVitalObjectFactory from './vital/FluxVitalObjectFactory';
 
 /*
  *  FluxObjectFactory class returns instances of Flux model classes
@@ -33,6 +34,7 @@ export default class FluxObjectFactory {
             case 'shr.procedure': return FluxProcedureObjectFactory.createInstance(json, type, patientRecord);
             case 'shr.research': return FluxResearchObjectFactory.createInstance(json, type, patientRecord);
             case 'shr.allergy': return FluxAllergyObjectFactory.createInstance(json, type, patientRecord);
+            case 'shr.vital': return FluxVitalObjectFactory.createInstance(json, type, patientRecord);
             default: return ObjectFactory.createInstance(json, type, patientRecord);
         }
     }

--- a/src/model/vital/FluxBloodPressure.js
+++ b/src/model/vital/FluxBloodPressure.js
@@ -1,0 +1,21 @@
+import BloodPressure from '../shr/vital/BloodPressure';
+import FluxObservation from '../finding/FluxObservation';
+
+class FluxBloodPressure extends FluxObservation{
+    constructor(json) {
+        super();
+        this._observation = BloodPressure.fromJSON(json);
+    }
+
+    get value() {
+        return this._observation._observationComponent.map((comp) => {
+            return comp.value.value;
+        }).join("/");
+    }
+
+    toJSON() {
+        return this._observation.toJSON();
+    }
+}
+
+export default FluxBloodPressure;

--- a/src/model/vital/FluxBodyTemperature.js
+++ b/src/model/vital/FluxBodyTemperature.js
@@ -11,6 +11,10 @@ class FluxBodyTemperature extends FluxObservation{
         return this._observation._quantity._decimal;
     }
 
+    get units() {
+        return this._observation._quantity.units.value.value;
+    }
+
     toJSON() {
         return this._observation.toJSON();
     }

--- a/src/model/vital/FluxBodyTemperature.js
+++ b/src/model/vital/FluxBodyTemperature.js
@@ -1,0 +1,19 @@
+import BodyTemperature from '../shr/vital/BodyTemperature';
+import FluxObservation from '../finding/FluxObservation';
+
+class FluxBodyTemperature extends FluxObservation{
+    constructor(json) {
+        super();
+        this._observation = BodyTemperature.fromJSON(json);
+    }
+
+    get value() {
+        return this._observation._quantity._decimal;
+    }
+
+    toJSON() {
+        return this._observation.toJSON();
+    }
+}
+
+export default FluxBodyTemperature;

--- a/src/model/vital/FluxBodyWeight.js
+++ b/src/model/vital/FluxBodyWeight.js
@@ -1,0 +1,19 @@
+import BodyWeight from '../shr/vital/BodyWeight';
+import FluxObservation from '../finding/FluxObservation';
+
+class FluxBodyWeight extends FluxObservation{
+    constructor(json) {
+        super();
+        this._observation = BodyWeight.fromJSON(json);
+    }
+
+    get value() {
+        return this._observation._quantity.value;
+    }
+
+    toJSON() {
+        return this._observation.toJSON();
+    }
+}
+
+export default FluxBodyWeight;

--- a/src/model/vital/FluxHeartRate.js
+++ b/src/model/vital/FluxHeartRate.js
@@ -1,14 +1,14 @@
-import BodyWeight from '../shr/vital/BodyWeight';
+import HeartRate from '../shr/vital/HeartRate';
 import FluxObservation from '../finding/FluxObservation';
 
-class FluxBodyWeight extends FluxObservation{
+class FluxHeartRate extends FluxObservation{
     constructor(json) {
         super();
-        this._observation = BodyWeight.fromJSON(json);
+        this._observation = HeartRate.fromJSON(json);
     }
 
     get value() {
-        return this._observation._quantity.value;
+        return this._observation._quantity._decimal;
     }
 
     get units() {
@@ -20,4 +20,4 @@ class FluxBodyWeight extends FluxObservation{
     }
 }
 
-export default FluxBodyWeight;
+export default FluxHeartRate;

--- a/src/model/vital/FluxVitalObjectFactory.js
+++ b/src/model/vital/FluxVitalObjectFactory.js
@@ -1,0 +1,18 @@
+import { getNamespaceAndName } from '../json-helper';
+import ShrVitalObjectFactory from '../shr/vital/ShrVitalObjectFactory';
+import FluxBloodPressure from './FluxBloodPressure';
+
+
+export default class FluxVitalObjectFactory {
+    static createInstance(json, type) {
+        const { namespace, elementName } = getNamespaceAndName(json, type);
+        if (namespace !== 'shr.vital') {
+            throw new Error(`Unsupported type in ShrVitalObjectFactory: ${type}`);
+        }
+        // returns Flux wrapper class if found, otherwise use ShrVitalObjectFactory
+        switch (elementName) {
+            case 'BloodPressure': return new FluxBloodPressure(json);
+            default: return ShrVitalObjectFactory.createInstance(json, type);
+        }
+    }
+}

--- a/src/model/vital/FluxVitalObjectFactory.js
+++ b/src/model/vital/FluxVitalObjectFactory.js
@@ -3,6 +3,7 @@ import ShrVitalObjectFactory from '../shr/vital/ShrVitalObjectFactory';
 import FluxBloodPressure from './FluxBloodPressure';
 import FluxBodyTemperature from './FluxBodyTemperature';
 import FluxBodyWeight from './FluxBodyWeight';
+import FluxHeartRate from './FluxHeartRate';
 
 
 export default class FluxVitalObjectFactory {
@@ -16,6 +17,7 @@ export default class FluxVitalObjectFactory {
             case 'BloodPressure': return new FluxBloodPressure(json);
             case 'BodyTemperature': return new FluxBodyTemperature(json);
             case 'BodyWeight': return new FluxBodyWeight(json);
+            case 'HeartRate': return new FluxHeartRate(json);
             default: return ShrVitalObjectFactory.createInstance(json, type);
         }
     }

--- a/src/model/vital/FluxVitalObjectFactory.js
+++ b/src/model/vital/FluxVitalObjectFactory.js
@@ -1,6 +1,7 @@
 import { getNamespaceAndName } from '../json-helper';
 import ShrVitalObjectFactory from '../shr/vital/ShrVitalObjectFactory';
 import FluxBloodPressure from './FluxBloodPressure';
+import FluxBodyTemperature from './FluxBodyTemperature';
 
 
 export default class FluxVitalObjectFactory {
@@ -12,6 +13,7 @@ export default class FluxVitalObjectFactory {
         // returns Flux wrapper class if found, otherwise use ShrVitalObjectFactory
         switch (elementName) {
             case 'BloodPressure': return new FluxBloodPressure(json);
+            case 'BodyTemperature': return new FluxBodyTemperature(json);
             default: return ShrVitalObjectFactory.createInstance(json, type);
         }
     }

--- a/src/model/vital/FluxVitalObjectFactory.js
+++ b/src/model/vital/FluxVitalObjectFactory.js
@@ -2,6 +2,7 @@ import { getNamespaceAndName } from '../json-helper';
 import ShrVitalObjectFactory from '../shr/vital/ShrVitalObjectFactory';
 import FluxBloodPressure from './FluxBloodPressure';
 import FluxBodyTemperature from './FluxBodyTemperature';
+import FluxBodyWeight from './FluxBodyWeight';
 
 
 export default class FluxVitalObjectFactory {
@@ -14,6 +15,7 @@ export default class FluxVitalObjectFactory {
         switch (elementName) {
             case 'BloodPressure': return new FluxBloodPressure(json);
             case 'BodyTemperature': return new FluxBodyTemperature(json);
+            case 'BodyWeight': return new FluxBodyWeight(json);
             default: return ShrVitalObjectFactory.createInstance(json, type);
         }
     }

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -25,6 +25,7 @@ import moment from 'moment';
 import Guid from 'guid';
 import _ from 'lodash';
 import FluxBloodPressure from '../model/vital/FluxBloodPressure';
+import FluxBodyTemperature from '../model/vital/FluxBodyTemperature';
 
 class PatientRecord {
 
@@ -1016,7 +1017,12 @@ class PatientRecord {
             const clinicallyRelevantTime = new moment(bloodPressure.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
             return clinicallyRelevantTime === today; 
         });
-        return bloodPressure.value
+        const bodyTemperature = this.getEntriesOfType(FluxBodyTemperature).find((bodyTemperature) => {  
+            const clinicallyRelevantTime = new moment(bodyTemperature.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
+            return clinicallyRelevantTime === today; 
+        });
+        let results = "Blood pressure is " + bloodPressure.value + ", temperature is " + bodyTemperature.value;
+        return results;
     }
 }
 

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -18,6 +18,7 @@ import FluxResearchSubject from '../model/research/FluxResearchSubject';
 import FluxBloodPressure from '../model/vital/FluxBloodPressure';
 import FluxBodyTemperature from '../model/vital/FluxBodyTemperature';
 import FluxBodyWeight from '../model/vital/FluxBodyWeight';
+import FluxHeartRate from '../model/vital/FluxHeartRate';
 import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList.jsx'; // put jsx because yarn test-ui errors on this import otherwise
 import CreationTime from '../model/shr/core/CreationTime';
 import LastUpdated from '../model/shr/base/LastUpdated';
@@ -1027,12 +1028,17 @@ class PatientRecord {
             const clinicallyRelevantTime = new moment(bodyWeight.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
             return clinicallyRelevantTime === today; 
         });
-        if (Lang.isUndefined(bloodPressure) && Lang.isUndefined(bodyTemperature) && Lang.isUndefined(bodyWeight)){
+        const heartRate = this.getEntriesOfType(FluxHeartRate).find((heartRate) => {  
+            const clinicallyRelevantTime = new moment(heartRate.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
+            return clinicallyRelevantTime === today; 
+        });
+        if (Lang.isUndefined(bloodPressure) && Lang.isUndefined(bodyTemperature) && Lang.isUndefined(bodyWeight) && Lang.isUndefined(heartRate)){
             return "no vital signs taken today";
         }
         const results = (Lang.isUndefined(bloodPressure) ? "" : "Blood pressure is " + bloodPressure.value + ". ") +
-                        (Lang.isUndefined(bodyTemperature) ? "" : "Temperature is " + bodyTemperature.value + ". ") +
-                        (Lang.isUndefined(bodyWeight) ? "" : "Weight is " + bodyWeight.value + ".");
+                        (Lang.isUndefined(bodyTemperature) ? "" : "Temperature is " + bodyTemperature.value + " "+ bodyTemperature.units + ". ") +
+                        (Lang.isUndefined(bodyWeight) ? "" : "Weight is " + bodyWeight.value + " " + bodyWeight.units + ". ") + 
+                        (Lang.isUndefined(heartRate) ? "" : "Heart rate is " + heartRate.value + heartRate.units + ".");;
         return results;
     }
 }

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -24,6 +24,7 @@ import Lang from 'lodash';
 import moment from 'moment';
 import Guid from 'guid';
 import _ from 'lodash';
+import FluxBloodPressure from '../model/vital/FluxBloodPressure';
 
 class PatientRecord {
 
@@ -1007,6 +1008,15 @@ class PatientRecord {
             return null;
         }
         return result[0];
+    }
+
+    getTodaysVitalsAsString() {
+        let today = new moment().format("D MMM YYYY");
+        const bloodPressure = this.getEntriesOfType(FluxBloodPressure).find((bloodPressure) => {  
+            const clinicallyRelevantTime = new moment(bloodPressure.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
+            return clinicallyRelevantTime === today; 
+        });
+        return bloodPressure.value
     }
 }
 

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -15,6 +15,9 @@ import FluxPatientIdentifier from '../model/base/FluxPatientIdentifier';
 import FluxProcedureRequested from '../model/procedure/FluxProcedureRequested';
 import FluxQuestionAnswer from '../model/finding/FluxQuestionAnswer';
 import FluxResearchSubject from '../model/research/FluxResearchSubject';
+import FluxBloodPressure from '../model/vital/FluxBloodPressure';
+import FluxBodyTemperature from '../model/vital/FluxBodyTemperature';
+import FluxBodyWeight from '../model/vital/FluxBodyWeight';
 import ClinicalTrialsList from '../clinicalTrials/ClinicalTrialsList.jsx'; // put jsx because yarn test-ui errors on this import otherwise
 import CreationTime from '../model/shr/core/CreationTime';
 import LastUpdated from '../model/shr/base/LastUpdated';
@@ -24,8 +27,7 @@ import Lang from 'lodash';
 import moment from 'moment';
 import Guid from 'guid';
 import _ from 'lodash';
-import FluxBloodPressure from '../model/vital/FluxBloodPressure';
-import FluxBodyTemperature from '../model/vital/FluxBodyTemperature';
+
 
 class PatientRecord {
 
@@ -1021,7 +1023,16 @@ class PatientRecord {
             const clinicallyRelevantTime = new moment(bodyTemperature.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
             return clinicallyRelevantTime === today; 
         });
-        let results = "Blood pressure is " + bloodPressure.value + ", temperature is " + bodyTemperature.value;
+        const bodyWeight = this.getEntriesOfType(FluxBodyWeight).find((bodyWeight) => {  
+            const clinicallyRelevantTime = new moment(bodyWeight.clinicallyRelevantTime, "D MMM YYYY").format("D MMM YYYY");
+            return clinicallyRelevantTime === today; 
+        });
+        if (Lang.isUndefined(bloodPressure) && Lang.isUndefined(bodyTemperature) && Lang.isUndefined(bodyWeight)){
+            return "no vital signs taken today";
+        }
+        const results = (Lang.isUndefined(bloodPressure) ? "" : "Blood pressure is " + bloodPressure.value + ". ") +
+                        (Lang.isUndefined(bodyTemperature) ? "" : "Temperature is " + bodyTemperature.value + ". ") +
+                        (Lang.isUndefined(bodyWeight) ? "" : "Weight is " + bodyWeight.value + ".");
         return results;
     }
 }

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -531,7 +531,7 @@
     "id": "VitalsInserter",
     "getData": {"object": "patient", "method": "getTodaysVitalsAsString"},
     "isContext": false,
-    "stringTriggers": [{"name": "@Vitals", "description": "Insert patient's vital signs for today"}],
+    "stringTriggers": [{"name": "@vitals", "description": "Insert patient's vital signs for today"}],
     "knownParentContexts": "Patient"
   }
 ]

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -525,5 +525,13 @@
     "knownParentContexts": "ConditionInserter",	
     "description": "Side effects to treatment, important for effective evaluation of disease and treatment, based on Common Terminology Criteria for Adverse Events (CTCAE) version 4.03 (June 14, 2010).",	
     "structuredPhraseDocumentation": "nlptoxicitySheet.pdf"
+  },
+
+  { "type": "InsertValue",
+    "id": "VitalsInserter",
+    "getData": {"object": "patient", "method": "getTodaysVitalsAsString"},
+    "isContext": false,
+    "stringTriggers": [{"name": "@Vitals", "description": "Insert patient's vital signs for today"}],
+    "knownParentContexts": "Patient"
   }
 ]

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -2015,8 +2015,8 @@ export default class SummaryMetadata {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         try {
             // Commenting out the api call with actual patient criteria til we get patient data
-            //const data = api.findTreatmentOptionsByPatientStats(condition.codeURL, {race: this.toFirstLetterCapital(patient.getPatient().race), dxGrade: condition.getMostRecentHistologicalGrade().getGradeAsSimpleNumber()});
-            const data = api.findTreatmentOptionsByPatientStats("http://snomed.info/sct/399068003", {race: "Black"});
+            const data = api.findTreatmentOptionsByPatientStats(condition.codeURL, {race: this.toFirstLetterCapital(patient.getPatient().race), dxGrade: condition.getMostRecentHistologicalGrade().getGradeAsSimpleNumber()});
+            //const data = api.findTreatmentOptionsByPatientStats("http://snomed.info/sct/399068003", {race: "Black"});
             const parsedData = JSON.parse(data);
             if(parsedData[0].length === 0 && parsedData[1].length === 0){
                 return "No relevant data found for patient";


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1338

Only returns vital signs for today, so you will need to change the cliniciallyRelevantDate
in the mid year demo and sacroma patient to today's date for the last 4 entries. 
Search "6000" in the json to find the first of the 4 added vital signs entries. 
To test open flux notes editor and type @vitals 
Currently supports blood pressure, body temperature, body weight, and heart rate. 


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
