### PR TITLE
Interact with structured field search results

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -162,8 +162,17 @@ export class FullApp extends Component {
 
     receive_command(commandType, data) {
         if (commandType === 'navigate_targeted_data_panel') {
+            // if we just have a section name, move to it
+            // if we have a section and subsection names, move to section and then move to subsection if its not already visible.
             const sectionName = data.section;
-            return this.dashboard.moveTargetedDataPanelToSection(sectionName);
+            const subsectionName = data.subsectionName;
+            let result = this.dashboard.moveTargetedDataPanelToSection(sectionName);
+            if (subsectionName) {
+                if (!Lang.isNull(result)) return result;
+                return this.dashboard.moveTargetedDataPanelToSubsection(subsectionName);
+            } else {
+                return result;
+            }
         } else if (commandType === 'insert-structured-phrase') {
             return this.dashboard.insertStructuredPhraseInCurrentNote(data, "command");
         } else {
@@ -331,6 +340,10 @@ export class FullApp extends Component {
         this.setState({ isModalOpen: false });
     }
 
+    moveTargetedDataPanelToSection = (sectionName) => {
+        return this.dashboard.moveTargetedDataPanelToSection(sectionName);
+    }
+
     render() {
         // Get the Current Dashboard based on superRole of user
         const CurrentDashboard = this.dashboardManager.getDashboardForSuperRole(this.state.superRole);
@@ -353,6 +366,7 @@ export class FullApp extends Component {
                                     setSearchSelectedItem={this.setSearchSelectedItem}
                                     supportLogin={true}
                                     searchIndex={this.searchIndex}
+                                    moveTargetedDataPanelToSection={this.moveTargetedDataPanelToSection}
                                 />
                             </Col>
                         </Row>

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -162,17 +162,9 @@ export class FullApp extends Component {
 
     receive_command(commandType, data) {
         if (commandType === 'navigate_targeted_data_panel') {
-            // if we just have a section name, move to it
-            // if we have a section and subsection names, move to section and then move to subsection if its not already visible.
             const sectionName = data.section;
-            const subsectionName = data.subsectionName;
-            let result = this.dashboard.moveTargetedDataPanelToSection(sectionName);
-            if (subsectionName) {
-                if (!Lang.isNull(result)) return result;
-                return this.dashboard.moveTargetedDataPanelToSubsection(subsectionName);
-            } else {
-                return result;
-            }
+            const subsectionName = data.subsection;
+            return this.dashboard.moveTargetedDataPanelToSubsection(sectionName, subsectionName);
         } else if (commandType === 'insert-structured-phrase') {
             return this.dashboard.insertStructuredPhraseInCurrentNote(data, "command");
         } else {
@@ -340,8 +332,8 @@ export class FullApp extends Component {
         this.setState({ isModalOpen: false });
     }
 
-    moveTargetedDataPanelToSection = (sectionName) => {
-        return this.dashboard.moveTargetedDataPanelToSection(sectionName);
+    moveTargetedDataPanelToSubsection = (sectionName, subsectionName) => {
+        return this.dashboard.moveTargetedDataPanelToSubsection(sectionName, subsectionName);
     }
 
     render() {
@@ -366,7 +358,7 @@ export class FullApp extends Component {
                                     setSearchSelectedItem={this.setSearchSelectedItem}
                                     supportLogin={true}
                                     searchIndex={this.searchIndex}
-                                    moveTargetedDataPanelToSection={this.moveTargetedDataPanelToSection}
+                                    moveTargetedDataPanelToSubsection={this.moveTargetedDataPanelToSubsection}
                                 />
                             </Col>
                         </Row>

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -147,8 +147,8 @@ export default class ClinicianDashboard extends Component {
         return this.targetedDataPanel.moveToSection(sectionName);
     }
 
-    moveTargetedDataPanelToSubsection = (subsectionName) => {
-        return this.targetedDataPanel.moveToSubsection(subsectionName);
+    moveTargetedDataPanelToSubsection = (sectionName, subsectionName) => {
+        return this.targetedDataPanel.moveToSubsection(sectionName, subsectionName);
     }
 
     insertStructuredPhraseInCurrentNote = (data, source) => {

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -147,6 +147,10 @@ export default class ClinicianDashboard extends Component {
         return this.targetedDataPanel.moveToSection(sectionName);
     }
 
+    moveTargetedDataPanelToSubsection = (subsectionName) => {
+        return this.targetedDataPanel.moveToSubsection(subsectionName);
+    }
+
     insertStructuredPhraseInCurrentNote = (data, source) => {
         return this.notesPanel.insertStructuredPhraseInCurrentNote(data, source);
     }

--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -143,38 +143,53 @@ export class Minimap extends React.Component {
     })
   }
 
-  moveToSection(sectionName) {
-      const posForSection = this.sectionPositions[sectionName];
-      if (Lang.isUndefined(posForSection)) return "No section named '" + sectionName + "' found.";
-      const { left, top } = posForSection;
-      if (Lang.isUndefined(this.x) || Lang.isUndefined(this.y)) {
-        this.x = 0
-        this.y = 0;
-      }
-      this.scrollTo(left, top);
-      return null;
-  }
+    moveToSection(sectionName) {
+//        const posForSection = this.sectionPositions[sectionName];
+//        if (Lang.isUndefined(posForSection)) return "No section named '" + sectionName + "' found.";
+//        const { left, top } = posForSection;
+        const sectionElements = Array.from(this.ref.querySelectorAll(".section-header>span"));
+        const sectionNodes = sectionElements.filter(el => el.textContent === sectionName);
+        if (!sectionNodes || sectionNodes.length === 0) return `Section '${sectionName}' not found.`;
 
-  isScrolledIntoView(elem) {
-    const overall_div = document.querySelector('.minimap-container');
-    var docViewTop = this.ref.clientTop; //this.ref.scrollTop;
-    var docViewBottom = docViewTop + overall_div.clientHeight; //this.ref.clientHeight; //scrollHeight
 
-    const { height, top} = elem.getBoundingClientRect()
-    var elemTop = top;
-    var elemBottom = elemTop + height;
-    //console.log(docViewTop, docViewBottom, elemTop, elemBottom);
-    return ((elemBottom <= docViewBottom) && (elemTop >= docViewTop));
-  }
 
-  moveToSubsection(subsectionName) {
-      const subsectionSpans = Array.from(this.ref.querySelectorAll(".list-subsection-header>span"));
-      const subsectionNode = subsectionSpans.filter(el => el.textContent === subsectionName)
-      if (!this.isScrolledIntoView(subsectionNode[0])) {
-        subsectionNode[0].scrollIntoView();
-      }
-      return null;
-  }
+        if (Lang.isUndefined(this.x) || Lang.isUndefined(this.y)) {
+            this.x = 0
+            this.y = 0;
+        }
+        sectionNodes[0].scrollIntoView();
+//        this.scrollTo(left, top);
+        return null;
+    }
+
+    isScrolledIntoView(elem) {
+        const overall_div = document.querySelector('.minimap-container');
+        var docViewTop = this.ref.clientTop; //this.ref.scrollTop;
+        var docViewBottom = docViewTop + overall_div.clientHeight; //this.ref.clientHeight; //scrollHeight
+
+        const { height, top} = elem.getBoundingClientRect()
+        var elemTop = top;
+        var elemBottom = elemTop + height;
+        return ((elemBottom <= docViewBottom) && (elemTop >= docViewTop));
+    }
+
+    // if we just have a section name, move to it
+    // if we have a section and subsection names, move to section and then move to subsection if its not already visible.
+    moveToSubsection(sectionName, subsectionName) {
+        let result = this.moveToSection(sectionName);
+        // if no subsectionName specified or got an error on scroll to section, we're done
+        if (!subsectionName || !Lang.isNull(result)) return result;
+        // if we have a subsectionName and scrolling to the section doesn't make entire subsection visible,
+        // just scroll to subsection instead
+        const subsectionSpans = Array.from(this.ref.querySelectorAll(".list-subsection-header>span"));
+        const subsectionNodes = subsectionSpans.filter(el => el.textContent === subsectionName);
+        if (!subsectionNodes || subsectionNodes.length === 0) return `Subsection '${subsectionNodes}' of section '${sectionName}' not found.`;
+        const isVisible = this.isScrolledIntoView(subsectionNodes[0]);
+        if (!isVisible) {
+            subsectionNodes[0].scrollIntoView();
+        }
+        return null;
+    }
 
   down( e ) {
     const pos = this.minimap.getBoundingClientRect()

--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -100,7 +100,6 @@ export class Minimap extends React.Component {
       }
     }
 
-    this.sectionPositions = {};
     const nodes = this.ref.querySelectorAll(this.props.selector)
     let diff = 0;
     this.setState({
@@ -122,11 +121,6 @@ export class Minimap extends React.Component {
           hM = 0;
         }
 
-        this.sectionPositions[title] = this.sectionPositions[shortTitle] = {
-            left: Math.round( xM ),
-            top: Math.round( yM )
-        };
-
         return (
           <ChildComponent
             key={key}
@@ -144,21 +138,15 @@ export class Minimap extends React.Component {
   }
 
     moveToSection(sectionName) {
-//        const posForSection = this.sectionPositions[sectionName];
-//        if (Lang.isUndefined(posForSection)) return "No section named '" + sectionName + "' found.";
-//        const { left, top } = posForSection;
         const sectionElements = Array.from(this.ref.querySelectorAll(".section-header>span"));
         const sectionNodes = sectionElements.filter(el => el.textContent === sectionName);
         if (!sectionNodes || sectionNodes.length === 0) return `Section '${sectionName}' not found.`;
-
-
 
         if (Lang.isUndefined(this.x) || Lang.isUndefined(this.y)) {
             this.x = 0
             this.y = 0;
         }
         sectionNodes[0].scrollIntoView();
-//        this.scrollTo(left, top);
         return null;
     }
 
@@ -183,7 +171,7 @@ export class Minimap extends React.Component {
         // just scroll to subsection instead
         const subsectionSpans = Array.from(this.ref.querySelectorAll(".list-subsection-header>span"));
         const subsectionNodes = subsectionSpans.filter(el => el.textContent === subsectionName);
-        if (!subsectionNodes || subsectionNodes.length === 0) return `Subsection '${subsectionNodes}' of section '${sectionName}' not found.`;
+        if (!subsectionNodes || subsectionNodes.length === 0) return `Subsection '${subsectionName}' of section '${sectionName}' not found.`;
         const isVisible = this.isScrolledIntoView(subsectionNodes[0]);
         if (!isVisible) {
             subsectionNodes[0].scrollIntoView();

--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -155,6 +155,27 @@ export class Minimap extends React.Component {
       return null;
   }
 
+  isScrolledIntoView(elem) {
+    const overall_div = document.querySelector('.minimap-container');
+    var docViewTop = this.ref.clientTop; //this.ref.scrollTop;
+    var docViewBottom = docViewTop + overall_div.clientHeight; //this.ref.clientHeight; //scrollHeight
+
+    const { height, top} = elem.getBoundingClientRect()
+    var elemTop = top;
+    var elemBottom = elemTop + height;
+    //console.log(docViewTop, docViewBottom, elemTop, elemBottom);
+    return ((elemBottom <= docViewBottom) && (elemTop >= docViewTop));
+  }
+
+  moveToSubsection(subsectionName) {
+      const subsectionSpans = Array.from(this.ref.querySelectorAll(".list-subsection-header>span"));
+      const subsectionNode = subsectionSpans.filter(el => el.textContent === subsectionName)
+      if (!this.isScrolledIntoView(subsectionNode[0])) {
+        subsectionNode[0].scrollIntoView();
+      }
+      return null;
+  }
+
   down( e ) {
     const pos = this.minimap.getBoundingClientRect()
 

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -60,7 +60,7 @@ class PatientControlPanel extends Component {
                                             patient={this.props.patient}
                                             setSearchSelectedItem={this.props.setSearchSelectedItem}
                                             searchIndex={this.props.searchIndex}
-                                            moveTargetedDataPanelToSection={this.props.moveTargetedDataPanelToSection}
+                                            moveTargetedDataPanelToSubsection={this.props.moveTargetedDataPanelToSubsection}
                                         />
                                     </Col>
                                 </Row>

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -60,6 +60,7 @@ class PatientControlPanel extends Component {
                                             patient={this.props.patient}
                                             setSearchSelectedItem={this.props.setSearchSelectedItem}
                                             searchIndex={this.props.searchIndex}
+                                            moveTargetedDataPanelToSection={this.props.moveTargetedDataPanelToSection}
                                         />
                                     </Col>
                                 </Row>

--- a/src/panels/TargetedDataPanel.jsx
+++ b/src/panels/TargetedDataPanel.jsx
@@ -17,6 +17,10 @@ export default class TargetedDataPanel extends Component {
         return this.minimap.moveToSection(sectionName);
     }
 
+    moveToSubsection(subsectionName) {
+        return this.minimap.moveToSubsection(subsectionName);
+    }
+
     render () {
         // The css data attribute associated with the minimap
         const minimapAttribute = 'data-test-summary-section';

--- a/src/panels/TargetedDataPanel.jsx
+++ b/src/panels/TargetedDataPanel.jsx
@@ -17,8 +17,8 @@ export default class TargetedDataPanel extends Component {
         return this.minimap.moveToSection(sectionName);
     }
 
-    moveToSubsection(subsectionName) {
-        return this.minimap.moveToSubsection(subsectionName);
+    moveToSubsection(sectionName, subsectionName) {
+        return this.minimap.moveToSubsection(sectionName, subsectionName);
     }
 
     render () {

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -229,7 +229,8 @@ class PatientSearch extends React.Component {
 
             this.props.setSearchSelectedItem(selectedNote);
         } else {
-            this.props.moveTargetedDataPanelToSection(suggestion.section);
+            console.log(suggestion);
+            this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
         }
     }
 

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -228,6 +228,8 @@ class PatientSearch extends React.Component {
             const selectedNote = contextNotes.find(note => note.entryInfo.entryId === suggestion.note.entryInfo.entryId);
 
             this.props.setSearchSelectedItem(selectedNote);
+        } else {
+            this.props.moveTargetedDataPanelToSection(suggestion.section);
         }
     }
 

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -229,7 +229,6 @@ class PatientSearch extends React.Component {
 
             this.props.setSearchSelectedItem(selectedNote);
         } else {
-            console.log(suggestion);
             this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
         }
     }

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -179,7 +179,7 @@ class BandedLineChartVisualizer extends Component {
             >
                 <div className="sub-section-heading">
                     <h2 className="sub-section-name list-subsection-header">
-                        <span>{`${yVar} (${yUnit})`}</span>
+                        <span>{`${yVar}`}</span><span>{` (${yUnit})`}</span>
                     </h2>
                 </div>
                 <LineChart

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -117,8 +117,8 @@ class BandedLineChartVisualizer extends Component {
         if (Lang.isUndefined(processedData) || processedData.length === 0) {
             return <div key={yVar}>
                         <div className="sub-section-heading">
-                            <h2 className="sub-section-name">
-                                {yVar}
+                            <h2 className="sub-section-name list-subsection-header">
+                                <span>{yVar}</span>
                             </h2>
                         </div>
                         <h2 style={{paddingTop: '10px'}}>None</h2>
@@ -178,8 +178,8 @@ class BandedLineChartVisualizer extends Component {
                 key={yVar}
             >
                 <div className="sub-section-heading">
-                    <h2 className="sub-section-name">
-                        {`${yVar} (${yUnit})`}
+                    <h2 className="sub-section-name list-subsection-header">
+                        <span>{`${yVar} (${yUnit})`}</span>
                     </h2>
                 </div>
                 <LineChart

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -143,8 +143,12 @@ export default class TabularListVisualizer extends Component {
             subsectionName = transformedSubsection.name;
         }
 
+        let nameSuffix = '';
+        if (transformedSubsection.name_suffix) {
+            nameSuffix = <span>{nameSuffix}</span>;
+        }
         if (subsectionName && subsectionName.length > 0) {
-            subsectionNameHTML = <h2 className="subsection list-subsection-header"><span>{subsectionName}</span></h2>;
+            subsectionNameHTML = <h2 className="subsection list-subsection-header"><span>{subsectionName}</span>{nameSuffix}</h2>;
         }
 
         if (list.length <= 0) {

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -50,7 +50,8 @@ class VisualizerManager {
             typicalRange += ")";
         }
 
-        newsection.name = subsection.name + typicalRange;
+        newsection.name = subsection.name;
+        newsection.name_suffix = typicalRange;
         newsection.headings = ["Date", "Value"];
         newsection.items = itemList.map((labResult) => {
             return [ labResult["start_time"], labResult[subsection.name] + " " + labResult["unit"] ];


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1354 subtask for search task. requesting merge into search-structured-data branch. @mgramigna  should be 1 reviewer plus we need another.

Should be able to click on structured data search results and it will show the subsection that the data is in within the targeted data panel. Did not change clinical note search results but I think they should work. I added a JIRA for search results being under the timeline when that is scrolled up. I also added a JIRA to fix the patient search tests in our backend tests. This sub-task did not break them but instead the overall task did so I just made a sub-task to fix them.

JIRA 1301 bug. Easy fix. Now can send commands to navigate to a subsection or a section. To show a subsection, it first scrolls to its section and if the entire subsection is not visible, it will then scroll to the subsection instead (e.g., the 3rd graph).

NOTE that only the names of sections on the right in the content can be used as targets of command scrolling. We no longer support the minimap names when they are shorter. 

Examples:
  flux_command('navigate_targeted_data_panel', {section:'Labs', subsection:'Hemoglobin'})
  flux_command('navigate_targeted_data_panel', {section:'Clinical Trials', subsection:'Potential to enroll'})
  flux_command('navigate_targeted_data_panel', {section:'Timeline'})
  flux_command('navigate_targeted_data_panel', {section:'Medications'})
  flux_command('navigate_targeted_data_panel', {section:'Summary', subsection:'Most Recent Visit'})
  flux_command('navigate_targeted_data_panel', {section:'Summary', subsection:'Key Dates'})
  flux_command('navigate_targeted_data_panel', {section:'Procedures'})
  flux_command('navigate_targeted_data_panel', {section:'Active Conditions'})

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
