### PR TITLE
Search structured data results

### DIFF
--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -151,6 +151,7 @@ class PatientSearch extends React.Component {
                 section: obj.section,
                 subsection: obj.subsection,
                 contentSnapshot: obj.value,
+                valueTitle: obj.valueTitle,
                 inputValue,
                 matchedOn: "",
                 source: "structuredData"

--- a/src/patientControl/SearchSuggestion.css
+++ b/src/patientControl/SearchSuggestion.css
@@ -1,22 +1,21 @@
 .suggestion-item { 
-    display: flex;
+    display: block;
     align-items: center;
 }
 
 .suggestion-label { 
     min-width: 80px;
-    display: inline-block;
+    display: block;
     font-size: 10px;
     width: 80px;
     padding: 5px auto;
 }
 
 .suggestion-label .label-content { 
-    display: block;
     margin: 0;
+    display: inline-block;
     white-space: nowrap;
     line-height: 1.2rem;
-    overflow: hidden;
     text-overflow: ellipsis;
 }
 
@@ -34,7 +33,7 @@
 
 .suggestion-text { 
     font-size: 14px;
-    display: inline-block;
+    display: block;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -5,9 +5,110 @@ import './SearchSuggestion.css';
 
 
 class SearchSuggestion extends React.Component {
-    render() { 
-        const { suggestion} = this.props;
 
+    getSuggestionText() {
+        const { suggestion} = this.props;
+        //console.log(suggestion);
+        const fullSnapshot = suggestion.contentSnapshot;
+        const inputValue = suggestion.inputValue;
+        // Lowercase versions for index finding
+        const fullSnapshotLowerCase = fullSnapshot.toLowerCase();
+        const inputValueLowerCase = inputValue.toLowerCase();
+        const indexOfMatch = fullSnapshotLowerCase.indexOf(inputValueLowerCase);
+        // Slice original copies for highlighting
+        const preText = fullSnapshot.slice(0, indexOfMatch);
+        const highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length)
+        const postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
+        
+        let suggestionText = ''; 
+        if (suggestion.source === 'clincicalNote') {
+            console.log("note");
+            suggestionText = (
+                <div className="suggestion-text">
+                    <span>{preText}</span>
+                    <span className="highlightedInputValue">{highlightedText}</span>
+                    <span>{postText}</span>
+                </div>
+            )
+        } else if(suggestion.matchedOn === "contentSnapshot" && suggestion.source === 'structuredData') { 
+            console.log("value");
+            suggestionText = (
+                <div className="suggestion-text">
+                    <span>{suggestion.valueTitle + ` > `}</span>
+                    <span>{preText}</span>
+                    <span className="highlightedInputValue">{highlightedText}</span>
+                    <span>{postText}</span>
+                </div>
+            )
+        } else if (suggestion.matchedOn === "valueTitle"){ 
+            console.log("valueTitle");
+            suggestionText = (
+                <div className="suggestion-text">
+                    <span className="highlightedInputValue">{suggestion.valueTitle}</span>
+                    <span>{' > '}</span>
+                    <span>{suggestion.contentSnapshot}</span>
+                </div>
+            )
+        } else { 
+            console.log("section or subsection");
+            suggestionText = (
+                <div className="suggestion-text">{suggestion.contentSnapshot}</div> 
+            );
+        }
+        return suggestionText;
+    }
+
+    renderLabel = (suggestion) => {
+        let suggestionLabel = '';
+        if (suggestion.source === 'structuredData') {
+
+            if(suggestion.matchedOn === "section") {
+                let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
+                suggestionLabel = (
+                    <div className="suggestion-label">
+                        <span className={"label-content"}>  
+                            <span className="highlightedInputValue">{suggestion.section}</span>
+                         {subsection}</span>
+                    </div> 
+                );
+            }
+            else if(suggestion.matchedOn === "subsection") {
+                suggestionLabel = (
+                    <div className="suggestion-label">
+                        <span className={"label-content"}>{suggestion.section + ` > `}
+                            <span className="highlightedInputValue">{suggestion.subsection}</span>
+                        </span>
+                    </div> 
+                );
+            } else {
+                let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
+                suggestionLabel = (
+                <div className="suggestion-label">
+                    <span className={"label-content"}>{suggestion.section + subsection}</span>
+                </div> 
+                );
+            }
+            
+        } else if (suggestion.source === 'clinicalNote') {
+
+            suggestionLabel = (
+                <div className="suggestion-label">
+                    <span className={"label-content"}>
+                        <span className={(suggestion.matchedOn === "date" ? "highlightedInputValue" : "")}>{suggestion.date+ ` `}</span>
+                        <span className={(suggestion.matchedOn === "subject" ? "highlightedInputValue" : "")}>{suggestion.subject + ` `}</span>
+                        <span className={(suggestion.matchedOn === "hospital" ? "highlightedInputValue" : "")}>{ suggestion.hospital}</span>
+                    </span>
+                </div>
+            );
+        }
+
+        return suggestionLabel;
+    }
+
+    render() { 
+        
+        const { suggestion} = this.props;
+        /*console.log(suggestion);
         const fullSnapshot = suggestion.contentSnapshot;
         const inputValue = suggestion.inputValue;
         // Lowercase versions for index finding
@@ -33,7 +134,8 @@ class SearchSuggestion extends React.Component {
                 <span className="suggestion-text">{suggestion.contentSnapshot}</span> 
             );
         }
-
+        */
+        /*
         let suggestionLabel = '';
         if (suggestion.source === 'structuredData') {
             let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
@@ -50,15 +152,19 @@ class SearchSuggestion extends React.Component {
                     <span className={"label-content " + (suggestion.matchedOn === "hospital" ? "highlightedInputValue" : "")}>{suggestion.hospital}</span>
                 </div>
             );
-        }
+        }*/
         return (
             <div className="suggestion-item">
-                {suggestionLabel}
-                <span className="dividing-line"></span>
-                {suggestionText} 
+                {this.renderLabel(suggestion)}
+                {this.getSuggestionText()}
             </div>
         );
+
+        
+
+        
     }
+    
 }
 
 SearchSuggestion.propTypes = {

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -29,7 +29,7 @@ class SearchSuggestion extends React.Component {
                 </div>
             )
         } else if(suggestion.matchedOn === "contentSnapshot" && suggestion.source === 'structuredData') { 
-            let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle} > ` : '';
+            let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle} : ` : '';
             suggestionText = (
                 <div className="suggestion-text">
                     <span>{title}</span>
@@ -49,12 +49,12 @@ class SearchSuggestion extends React.Component {
                     <span>{preText}</span>
                     <span className="highlightedInputValue">{highlightedText}</span>
                     <span>{postText}</span>
-                    <span>{' > '}</span>
+                    <span>{' : '}</span>
                     <span>{suggestion.contentSnapshot}</span>
                 </div>
             )
         } else if (suggestion.matchedOn === "section" || suggestion.matchedOn === "subsection"){ 
-            let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle} > ` : '';
+            let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle} : ` : '';
             suggestionText = (
                 <div className="suggestion-text">
                 {title + suggestion.contentSnapshot}</div> 

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -40,10 +40,10 @@ class SearchSuggestion extends React.Component {
             )
         } else if (suggestion.matchedOn === "valueTitle"){ 
             let valueTitleLowerCase = suggestion.valueTitle.toLowerCase();
-            let indexOfMatch = valueTitleLowerCase.indexOf(inputValueLowerCase);
-            let preText = suggestion.valueTitle.slice(0, indexOfMatch);
-            let highlightedText = suggestion.valueTitle.slice(indexOfMatch, preText.length + inputValue.length);
-            let postText = suggestion.valueTitle.slice(preText.length + inputValue.length, suggestion.valueTitle.length);
+            indexOfMatch = valueTitleLowerCase.indexOf(inputValueLowerCase);
+            preText = suggestion.valueTitle.slice(0, indexOfMatch);
+            highlightedText = suggestion.valueTitle.slice(indexOfMatch, preText.length + inputValue.length);
+            postText = suggestion.valueTitle.slice(preText.length + inputValue.length, suggestion.valueTitle.length);
             suggestionText = (
                 <div className="suggestion-text">
                     <span>{preText}</span>
@@ -69,27 +69,19 @@ class SearchSuggestion extends React.Component {
 
     renderLabel = () => {
         const { suggestion} = this.props;
-        const fullSnapshot = suggestion.contentSnapshot;
         const inputValue = suggestion.inputValue;
-        // Lowercase versions for index finding
-        const fullSnapshotLowerCase = fullSnapshot.toLowerCase();
         const inputValueLowerCase = inputValue.toLowerCase();
-        let indexOfMatch = fullSnapshotLowerCase.indexOf(inputValueLowerCase);
-        // Slice original copies for highlighting
-        let preText = fullSnapshot.slice(0, indexOfMatch);
-        let highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length);
-        let postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
-
+   
         let suggestionLabel = '';
         if (suggestion.source === 'structuredData') {
 
             if(suggestion.matchedOn === "section") {
-                let sectionLowerCase = suggestion.section.toLowerCase();
-                let indexOfMatch = sectionLowerCase.indexOf(inputValueLowerCase);
-                let preText = suggestion.section.slice(0, indexOfMatch);
-                let highlightedText = suggestion.section.slice(indexOfMatch, preText.length + inputValue.length);
-                let postText = suggestion.section.slice(preText.length + inputValue.length, suggestion.section.length);
-                let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
+                const sectionLowerCase = suggestion.section.toLowerCase();
+                const indexOfMatch = sectionLowerCase.indexOf(inputValueLowerCase);
+                const preText = suggestion.section.slice(0, indexOfMatch);
+                const highlightedText = suggestion.section.slice(indexOfMatch, preText.length + inputValue.length);
+                const postText = suggestion.section.slice(preText.length + inputValue.length, suggestion.section.length);
+                const subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
                 suggestionLabel = (
                     <div className="suggestion-label">
                         <span className={"label-content"}>  
@@ -101,11 +93,11 @@ class SearchSuggestion extends React.Component {
                 );
             }
             else if(suggestion.matchedOn === "subsection") {
-                let subsectionLowerCase = suggestion.subsection.toLowerCase();
-                let indexOfMatch = subsectionLowerCase.indexOf(inputValueLowerCase);
-                let preText = suggestion.subsection.slice(0, indexOfMatch);
-                let highlightedText = suggestion.subsection.slice(indexOfMatch, preText.length + inputValue.length);
-                let postText = suggestion.subsection.slice(preText.length + inputValue.length, suggestion.subsection.length);
+                const subsectionLowerCase = suggestion.subsection.toLowerCase();
+                const indexOfMatch = subsectionLowerCase.indexOf(inputValueLowerCase);
+                const preText = suggestion.subsection.slice(0, indexOfMatch);
+                const highlightedText = suggestion.subsection.slice(indexOfMatch, preText.length + inputValue.length);
+                const postText = suggestion.subsection.slice(preText.length + inputValue.length, suggestion.subsection.length);
                 suggestionLabel = (
                     <div className="suggestion-label">
                         <span className={"label-content"}>{suggestion.section + ` > `}
@@ -116,7 +108,7 @@ class SearchSuggestion extends React.Component {
                     </div> 
                 );
             } else {
-                let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
+                const subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
                 suggestionLabel = (
                 <div className="suggestion-label">
                     <span className={"label-content"}>{suggestion.section + subsection}</span>
@@ -129,11 +121,11 @@ class SearchSuggestion extends React.Component {
             let subject = <span>{suggestion.subject + ` `}</span>;
             let hospital = <span>{suggestion.hospital + ` `}</span>;
             if(suggestion.matchedOn === "date"){
-                let dateLowerCase = suggestion.date.toLowerCase();
-                let indexOfMatch = dateLowerCase.indexOf(inputValueLowerCase);
-                let preText = suggestion.date.slice(0, indexOfMatch);
-                let highlightedText = suggestion.date.slice(indexOfMatch, preText.length + inputValue.length);
-                let postText = suggestion.date.slice(preText.length + inputValue.length, suggestion.date.length);
+                const dateLowerCase = suggestion.date.toLowerCase();
+                const indexOfMatch = dateLowerCase.indexOf(inputValueLowerCase);
+                const preText = suggestion.date.slice(0, indexOfMatch);
+                const highlightedText = suggestion.date.slice(indexOfMatch, preText.length + inputValue.length);
+                const postText = suggestion.date.slice(preText.length + inputValue.length, suggestion.date.length);
                 date = (
                     <span>
                     <span>{preText}</span>
@@ -142,11 +134,11 @@ class SearchSuggestion extends React.Component {
                     </span>
                 );
             } else if(suggestion.matchedOn === "subject"){
-                let subjectLowerCase = suggestion.subject.toLowerCase();
-                let indexOfMatch = subjectLowerCase.indexOf(inputValueLowerCase);
-                let preText = suggestion.subject.slice(0, indexOfMatch);
-                let highlightedText = suggestion.subject.slice(indexOfMatch, preText.length + inputValue.length);
-                let postText = suggestion.subject.slice(preText.length + inputValue.length, suggestion.subject.length);
+                const subjectLowerCase = suggestion.subject.toLowerCase();
+                const indexOfMatch = subjectLowerCase.indexOf(inputValueLowerCase);
+                const preText = suggestion.subject.slice(0, indexOfMatch);
+                const highlightedText = suggestion.subject.slice(indexOfMatch, preText.length + inputValue.length);
+                const postText = suggestion.subject.slice(preText.length + inputValue.length, suggestion.subject.length);
                 subject = (
                     <span>
                     <span>{preText}</span>
@@ -155,11 +147,11 @@ class SearchSuggestion extends React.Component {
                     </span>
                 );
             } else if(suggestion.matchedOn === "hospital"){
-                let hospitalLowerCase = suggestion.hospital.toLowerCase();
-                let indexOfMatch = hospitalLowerCase.indexOf(inputValueLowerCase);
-                let preText = suggestion.hospital.slice(0, indexOfMatch);
-                let highlightedText = suggestion.hospital.slice(indexOfMatch, preText.length + inputValue.length);
-                let postText = suggestion.hospital.slice(preText.length + inputValue.length, suggestion.hospital.length);
+                const hospitalLowerCase = suggestion.hospital.toLowerCase();
+                const indexOfMatch = hospitalLowerCase.indexOf(inputValueLowerCase);
+                const preText = suggestion.hospital.slice(0, indexOfMatch);
+                const highlightedText = suggestion.hospital.slice(indexOfMatch, preText.length + inputValue.length);
+                const postText = suggestion.hospital.slice(preText.length + inputValue.length, suggestion.hospital.length);
                 hospital = (
                     <span>
                     <span>{preText}</span>

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -6,23 +6,21 @@ import './SearchSuggestion.css';
 
 class SearchSuggestion extends React.Component {
 
-    getSuggestionText() {
+    renderSuggestionText() {
         const { suggestion} = this.props;
-        //console.log(suggestion);
         const fullSnapshot = suggestion.contentSnapshot;
         const inputValue = suggestion.inputValue;
         // Lowercase versions for index finding
         const fullSnapshotLowerCase = fullSnapshot.toLowerCase();
         const inputValueLowerCase = inputValue.toLowerCase();
-        const indexOfMatch = fullSnapshotLowerCase.indexOf(inputValueLowerCase);
+        let indexOfMatch = fullSnapshotLowerCase.indexOf(inputValueLowerCase);
         // Slice original copies for highlighting
-        const preText = fullSnapshot.slice(0, indexOfMatch);
-        const highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length)
-        const postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
+        let preText = fullSnapshot.slice(0, indexOfMatch);
+        let highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length)
+        let postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
         
         let suggestionText = ''; 
-        if (suggestion.source === 'clincicalNote') {
-            console.log("note");
+        if (suggestion.matchedOn === "contentSnapshot" && suggestion.source === 'clinicalNote') {
             suggestionText = (
                 <div className="suggestion-text">
                     <span>{preText}</span>
@@ -31,26 +29,37 @@ class SearchSuggestion extends React.Component {
                 </div>
             )
         } else if(suggestion.matchedOn === "contentSnapshot" && suggestion.source === 'structuredData') { 
-            console.log("value");
+            let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle} > ` : '';
             suggestionText = (
                 <div className="suggestion-text">
-                    <span>{suggestion.valueTitle + ` > `}</span>
+                    <span>{title}</span>
                     <span>{preText}</span>
                     <span className="highlightedInputValue">{highlightedText}</span>
                     <span>{postText}</span>
                 </div>
             )
         } else if (suggestion.matchedOn === "valueTitle"){ 
-            console.log("valueTitle");
+            let valueTitleLowerCase = suggestion.valueTitle.toLowerCase();
+            let indexOfMatch = valueTitleLowerCase.indexOf(inputValueLowerCase);
+            let preText = suggestion.valueTitle.slice(0, indexOfMatch);
+            let highlightedText = suggestion.valueTitle.slice(indexOfMatch, preText.length + inputValue.length);
+            let postText = suggestion.valueTitle.slice(preText.length + inputValue.length, suggestion.valueTitle.length);
             suggestionText = (
                 <div className="suggestion-text">
-                    <span className="highlightedInputValue">{suggestion.valueTitle}</span>
+                    <span>{preText}</span>
+                    <span className="highlightedInputValue">{highlightedText}</span>
+                    <span>{postText}</span>
                     <span>{' > '}</span>
                     <span>{suggestion.contentSnapshot}</span>
                 </div>
             )
-        } else { 
-            console.log("section or subsection");
+        } else if (suggestion.matchedOn === "section" || suggestion.matchedOn === "subsection"){ 
+            let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle} > ` : '';
+            suggestionText = (
+                <div className="suggestion-text">
+                {title + suggestion.contentSnapshot}</div> 
+            );
+        } else {
             suggestionText = (
                 <div className="suggestion-text">{suggestion.contentSnapshot}</div> 
             );
@@ -58,25 +67,51 @@ class SearchSuggestion extends React.Component {
         return suggestionText;
     }
 
-    renderLabel = (suggestion) => {
+    renderLabel = () => {
+        const { suggestion} = this.props;
+        const fullSnapshot = suggestion.contentSnapshot;
+        const inputValue = suggestion.inputValue;
+        // Lowercase versions for index finding
+        const fullSnapshotLowerCase = fullSnapshot.toLowerCase();
+        const inputValueLowerCase = inputValue.toLowerCase();
+        let indexOfMatch = fullSnapshotLowerCase.indexOf(inputValueLowerCase);
+        // Slice original copies for highlighting
+        let preText = fullSnapshot.slice(0, indexOfMatch);
+        let highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length);
+        let postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
+
         let suggestionLabel = '';
         if (suggestion.source === 'structuredData') {
 
             if(suggestion.matchedOn === "section") {
+                let sectionLowerCase = suggestion.section.toLowerCase();
+                let indexOfMatch = sectionLowerCase.indexOf(inputValueLowerCase);
+                let preText = suggestion.section.slice(0, indexOfMatch);
+                let highlightedText = suggestion.section.slice(indexOfMatch, preText.length + inputValue.length);
+                let postText = suggestion.section.slice(preText.length + inputValue.length, suggestion.section.length);
                 let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
                 suggestionLabel = (
                     <div className="suggestion-label">
                         <span className={"label-content"}>  
-                            <span className="highlightedInputValue">{suggestion.section}</span>
+                            <span>{preText}</span>
+                            <span className="highlightedInputValue">{highlightedText}</span>
+                            <span>{postText}</span>
                          {subsection}</span>
                     </div> 
                 );
             }
             else if(suggestion.matchedOn === "subsection") {
+                let subsectionLowerCase = suggestion.subsection.toLowerCase();
+                let indexOfMatch = subsectionLowerCase.indexOf(inputValueLowerCase);
+                let preText = suggestion.subsection.slice(0, indexOfMatch);
+                let highlightedText = suggestion.subsection.slice(indexOfMatch, preText.length + inputValue.length);
+                let postText = suggestion.subsection.slice(preText.length + inputValue.length, suggestion.subsection.length);
                 suggestionLabel = (
                     <div className="suggestion-label">
                         <span className={"label-content"}>{suggestion.section + ` > `}
-                            <span className="highlightedInputValue">{suggestion.subsection}</span>
+                            <span>{preText}</span>
+                            <span className="highlightedInputValue">{highlightedText}</span>
+                            <span>{postText}</span>
                         </span>
                     </div> 
                 );
@@ -90,13 +125,56 @@ class SearchSuggestion extends React.Component {
             }
             
         } else if (suggestion.source === 'clinicalNote') {
+            let date = <span>{suggestion.date + ` `}</span>;
+            let subject = <span>{suggestion.subject + ` `}</span>;
+            let hospital = <span>{suggestion.hospital + ` `}</span>;
+            if(suggestion.matchedOn === "date"){
+                let dateLowerCase = suggestion.date.toLowerCase();
+                let indexOfMatch = dateLowerCase.indexOf(inputValueLowerCase);
+                let preText = suggestion.date.slice(0, indexOfMatch);
+                let highlightedText = suggestion.date.slice(indexOfMatch, preText.length + inputValue.length);
+                let postText = suggestion.date.slice(preText.length + inputValue.length, suggestion.date.length);
+                date = (
+                    <span>
+                    <span>{preText}</span>
+                    <span className="highlightedInputValue">{highlightedText}</span>
+                    <span>{postText + ` `}</span>
+                    </span>
+                );
+            } else if(suggestion.matchedOn === "subject"){
+                let subjectLowerCase = suggestion.subject.toLowerCase();
+                let indexOfMatch = subjectLowerCase.indexOf(inputValueLowerCase);
+                let preText = suggestion.subject.slice(0, indexOfMatch);
+                let highlightedText = suggestion.subject.slice(indexOfMatch, preText.length + inputValue.length);
+                let postText = suggestion.subject.slice(preText.length + inputValue.length, suggestion.subject.length);
+                subject = (
+                    <span>
+                    <span>{preText}</span>
+                    <span className="highlightedInputValue">{highlightedText}</span>
+                    <span>{postText + ` `}</span>
+                    </span>
+                );
+            } else if(suggestion.matchedOn === "hospital"){
+                let hospitalLowerCase = suggestion.hospital.toLowerCase();
+                let indexOfMatch = hospitalLowerCase.indexOf(inputValueLowerCase);
+                let preText = suggestion.hospital.slice(0, indexOfMatch);
+                let highlightedText = suggestion.hospital.slice(indexOfMatch, preText.length + inputValue.length);
+                let postText = suggestion.hospital.slice(preText.length + inputValue.length, suggestion.hospital.length);
+                hospital = (
+                    <span>
+                    <span>{preText}</span>
+                    <span className="highlightedInputValue">{highlightedText}</span>
+                    <span>{postText}</span>
+                    </span>
+                );
+            }
 
             suggestionLabel = (
                 <div className="suggestion-label">
                     <span className={"label-content"}>
-                        <span className={(suggestion.matchedOn === "date" ? "highlightedInputValue" : "")}>{suggestion.date+ ` `}</span>
-                        <span className={(suggestion.matchedOn === "subject" ? "highlightedInputValue" : "")}>{suggestion.subject + ` `}</span>
-                        <span className={(suggestion.matchedOn === "hospital" ? "highlightedInputValue" : "")}>{ suggestion.hospital}</span>
+                        {date}
+                        {subject}
+                        {hospital}
                     </span>
                 </div>
             );
@@ -106,63 +184,12 @@ class SearchSuggestion extends React.Component {
     }
 
     render() { 
-        
-        const { suggestion} = this.props;
-        /*console.log(suggestion);
-        const fullSnapshot = suggestion.contentSnapshot;
-        const inputValue = suggestion.inputValue;
-        // Lowercase versions for index finding
-        const fullSnapshotLowerCase = fullSnapshot.toLowerCase();
-        const inputValueLowerCase = inputValue.toLowerCase();
-        const indexOfMatch = fullSnapshotLowerCase.indexOf(inputValueLowerCase);
-        // Slice original copies for highlighting
-        const preText = fullSnapshot.slice(0, indexOfMatch);
-        const highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length)
-        const postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
-        
-        let suggestionText = '';
-        if(suggestion.matchedOn === "contentSnapshot") { 
-            suggestionText = (
-                <div className="suggestion-text">
-                    <span>{preText}</span>
-                    <span className="highlightedInputValue">{highlightedText}</span>
-                    <span>{postText}</span>
-                </div>
-            )
-        } else { 
-            suggestionText = (
-                <span className="suggestion-text">{suggestion.contentSnapshot}</span> 
-            );
-        }
-        */
-        /*
-        let suggestionLabel = '';
-        if (suggestion.source === 'structuredData') {
-            let subsection = suggestion.subsection.length > 0 ? ` > ${suggestion.subsection}` : '';
-            suggestionLabel = (
-                <div className="suggestion-label">
-                    <span className={"label-content"}>{suggestion.section + subsection}</span>
-                </div> 
-            );
-        } else if (suggestion.source === 'clinicalNote') {
-            suggestionLabel = (
-                <div className="suggestion-label">
-                    <span className={"label-content " + (suggestion.matchedOn === "date" ? "highlightedInputValue" : "")}>{suggestion.date}</span>
-                    <span className={"label-content " + (suggestion.matchedOn === "subject" ? "highlightedInputValue" : "")}>{suggestion.subject}</span>
-                    <span className={"label-content " + (suggestion.matchedOn === "hospital" ? "highlightedInputValue" : "")}>{suggestion.hospital}</span>
-                </div>
-            );
-        }*/
         return (
             <div className="suggestion-item">
-                {this.renderLabel(suggestion)}
-                {this.getSuggestionText()}
+                {this.renderLabel()}
+                {this.renderSuggestionText()}
             </div>
         );
-
-        
-
-        
     }
     
 }


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Styling for the results of search structured data and clinical notes. Search input is bolded in the search results. 

Note that current enzyme tests do not pass due to changes in search-structured-data 

## Submitter:

**Running the Application**

- [ x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
