### PR TITLE
Remove grouping from timeline data retrieval

### DIFF
--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1858,7 +1858,6 @@ export default class SummaryMetadata {
 
     // Gets progression items for timeline view
     getProgressionItems = (patient, condition) => {
-        console.log("progression items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const progressions = patient.getProgressionsForConditionChronologicalOrder(condition);
         let items = [];
@@ -1895,7 +1894,6 @@ export default class SummaryMetadata {
     }
 
     getMedicationItems = (patient, condition) => {
-        console.log("medication items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const meds = patient.getMedicationsForConditionChronologicalOrder(condition);
         let items = [];
@@ -1932,7 +1930,6 @@ export default class SummaryMetadata {
     }
 
     getProcedureItems = (patient, condition) => {
-        console.log("procedure items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const procedures = patient.getProceduresForConditionChronologicalOrder(condition);
         let items = [];
@@ -1974,7 +1971,6 @@ export default class SummaryMetadata {
     }
 
     getEventItems = (patient, condition) => {
-        console.log("event items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const events = patient.getKeyEventsForConditionChronologicalOrder(condition);
         let items = [];
@@ -2017,7 +2013,6 @@ export default class SummaryMetadata {
     nextGroupNumber = 1;
 
     resetTimelineData = () => {
-        console.log("*********************** RESET")
         this.nextGroupNumber = 1;
     }
 
@@ -2032,15 +2027,12 @@ export default class SummaryMetadata {
         let availableGroup = this.nextGroupNumber || 1;
         let assignedGroup = null;
 
-        console.log("Starting at group " + availableGroup + " does " + startTime + " to " + endTime + " conflict?");
-
         while (!assignedGroup) {
             const existingItemsInGroup = this.filterItemsByGroup(existingItems, availableGroup);
             let conflict = false;
 
             for (let i = 0; i < existingItemsInGroup.length; i++) {
                 const existingItem = existingItemsInGroup[i];
-                console.log("    with " + existingItem.start_time + " to " + existingItem.end_time);
                 // endTime not always guarentted; perform our check conditionally here 
                 const doesEndTimeConflictWithExistingItem = (endTime ? endTime < existingItem.end_time && endTime >= existingItem.start_time : false);
                 const doesStartTimeConflictWithExistingItem = startTime < existingItem.end_time && startTime >= existingItem.start_time;
@@ -2057,7 +2049,6 @@ export default class SummaryMetadata {
                 conflict = false;
             } else {
                 assignedGroup = availableGroup;
-                console.log("  assigned: " + assignedGroup);
             }
         }
         this.nextGroupNumber = assignedGroup;
@@ -2072,7 +2063,7 @@ export default class SummaryMetadata {
                 subset.push(item);
             }
         });
-
+        
         return subset;
     }
 

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -700,6 +700,7 @@ export default class SummaryMetadata {
                         name: "Timeline",
                         shortName: "Timeline",
                         type: "Events",
+                        resetData: this.resetTimelineData,
                         data: [
                             {
                                 name: "Medications",
@@ -1500,6 +1501,7 @@ export default class SummaryMetadata {
                         name: "Timeline",
                         shortName: "Timeline",
                         type: "Events",
+                        resetData: this.resetTimelineData,
                         data: [
                             {
                                 name: "Medications",
@@ -1856,6 +1858,7 @@ export default class SummaryMetadata {
 
     // Gets progression items for timeline view
     getProgressionItems = (patient, condition) => {
+        console.log("progression items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const progressions = patient.getProgressionsForConditionChronologicalOrder(condition);
         let items = [];
@@ -1892,6 +1895,7 @@ export default class SummaryMetadata {
     }
 
     getMedicationItems = (patient, condition) => {
+        console.log("medication items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const meds = patient.getMedicationsForConditionChronologicalOrder(condition);
         let items = [];
@@ -1928,10 +1932,12 @@ export default class SummaryMetadata {
     }
 
     getProcedureItems = (patient, condition) => {
+        console.log("procedure items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const procedures = patient.getProceduresForConditionChronologicalOrder(condition);
         let items = [];
 
+        if (procedures.length > 0) this.incrementGroupNumber();
         procedures.forEach((proc) => {
             let startTime = new moment(typeof proc.occurrenceTime === 'string' ? proc.occurrenceTime : proc.occurrenceTime.timePeriodStart, "D MMM YYYY");
             let endTime = proc.occurrenceTime.timePeriodStart ? (!Lang.isNull(proc.occurrenceTime.timePeriodEnd) ? new moment(proc.occurrenceTime.timePeriodEnd, "D MMM YYYY") : null) : null;
@@ -1968,10 +1974,12 @@ export default class SummaryMetadata {
     }
 
     getEventItems = (patient, condition) => {
+        console.log("event items");
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const events = patient.getKeyEventsForConditionChronologicalOrder(condition);
         let items = [];
 
+        if (events.length > 0) this.incrementGroupNumber();
         events.forEach((evt) => {
             const assignedGroup = this.assignItemToGroup(items, evt.start_time, evt.end_time);
 
@@ -2009,7 +2017,12 @@ export default class SummaryMetadata {
     nextGroupNumber = 1;
 
     resetTimelineData = () => {
+        console.log("*********************** RESET")
         this.nextGroupNumber = 1;
+    }
+
+    incrementGroupNumber = () => {
+        this.nextGroupNumber++;
     }
 
     // Assigns a new timeline item to a group in the timeline, avoiding conflicts with
@@ -2019,12 +2032,15 @@ export default class SummaryMetadata {
         let availableGroup = this.nextGroupNumber || 1;
         let assignedGroup = null;
 
+        console.log("Starting at group " + availableGroup + " does " + startTime + " to " + endTime + " conflict?");
+
         while (!assignedGroup) {
             const existingItemsInGroup = this.filterItemsByGroup(existingItems, availableGroup);
             let conflict = false;
 
             for (let i = 0; i < existingItemsInGroup.length; i++) {
                 const existingItem = existingItemsInGroup[i];
+                console.log("    with " + existingItem.start_time + " to " + existingItem.end_time);
                 // endTime not always guarentted; perform our check conditionally here 
                 const doesEndTimeConflictWithExistingItem = (endTime ? endTime < existingItem.end_time && endTime >= existingItem.start_time : false);
                 const doesStartTimeConflictWithExistingItem = startTime < existingItem.end_time && startTime >= existingItem.start_time;
@@ -2041,6 +2057,7 @@ export default class SummaryMetadata {
                 conflict = false;
             } else {
                 assignedGroup = availableGroup;
+                console.log("  assigned: " + assignedGroup);
             }
         }
         this.nextGroupNumber = assignedGroup;

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -1340,6 +1340,7 @@ export default class SummaryMetadata {
                         name: "Timeline",
                         shortName: "Timeline",
                         type: "Events",
+                        resetData: this.resetTimelineData,
                         data: [
                             {
                                 name: "Medications",
@@ -1854,13 +1855,13 @@ export default class SummaryMetadata {
     }
 
     // Gets progression items for timeline view
-    getProgressionItems = (patient, condition, groupStartIndex) => {
+    getProgressionItems = (patient, condition) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const progressions = patient.getProgressionsForConditionChronologicalOrder(condition);
         let items = [];
 
         progressions.forEach((prog) => {
-            const assignedGroup = this.assignItemToGroup(items, groupStartIndex, prog.clinicallyRelevantTime);
+            const assignedGroup = this.assignItemToGroup(items, prog.clinicallyRelevantTime);
 
             let classes = 'progression-item';
             // Do not include progression on timeline if status not set
@@ -1903,7 +1904,7 @@ export default class SummaryMetadata {
             if (!endTime.isValid()) {
                 endTime = new moment();
             }
-            const assignedGroup = this.assignItemToGroup(items, 1, startTime, endTime);
+            const assignedGroup = this.assignItemToGroup(items, startTime, endTime);
             const name = med.medication;
             let dosage;
             if (!med.amountPerDose) {
@@ -1926,7 +1927,7 @@ export default class SummaryMetadata {
         return items;
     }
 
-    getProcedureItems = (patient, condition, groupStartIndex) => {
+    getProcedureItems = (patient, condition) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const procedures = patient.getProceduresForConditionChronologicalOrder(condition);
         let items = [];
@@ -1934,7 +1935,7 @@ export default class SummaryMetadata {
         procedures.forEach((proc) => {
             let startTime = new moment(typeof proc.occurrenceTime === 'string' ? proc.occurrenceTime : proc.occurrenceTime.timePeriodStart, "D MMM YYYY");
             let endTime = proc.occurrenceTime.timePeriodStart ? (!Lang.isNull(proc.occurrenceTime.timePeriodEnd) ? new moment(proc.occurrenceTime.timePeriodEnd, "D MMM YYYY") : null) : null;
-            const assignedGroup = this.assignItemToGroup(items, groupStartIndex, startTime, endTime);
+            const assignedGroup = this.assignItemToGroup(items, startTime, endTime);
 
             let classes = 'event-item';
             //let endDate = proc.endDate;
@@ -1966,13 +1967,13 @@ export default class SummaryMetadata {
         return items;
     }
 
-    getEventItems = (patient, condition, groupStartIndex) => {
+    getEventItems = (patient, condition) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         const events = patient.getKeyEventsForConditionChronologicalOrder(condition);
         let items = [];
 
         events.forEach((evt) => {
-            const assignedGroup = this.assignItemToGroup(items, groupStartIndex, evt.start_time, evt.end_time);
+            const assignedGroup = this.assignItemToGroup(items, evt.start_time, evt.end_time);
 
             let classes = 'progression-item';
             let startDate = new moment(evt.start_time, "D MMM YYYY");
@@ -2005,11 +2006,17 @@ export default class SummaryMetadata {
         return items;
     }
 
+    nextGroupNumber = 1;
+
+    resetTimelineData = () => {
+        this.nextGroupNumber = 1;
+    }
+
     // Assigns a new timeline item to a group in the timeline, avoiding conflicts with
     // existing timeline items. If firstAvailableGroup is provided, the group assigned
     // will not be less than the firstAvailableGroup.
-    assignItemToGroup = (existingItems, firstAvailableGroup, startTime, endTime = null) => {
-        let availableGroup = firstAvailableGroup || 1;
+    assignItemToGroup = (existingItems, startTime, endTime = null) => {
+        let availableGroup = this.nextGroupNumber || 1;
         let assignedGroup = null;
 
         while (!assignedGroup) {
@@ -2036,6 +2043,7 @@ export default class SummaryMetadata {
                 assignedGroup = availableGroup;
             }
         }
+        this.nextGroupNumber = assignedGroup;
         return assignedGroup;
     }
 

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -144,6 +144,9 @@ export default class TargetedDataSection extends Component {
         const sectionTransform = viz.transform;
         const Visualizer = viz.visualizer;
         const subsections = this.getSubsections(section);
+
+        if (section.resetData) section.resetData();
+
         subsections.forEach(subsection => {
             let items = subsection.items;
             let itemsFunction = subsection.itemsFunction;

--- a/src/timeline/TimelineEventsVisualizer.jsx
+++ b/src/timeline/TimelineEventsVisualizer.jsx
@@ -69,8 +69,9 @@ class TimelineEventsVisualizer extends Component {
     createItems = (patient, condition, section) => {
         // Create groups and items to display on the timeline
         let items = [];
+        if (section.resetData) section.resetData();
         section.data.forEach((item, i) => {
-            items = items.concat(item.itemsFunction(patient, condition, this.getMaxGroup(items) + 1));
+            items = items.concat(item.itemsFunction(patient, condition)); //, this.getMaxGroup(items) + 1));
         });
 
         // Assign every item an ID and onClick handler


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
