### PR TITLE
Changed NLP-server domain to parser.mitre.org

### DIFF
--- a/src/notes/NLPHashtagPlugin.jsx
+++ b/src/notes/NLPHashtagPlugin.jsx
@@ -4,7 +4,7 @@ import Shortcut from '../shortcuts/Shortcut';
 // import Slate from '../lib/slate'
 import { Selection } from '../lib/slate'
 
-const DOMAIN = "http://MM224122-PC.mitre.org"
+const DOMAIN = "http://parser.mitre.org"
 const PORT = "8551"
 const API_ROUTE = "/api/parse_sentence"
 const API_ENDPOINT = `${DOMAIN}:${PORT}${API_ROUTE}`


### PR DESCRIPTION
In addition, I've documented in detail the steps taken in provisioning and setting the NLP server. Look over this [documentation here:](https://github.com/FluxNotes/flux/wiki/NLP-Server%3A-Provisioning-and-Troubleshooting)

Happy testing!