### PR TITLE
Fix tabular list visualizer

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -257,37 +257,37 @@ export class FullApp extends Component {
     }
 
     sourceActionIsDisabled = (element) => {
-        if (element.value && Lang.isArray(element.value) && element.value.length > 2 && element.value[2]) {
+        if (element.source) {
             return false;
         }
         return true;
     }
 
     nameSourceAction = (element) => {
-        if (element.value && Lang.isArray(element.value) && element.value.length > 2 && element.value[2]) {
-            return (element.value[2] instanceof Reference ? "Open Source Note" : "View Source");
+        if (element.source) {
+            return (element.source instanceof Reference ? "Open Source Note" : "View Source");
         }
         return "No source information";
     }
 
     openReferencedNote = (item, itemLabel) => {
-        if (!item.value || !Lang.isArray(item.value) || item.value.length < 3 || Lang.isUndefined(item.value[2]) || Lang.isNull(item.value[2]) || item.value[2] === '') {
+        if (!item.source) {
             this.setState({
                 snackbarOpen: true,
                 snackbarMessage: "No source information or note available."
             });
             return;
         }
-        if (item.value[2] instanceof Reference) {
-            const sourceNote = this.state.patient.getEntryFromReference(item.value[2]);
+        if (item.source instanceof Reference) {
+            const sourceNote = this.state.patient.getEntryFromReference(item.source);
             this.setOpenClinicalNote(sourceNote);
         } else {
-            const labelForItem = (Lang.isArray(itemLabel) ? itemLabel[0] : itemLabel );
-            const title = "Source for " + (labelForItem === item.value[0] ? labelForItem : labelForItem + " of " + item.value[0]);
+            const labelForItem = itemLabel; // (Lang.isArray(itemLabel) ? itemLabel[0] : itemLabel );
+            const title = "Source for " + (labelForItem === item.value ? labelForItem : labelForItem + " of " + item.value);
             this.setState({
                 isModalOpen: true,
                 modalTitle: title,
-                modalContent: item.value[2]
+                modalContent: item.source
             });
         }
     }

--- a/src/patientControl/ColumnsIndexer.js
+++ b/src/patientControl/ColumnsIndexer.js
@@ -1,19 +1,32 @@
 import BaseIndexer from './BaseIndexer';
-import Lang from 'lodash';
 
 class ColumnIndexer extends BaseIndexer {
-    indexData(section, subsection, data, searchIndex) {
-        let list = data.items || [];
-        list.forEach(([title, valueObject]) => {
-            if(Lang.isObject(valueObject)) {
+    indexData(section, subsection, data, searchIndex, subsectionDescriptor) {
+        if (subsectionDescriptor.headings) {
+            // true tabular where each item is a column of data
+            // add each column value using title of the column heading
+            data.forEach((row) => {
+                row.forEach((col, columnNumber) => {
+                    searchIndex.addSearchableData({
+                        section,
+                        subsection,
+                        valueTitle: subsectionDescriptor.headings[columnNumber],
+                        value: col.value || "Missing Data"
+                    });    
+                });
+            });
+        } else {
+            // ones that are really just a name and value so more of a layout than columns/tabular
+            // add each row with 1st column as title and 2nd column as value
+            data.forEach(([title, valueObject]) => {
                 searchIndex.addSearchableData({
                     section,
                     subsection,
                     valueTitle: title.value,
                     value: valueObject.value || "Missing Data"
                 });
-            }
-        });
+            });
+        }
     }
 }
 

--- a/src/patientControl/ColumnsIndexer.js
+++ b/src/patientControl/ColumnsIndexer.js
@@ -18,13 +18,24 @@ class ColumnIndexer extends BaseIndexer {
         } else {
             // ones that are really just a name and value so more of a layout than columns/tabular
             // add each row with 1st column as title and 2nd column as value
-            data.forEach(([title, valueObject]) => {
-                searchIndex.addSearchableData({
-                    section,
-                    subsection,
-                    valueTitle: title.value,
-                    value: valueObject.value || "Missing Data"
-                });
+            data.forEach((row) => {
+                if (row.length < 2) {
+                    const [ valueObject ] = row;
+                    searchIndex.addSearchableData({
+                        section,
+                        subsection,
+                        valueTitle: subsection,
+                        value: valueObject.value || "Missing Data"
+                    });
+                } else {
+                    const [ title, valueObject ] = row;
+                    searchIndex.addSearchableData({
+                        section,
+                        subsection,
+                        valueTitle: title.value,
+                        value: valueObject.value || "Missing Data"
+                    });
+                }
             });
         }
     }

--- a/src/patientControl/ColumnsIndexer.js
+++ b/src/patientControl/ColumnsIndexer.js
@@ -10,7 +10,7 @@ class ColumnIndexer extends BaseIndexer {
                     section,
                     subsection,
                     valueTitle: title.value,
-                    value: valueObject.value[0] || "Missing Data"
+                    value: valueObject.value || "Missing Data"
                 });
             }
         });

--- a/src/patientControl/PatientSearch.scss
+++ b/src/patientControl/PatientSearch.scss
@@ -4,7 +4,7 @@
         position: relative;
         background-color: #ffffff;
         width: 100%;
-        z-index: 4;
+        z-index: 200;
     }
 
     .react-autosuggest__input {
@@ -61,7 +61,7 @@
         max-height: 309px;
         font-size: 16px;
         border-radius: 5px;
-        z-index: 2;
+        z-index: 200;
         overflow-y: auto;
         background-color: #FAFAFA;
         box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12);

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -94,7 +94,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
                 } else {
                     let val = item.value(patient, condition, loginUser);
                     if (val) {
-                        return {name: item.name, value: val[0], shortcut: item.shortcut, unsigned: val[1], sourceNote: val[2]};
+                        return {name: item.name, value: val[0], shortcut: item.shortcut, unsigned: val[1], source: val[2]};
                     } else {
                         return {name: item.name, value: null};
                     }
@@ -225,7 +225,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
             value: [
                 snippet.value,
                 snippet.unsigned,
-                snippet.sourceNote
+                snippet.source
             ],
         };
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1573,7 +1573,17 @@ export default class SummaryMetadata {
     getItemListForConditions = (patient, currentConditionEntry, subsection) => {
         const conditions = patient.getActiveConditions();
         return conditions.map((c, i) => {
-            return [{value: [ c.type, patient.isUnsigned(c), this.determineSource(patient, c) ], shortcut: subsection.shortcut}, c.diagnosisDate, c.bodySite];
+            return [
+                {    value: c.type, 
+                     isUnsigned: patient.isUnsigned(c),
+                     source: this.determineSource(patient, c),
+                     shortcut: subsection.shortcut
+                }, 
+                {   value: c.diagnosisDate
+                },
+                {   value: c.bodySite
+                }
+            ];
         });
     }
 
@@ -1582,23 +1592,22 @@ export default class SummaryMetadata {
         return procedures.map((p, i) => {
             // Ensure that each array for a given data type (e.g. Procedures in this case) contains the same number of elements (e.g. here it is 2 elements).
             // Or add to the end of the array, that looks okay too
+            let result = [
+                {   value: p.name, 
+                    isUnsigned: patient.isUnsigned(p),
+                    source:  this.determineSource(patient, p),
+                    shortcut: "@procedure"
+                }];
             if (typeof p.occurrenceTime !== 'string') {
-                return [
-                    {
-                        value: [p.name, patient.isUnsigned(p), this.determineSource(patient, p) ],
-                        shortcut: "@procedure",
-                    },
-                    p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd
-                ];
+                result.push(
+                    {   value: p.occurrenceTime.timePeriodStart + " to " + p.occurrenceTime.timePeriodEnd }
+                );
             } else {
-                return [
-                    {
-                        value: [p.name, patient.isUnsigned(p), this.determineSource(patient, p) ],
-                        shortcut: "@procedure",
-                    },
-                    p.occurrenceTime
-                ];
+                result.push(
+                    {   value: p.occurrenceTime }
+                );
             }
+            return result;
         });
     }
 
@@ -1720,15 +1729,23 @@ export default class SummaryMetadata {
             }).map((c, i) => {
                 return [
                     {
-                        value: [c.title, patient.isUnsigned(c), c.sourceClinicalNoteReference]
+                        value: c.title, 
+                        isUnsigned: patient.isUnsigned(c), 
+                        source: c.sourceClinicalNoteReference
                     },
                     {
-                        value: [(c.status === 'Candidate') ? 'N/A' : c.enrollmentDate, patient.isUnsigned(c), c.sourceClinicalNoteReference]
+                        value: (c.status === 'Candidate') ? 'N/A' : c.enrollmentDate,
+                        isUnsigned: patient.isUnsigned(c), 
+                        source: c.sourceClinicalNoteReference
                     },
                     {
-                        value: [(c.status === 'Candidate' || c.status === 'Enrolled' || c.status === 'Active') ? 'N/A' : c.endDate, patient.isUnsigned(c), c.sourceClinicalNoteReference]
+                        value: (c.status === 'Candidate' || c.status === 'Enrolled' || c.status === 'Active') ? 'N/A' : c.endDate, 
+                        isUnsigned: patient.isUnsigned(c), 
+                        source: c.sourceClinicalNoteReference
                     },
-                    c.details
+                    {
+                        value: c.details
+                    }
                 ]; 
             });
         }
@@ -1738,7 +1755,11 @@ export default class SummaryMetadata {
         let clinicalTrialsAndCriteriaList = patient.getEligibleClinicalTrials(currentConditionEntry, this.getItemListForEnrolledClinicalTrials(patient, currentConditionEntry));
         let eligibleTrials = [];
         clinicalTrialsAndCriteriaList.forEach((trial) => {
-            eligibleTrials.push([{ value: trial.info.name }, (trial.numSatisfiedCriteria + " of " + trial.numTotalCriteria), trial.info.studyStartDate, trial.info.description]);
+            eligibleTrials.push([   { value: trial.info.name }, 
+                                    { value: (trial.numSatisfiedCriteria + " of " + trial.numTotalCriteria) }, 
+                                    { value: trial.info.studyStartDate }, 
+                                    { value: trial.info.description }
+            ]);
         });
         this.eligibleTrials = eligibleTrials;
         this.refreshClinicalTrials = false;
@@ -1774,7 +1795,9 @@ export default class SummaryMetadata {
         if (Lang.isNull(patient) || Lang.isNull(currentConditionEntry)) return [];
         const allergies = patient.getAllergyIntolerancesSortedBySeverity();
         return allergies.map((a) => {
-            return [{value: a.name}, a.severity, a.manifestation];
+            return [    { value: a.name }, 
+                        { value: a.severity },
+                        { value: a.manifestation }];
         });
     }
 

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -37,15 +37,10 @@ export default class TabularListVisualizer extends Component {
     // Get a list of subsections to display given the current condition section
     getSubsections() {
         const { patient, condition, conditionSection } = this.props;
-
         if (patient == null || condition == null || conditionSection == null) return [];
-
-        let subsections = [];
-        conditionSection.data.forEach((subsection) => {
-            subsections.push(subsection);
+        return conditionSection.data.map((subsection) => {
+            return subsection;
         });
-
-        return subsections;
     }
 
     renderedSubsections(subsections) {
@@ -54,15 +49,21 @@ export default class TabularListVisualizer extends Component {
         const { patient, condition, sectionTransform } = this.props;
         const isSingleColumn = !this.props.isWide;
 
+        // get the data once!
+        // either the transform gets it and puts it in .data_cache for each subsection
+        // or our else clause below gets the data using getList and puts it in
+        // .data_cache for each subsection
         let transformedSubsections = subsections.map((subsection) => {
             if (!Lang.isUndefined(sectionTransform) && !Lang.isNull(sectionTransform)) {
                 return sectionTransform(patient, condition, subsection);
             } else {
+                subsection.data_cache = this.getList(subsection);
                 return subsection;
             }
         });
-        let list = this.getList(transformedSubsections[0]);
-        const numColumns = (list.length === 0) ? 1 : list[0].length;
+        // data in transformedSubsections[subsection index].data_cache
+
+        const numColumns = (transformedSubsections[0].data_cache.length === 0) ? 1 : transformedSubsections[0].data_cache[0].length;
 
         // currently including 2 column sections with a single subsection to use full width. could change to only use left side
         // easily if we get feedback that people don't like this.
@@ -77,8 +78,7 @@ export default class TabularListVisualizer extends Component {
         // for the second half of sections
         let numRows = 0;
         transformedSubsections.forEach((subsection) => {
-           subsection.list = this.getList(subsection);
-           numRows += subsection.list.length + 1;
+           numRows += subsection.data_cache.length + 1;
         });
 
         let halfRows = numRows / 2;
@@ -87,8 +87,8 @@ export default class TabularListVisualizer extends Component {
         let firstHalfSections = [];
         let secondHalfSections = [];
         transformedSubsections.forEach((subsection) => {
-            if (firstColumnRows === 0 || ((firstColumnRows + subsection.list.length) <= halfRows)) {
-                firstColumnRows += subsection.list.length;
+            if (firstColumnRows === 0 || ((firstColumnRows + subsection.data_cache.length) <= halfRows)) {
+                firstColumnRows += subsection.data_cache.length;
                 subsection.column = 1;
                 firstHalfSections.push(subsection);
             } else {
@@ -123,7 +123,7 @@ export default class TabularListVisualizer extends Component {
     // Render each subsection as a table of values
     renderedSubsection(transformedSubsection, subsectionindex) {
 
-        const list = this.getList(transformedSubsection);
+        const list = transformedSubsection.data_cache;
 
         let preTableCount = null;
         if (transformedSubsection.preTableCount) {
@@ -207,26 +207,8 @@ export default class TabularListVisualizer extends Component {
 
     // Render all list items
     renderedListItems(subsectionindex, list, numberOfHeadings, subsectionName, subsectionActions, formatFunction) {
-        let onClick, hoverClass, rowClass, itemClass = "";
-
         return list.map((item, index) => {
-            // Handles case where this method is passed a NameValuePair or other type accidentally, or null
-            if(!Lang.isArray(item) || Lang.isEmpty(item)){
-                itemClass = "list-missing";
-                item = [ "Missing data" ];
-                onClick = null;
-                hoverClass = null;
-            } else if(item[0].unsigned){
-                rowClass = "list-unsigned";
-                itemClass = "list-unsigned";
-                hoverClass = "list-button-hover";
-            } else {
-                rowClass = "list-captured";
-                itemClass = "list-captured";
-                hoverClass = "list-button-hover";
-            }
-            
-            return this.renderedListItem(item.slice(0, numberOfHeadings), subsectionindex, index, rowClass, itemClass, onClick, hoverClass, subsectionName, subsectionActions, formatFunction);
+            return this.renderedListItem(item.slice(0, numberOfHeadings), subsectionindex, index, "list-captured", subsectionName, subsectionActions, formatFunction);
         });
     }
 
@@ -240,7 +222,7 @@ export default class TabularListVisualizer extends Component {
             if (this.props.allowItemClick) {
                 return (
                     <li key={elementId}>
-                        {this.renderedStructuredData(elementText, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
+                        {this.renderedStructuredData(list[0], element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
                     </li>
                 );
             } else {
@@ -270,50 +252,34 @@ export default class TabularListVisualizer extends Component {
     }
 
     // Render a given list item as a row in a table
-    renderedListItem(item, subsectionindex, index, rowClass, itemClass, onClick, hoverClass, subsectionName, subsectionActions, formatFunction) {
+    renderedListItem(item, subsectionindex, index, rowClass, subsectionName, subsectionActions, formatFunction) {
         // Array of all columns
         const renderedColumns = [];
 
-        let isInsertable, elementText;
         const numColumns = item.length;
         const colSize = (100 / numColumns) + "%";
-        let isUnsigned;
 
 
         item.forEach((element, arrayIndex) => {
             const elementId = `${subsectionindex}-${index}-item-${arrayIndex}`
             let columnItem = null;
-            isInsertable = (Lang.isNull(element) ? false : (Lang.isUndefined(element.isInsertable) ? true : element.IsInsertable));
-            
-            // If the element is an array or an object, elementText is set to  
-            // first element of array or the value of the object.
-            elementText = Lang.isNull(element) ? null : (Lang.isArray(element) ? element[0] : (Lang.isObject(element) ? element.value : element));
+            const isInsertable = element.IsInsertable || true;
+            const isUnsigned = element.isUnsigned || false;
+            let elementText = element.value;
             const longElementText = elementText;
             
             if (!Lang.isNull(elementText) && elementText.length > 100) elementText = elementText.substring(0, 100) + "...";
 
-            // ElementTexts that are arrays are assumed to have two elements
-            // where the second is a boolean representing signed or unsigned.
-            if (Lang.isNull(elementText)) {
-                itemClass = 'list-missing';
-            } else {
-                if (Lang.isArray(elementText)) {
-                    isUnsigned = elementText[1];
-                    elementText = elementText[0];
-                } else {
-                    isUnsigned = false;
-                }
-                itemClass = (isUnsigned ? 'list-unsigned' : 'list-captured');
-            }
+            let itemClass = isUnsigned ? 'list-unsigned' : 'list-captured';
 
             // If this section has an associated formatFunction (that
             // returns a specific) CSS class, it is applied to elementText.
             if (formatFunction) {
                 itemClass += " " + formatFunction(elementText, element, arrayIndex);
             }
-            
 
-            if(Lang.isNull(element) || Lang.isUndefined(elementText) || Lang.isNull(elementText) || (typeof(elementText) === 'string' && elementText.length === 0)) {
+            // Make unique key for each value
+            if (Lang.isUndefined(elementText) || Lang.isNull(elementText) || (typeof(elementText) === 'string' && elementText.length === 0)) {
                 columnItem = (
                     <TableCell
                         className={"list-missing"}
@@ -326,35 +292,18 @@ export default class TabularListVisualizer extends Component {
                     </TableCell>
                 );
             } else if (isInsertable) {
-                // Get value off of element given two cases:
-                // 1. Element type is shortcut, value is returned by element.value()
-                // 2. Element type is string, the value is just the string
-
-                // Make unique id for each value
                 columnItem = (
                     <TableCell width={colSize}
                         className={itemClass}
                         key={elementId}
                     >
-                        {this.renderedStructuredData(item[0].value, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
+                        {this.renderedStructuredData(elementText, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
                     </TableCell>
 
-                );
-            } else if (!isInsertable) {
-                columnItem = (
-                    <TableCell width={colSize}
-                        key={elementId}
-                    >
-                        <span>
-                            {elementText}
-                        </span>
-                    </TableCell>
                 );
             } else {
                 columnItem = (
                     <TableCell width={colSize}
-                        className={itemClass}
-                        data-test-summary-item={item[0].value}
                         key={elementId}
                     >
                         <span>
@@ -364,26 +313,26 @@ export default class TabularListVisualizer extends Component {
                 );
             }
 
-                if (!Lang.isNull(elementText) && !Lang.isUndefined(elementText) && elementText.length > 100) {
-                    const text = <span>{longElementText}</span>
-                    columnItem = (
-                        <Tooltip
-                            key={elementId}
-                            overlayStyle={{ 'visibility': true }}
-                            placement="top"
-                            overlayClassName={`tabular-list-tooltip`}
-                            overlay={text}
-                            destroyTooltipOnHide={true}
-                            mouseEnterDelay={0.5}
-                            onMouseEnter={this.mouseEnter}
-                            onMouseLeave={this.mouseLeave}
-                        >
-                            {columnItem}
-                        </Tooltip>
-                    )
-                }
-                renderedColumns.push(columnItem);
-            });
+            if (!Lang.isNull(elementText) && !Lang.isUndefined(elementText) && elementText.length > 100) {
+                const text = <span>{longElementText}</span>
+                columnItem = (
+                    <Tooltip
+                        key={elementId}
+                        overlayStyle={{ 'visibility': true }}
+                        placement="top"
+                        overlayClassName={`tabular-list-tooltip`}
+                        overlay={text}
+                        destroyTooltipOnHide={true}
+                        mouseEnterDelay={0.5}
+                        onMouseEnter={this.mouseEnter}
+                        onMouseLeave={this.mouseLeave}
+                    >
+                        {columnItem}
+                    </Tooltip>
+                )
+            }
+            renderedColumns.push(columnItem);
+        });
 
         return (
             <TableRow
@@ -408,10 +357,7 @@ export default class TabularListVisualizer extends Component {
         }
         let isSigned = true;
         
-        if (Lang.isArray(element.value)) {
-            isSigned = !element.value[1];
-            //element = element[0];
-        }
+        isSigned = !element.isUnsigned || true;
         
         return (
             <VisualizerMenu

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -263,7 +263,7 @@ export default class TabularListVisualizer extends Component {
         item.forEach((element, arrayIndex) => {
             const elementId = `${subsectionindex}-${index}-item-${arrayIndex}`
             let columnItem = null;
-            const isInsertable = element.IsInsertable || true;
+            const isInsertable = Lang.isUndefined(element.isInsertable) ? true : element.isInsertable;
             const isUnsigned = element.isUnsigned || false;
             let elementText = element.value;
             const longElementText = elementText;

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -222,7 +222,7 @@ export default class TabularListVisualizer extends Component {
             if (this.props.allowItemClick) {
                 return (
                     <li key={elementId}>
-                        {this.renderedStructuredData(list[0], element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
+                        {this.renderedStructuredData(list[0].value, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
                     </li>
                 );
             } else {
@@ -297,7 +297,7 @@ export default class TabularListVisualizer extends Component {
                         className={itemClass}
                         key={elementId}
                     >
-                        {this.renderedStructuredData(elementText, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
+                        {this.renderedStructuredData(item[0].value, element, elementId, elementText, subsectionName, subsectionActions, arrayIndex)}
                     </TableCell>
 
                 );

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -148,28 +148,29 @@ export default class TargetedDataSection extends Component {
             let items = subsection.items;
             let itemsFunction = subsection.itemsFunction;
             let list;
-            let typeToIndex = type;
-
-            if (Lang.isUndefined(items)) {
-                list = itemsFunction(patient, condition, subsection);
-            } else {
-                list = items.map((item, i) => {
-                    if (Lang.isNull(item.value)) {
-                        return {name: item.name, value: null};
-                    } else {
-                        let val = item.value(patient, condition, loginUser);
-                        if (val) {
-                            return {name: item.name, value: val[0], shortcut: item.shortcut, unsigned: val[1], sourceNote: val[2]};
-                        } else {
-                            return {name: item.name, value: null};
-                        }
-                    }
-                });
-            }
+            let typeToIndex;
 
             if (sectionTransform) {
-                list = sectionTransform(patient, condition, subsection);
                 typeToIndex = viz.renderedFormat;
+                list = sectionTransform(patient, condition, subsection);
+            } else {
+                typeToIndex = type;
+                if (Lang.isUndefined(items)) {
+                    list = itemsFunction(patient, condition, subsection);
+                } else {
+                    list = items.map((item, i) => {
+                        if (Lang.isNull(item.value)) {
+                            return {name: item.name, value: null};
+                        } else {
+                            let val = item.value(patient, condition, loginUser);
+                            if (val) {
+                                return {name: item.name, value: val[0], shortcut: item.shortcut, unsigned: val[1], source: val[2]};
+                            } else {
+                                return {name: item.name, value: null};
+                            }
+                        }
+                    });
+                }    
             }
             const indexer = this.props.visualizerManager.getIndexer(typeToIndex);
             if (indexer) indexer.indexData(section.name, subsection.name, list, searchIndex);

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -172,9 +172,10 @@ export default class TargetedDataSection extends Component {
                             }
                         }
                     });
-                }    
+                }
             }
             const indexer = this.props.visualizerManager.getIndexer(typeToIndex);
+            if (!Lang.isUndefined(subsection.nameFunction)) subsection.name = subsection.nameFunction();
             if (indexer) indexer.indexData(section.name, subsection.name, list, searchIndex, newSubsection);
         })
 

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -147,13 +147,15 @@ export default class TargetedDataSection extends Component {
         subsections.forEach(subsection => {
             let items = subsection.items;
             let itemsFunction = subsection.itemsFunction;
-            let list;
+            let list, newSubsection;
             let typeToIndex;
 
             if (sectionTransform) {
                 typeToIndex = viz.renderedFormat;
-                list = sectionTransform(patient, condition, subsection);
+                newSubsection = sectionTransform(patient, condition, subsection);
+                list = newSubsection.data_cache;
             } else {
+                newSubsection = subsection;
                 typeToIndex = type;
                 if (Lang.isUndefined(items)) {
                     list = itemsFunction(patient, condition, subsection);
@@ -173,7 +175,7 @@ export default class TargetedDataSection extends Component {
                 }    
             }
             const indexer = this.props.visualizerManager.getIndexer(typeToIndex);
-            if (indexer) indexer.indexData(section.name, subsection.name, list, searchIndex);
+            if (indexer) indexer.indexData(section.name, subsection.name, list, searchIndex, newSubsection);
         })
 
         return (

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -53,8 +53,10 @@ class VisualizerManager {
         newsection.name = subsection.name;
         newsection.name_suffix = typicalRange;
         newsection.headings = ["Date", "Value"];
-        newsection.items = itemList.map((labResult) => {
-            return [ labResult["start_time"], labResult[subsection.name] + " " + labResult["unit"] ];
+        newsection.data_cache = itemList.map((labResult) => {
+            return  [   {   value: labResult["start_time"] },
+                        {   value: labResult[subsection.name] + " " + labResult["unit"] }
+                    ];
         })
         newsection.formatFunction = this.formatLabResult.bind(this, goodband);
         return newsection;
@@ -67,7 +69,7 @@ class VisualizerManager {
 
         newsection.name = "";
         newsection.headings = ["Medication", "Change", "Dosage", "Timing", "Start", "End"];
-        newsection.items = itemList.map((med) => {
+        newsection.data_cache = itemList.map((med) => {
             
             
             const dose = med.medication.amountPerDose ? `${med.medication.amountPerDose.value} ${med.medication.amountPerDose.units}` : "";
@@ -94,12 +96,17 @@ class VisualizerManager {
                 sourceClinicalNote = med.medicationChange.sourceClinicalNote;
             }
 
-            return [    med.medication.medication,
-                        {value: [medicationChange, isUnsigned, sourceClinicalNote]},
-                        dose,
-                        timing,
-                        med.medication.expectedPerformanceTime.timePeriodStart,
-                        {value: [endDate, isUnsigned, sourceClinicalNote]}  ];
+            return [    {   value: med.medication.medication },
+                        {   value: medicationChange, 
+                            unsigned: isUnsigned, 
+                            source: sourceClinicalNote },
+                        {   value: dose },
+                        {   value: timing },
+                        {   value: med.medication.expectedPerformanceTime.timePeriodStart },
+                        {   value: endDate, 
+                            unsigned: isUnsigned, 
+                            source: sourceClinicalNote }
+                    ];
         });
 
         // Format function used to 
@@ -162,41 +169,35 @@ class VisualizerManager {
     transformNameValuePairToColumns = (patient, condition, subsection) => {
         let newsection = {};
 
-        const items = subsection.items;
-        const itemsFunction = subsection.itemsFunction;
+        const { items, itemsFunction } = subsection;
         let list = null;
 
         if (Lang.isUndefined(items)) {
             list = itemsFunction(patient, condition, subsection);
         } else {
+            // call value functions and get values
             list = items.map((item, i) => {
-                if (Lang.isNull(item.value)) {
-                    return {name: item.name, value: null};
-                } else if (item.shortcut) {
-                    const itemValue = item.value(patient, condition, this.user);
-                    if (itemValue) {
-                        return {name: item.name, value: itemValue, shortcut: item.shortcut};
-                    } else {
-                        return {name: item.name, value: null, shortcut: item.shortcut};
-                    }
-                } else {
-                    const itemValue = item.value(patient, condition, this.user);
-                    if (itemValue) {
-                        return {name: item.name, value: itemValue };
-                    } else {
-                        return {name: item.name, value: null};
-                    }
-                }
+                const itemValue = (Lang.isNull(item.value)) ? null : item.value(patient, condition, this.user);
+                return [    { value: item.name, isInsertable: false},
+                            { value: itemValue || null, shortcut: item.shortcut || null}]
             });
         }
 
+        // need to eliminate when value is an array as came from value of a name/value pair. In that case the value array
+        // contains [0] value, [1] isUnsigned, and [2] source
         newsection.name = subsection.name;
-        newsection.items = list.map((item) => {
-            if (Lang.isNull(item.value)) {
-                return [    { value: item.name, isInsertable: false}, null ];
-            } else {
-                return [    { value: item.name, isInsertable: false}, { value: item.value, shortcut: item.shortcut } ];
-            }
+        newsection.data_cache = list.map((row, i) => {
+            return row.map((item) => {
+                if (Lang.isArray(item.value)) {
+                    return {    value: item.value[0],
+                                isUnsigned: item.value[1],
+                                source: item.value[2],
+                                shortcut: item.shortcut
+                            };
+                } else {
+                    return item;
+                }
+            });
         });
         return newsection;
     };
@@ -267,8 +268,6 @@ class VisualizerManager {
     }
 
     _tabularIcon = (isSelected) => {
-//        const visualization = this.checkVisualization();
-//        const strokeColor = visualization === "tabular" ? "#3F3F3F" : "#CCCCCC";
         const strokeColor = isSelected ? "#3F3F3F" : "#CCCCCC";
         return (
             <svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -285,8 +284,6 @@ class VisualizerManager {
     }
 
     _narrativeIcon = (isSelected) => {
-        //const visualization = this.checkVisualization();
-        //const strokeColor = visualization === "narrative" ? "#3F3F3F" : "#CCCCCC";
         const strokeColor = isSelected ? "#3F3F3F" : "#CCCCCC";
         return (
             <svg width="17px" height="15px" viewBox="0 0 17 15" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -303,8 +300,6 @@ class VisualizerManager {
     }
 
     _timelineIcon = (isSelected) => {
-        //const visualization = this.checkVisualization();
-        //const strokeColor = visualization === "graphic" ? "#3F3F3F" : "#CCCCCC";
         const strokeColor = isSelected ? "#3F3F3F" : "#CCCCCC";
         return (
             <svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -322,8 +317,6 @@ class VisualizerManager {
     }
 
     _chartIcon = (isSelected) => {
-        //const visualization = this.checkVisualization();
-        //const strokeColor = visualization === "chart" ? "#3F3F3F" : "#CCCCCC";
         const strokeColor = isSelected ? "#3F3F3F" : "#CCCCCC";
         return (
             <svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg">

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -19,6 +19,17 @@ export default class VisualizerMenu extends Component {
         });
         return filteredActions;
     }
+
+    arrayConvertArrayToObject = (a) => {
+        if (Lang.isArray(a.value)) {
+            return {    value: a.value[0],
+                        isUnsigned: a.value[1],
+                        source: a.value[2],
+                        shortcut: a.shortcut };
+        } else {
+            return a;
+        }
+    }
     
     // Renders a menu for an element with its associated meny items.
     render() {
@@ -44,18 +55,18 @@ export default class VisualizerMenu extends Component {
                         if (a.text) {
                             textSpec = a.text;
                         } else {
-                            textSpec = a.textfunction(this.props.element);
+                            textSpec = a.textfunction(this.arrayConvertArrayToObject(this.props.element));
                         }
                         let disabled = false;
                         if (!Lang.isUndefined(a.isdisabled)) {
-                            disabled = a.isdisabled(this.props.element);
+                            disabled = a.isdisabled(this.arrayConvertArrayToObject(this.props.element));
                         }
                         const text = textSpec.replace("{elementText}", this.props.elementText);
                         return (
                             <MenuItem
                                 key={`${this.props.elementId}-${index}`}
                                 disabled={disabled}
-                                onClick={() => this.props.onMenuItemClicked(a.handler, this.props.element, this.props.rowId)}
+                                onClick={() => this.props.onMenuItemClicked(a.handler, this.arrayConvertArrayToObject(this.props.element), this.props.rowId)}
                                 className="narrative-inserter-box"
                             >
                                 {icon}


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1361. Cleaned up TabularListVisualizer to use a common format of an object per cell. All the source viewing options still work. all the visualizations including alternative ones seem to work still. Now if you search for Surgery you see Timeline and Procedures result. Dates also result in Procedures and Conditions showing up. Try '15 Mar'.

Tests don't pass until the subtask to fix them is done.

JIRA 1378. If you scroll timeline to the top in targeted data panel with no note open and then perform a search, the search results now completely render over the timeline component.

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
