### PR TITLE
Section search only finds section once

### DIFF
--- a/src/patientControl/BaseIndexer.js
+++ b/src/patientControl/BaseIndexer.js
@@ -1,7 +1,13 @@
 import { Component } from 'react';
 
 class BaseIndexer extends Component {
-    indexData() {
+    indexData(section, subsection, data, searchIndex) {
+        searchIndex.addSearchableData({
+            section,
+            subsection,
+            valueTitle: "subsection",
+            value: subsection
+        });
     }
 }
 

--- a/src/patientControl/BaseIndexer.js
+++ b/src/patientControl/BaseIndexer.js
@@ -6,7 +6,7 @@ class BaseIndexer extends Component {
             searchIndex.addSearchableData({
                 section,
                 subsection,
-                valueTitle: "subsection",
+                valueTitle: "Subsection",
                 value: subsection
             });
         }

--- a/src/patientControl/BaseIndexer.js
+++ b/src/patientControl/BaseIndexer.js
@@ -2,12 +2,14 @@ import { Component } from 'react';
 
 class BaseIndexer extends Component {
     indexData(section, subsection, data, searchIndex) {
-        searchIndex.addSearchableData({
-            section,
-            subsection,
-            valueTitle: "subsection",
-            value: subsection
-        });
+        if (subsection) {
+            searchIndex.addSearchableData({
+                section,
+                subsection,
+                valueTitle: "subsection",
+                value: subsection
+            });
+        }
     }
 }
 

--- a/src/patientControl/ClusterPointsIndexer.js
+++ b/src/patientControl/ClusterPointsIndexer.js
@@ -2,12 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class ClusterPointsIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
-        searchIndex.addSearchableData({
-            section,
-            subsection: "",
-            valueTitle: "",
-            value: ""
-        });
+        super.indexData(section, subsection, data, searchIndex);
     }
 }
 

--- a/src/patientControl/ColumnsIndexer.js
+++ b/src/patientControl/ColumnsIndexer.js
@@ -2,6 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class ColumnIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex, subsectionDescriptor) {
+        super.indexData(section, subsection, data, searchIndex);
         if (subsectionDescriptor.headings) {
             // true tabular where each item is a column of data
             // add each column value using title of the column heading

--- a/src/patientControl/DiseaseStatusValuesIndexer.js
+++ b/src/patientControl/DiseaseStatusValuesIndexer.js
@@ -2,6 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class DiseaseStatusValuesIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
+        super.indexData(section, subsection, data, searchIndex);
         data.potentialDiagnosisDates.forEach(item => {
             searchIndex.addSearchableData({
                 section,

--- a/src/patientControl/EventsIndexer.js
+++ b/src/patientControl/EventsIndexer.js
@@ -2,6 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class EventsIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
+        super.indexData(section, subsection, data, searchIndex);
         data.forEach(item => {
             searchIndex.addSearchableData({
                 section,

--- a/src/patientControl/MedicationsIndexer.js
+++ b/src/patientControl/MedicationsIndexer.js
@@ -2,6 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class MedicationsIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
+        super.indexData(section, subsection, data, searchIndex);
         data.forEach(item => {
             searchIndex.addSearchableData({
                 section,

--- a/src/patientControl/NameValuePairsIndexer.js
+++ b/src/patientControl/NameValuePairsIndexer.js
@@ -2,6 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class NameValuePairsIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
+        super.indexData(section, subsection, data, searchIndex);
         data.forEach(obj => {
             searchIndex.addSearchableData({
                 section,

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -161,16 +161,6 @@ class PatientSearch extends React.Component {
                 suggestion.matchedOn = "contentSnapshot";
                 suggestions.push(suggestion);
             }
-            contentMatches = regex.exec(obj.section);
-            if (contentMatches) {
-                suggestion.matchedOn = "section";
-                suggestions.push(suggestion);
-            }
-            contentMatches = regex.exec(obj.subsection);
-            if (contentMatches) {
-                suggestion.matchedOn = "subsection";
-                suggestions.push(suggestion);
-            }
             contentMatches = regex.exec(obj.valueTitle);
             if (contentMatches) {
                 suggestion.matchedOn = "valueTitle";

--- a/src/patientControl/ValueOverTimeIndexer.js
+++ b/src/patientControl/ValueOverTimeIndexer.js
@@ -2,6 +2,7 @@ import BaseIndexer from './BaseIndexer';
 
 class ValueOverTimeIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
+        super.indexData(section, subsection, data, searchIndex);
         data.forEach(item => {
             searchIndex.addSearchableData({
                 section,

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -183,7 +183,7 @@ export default class TargetedDataSection extends Component {
                 searchIndex.addSearchableData({
                     section: section.name,
                     subsection: "",
-                    valueTitle: "section",
+                    valueTitle: "Section",
                     value: section.name
                 });
                 indexer.indexData(section.name, subsection.name, list, searchIndex, newSubsection);

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -179,7 +179,15 @@ export default class TargetedDataSection extends Component {
             }
             const indexer = this.props.visualizerManager.getIndexer(typeToIndex);
             if (!Lang.isUndefined(subsection.nameFunction)) subsection.name = subsection.nameFunction();
-            if (indexer) indexer.indexData(section.name, subsection.name, list, searchIndex, newSubsection);
+            if (indexer) {
+                searchIndex.addSearchableData({
+                    section: section.name,
+                    subsection: "",
+                    valueTitle: "section",
+                    value: section.name
+                });
+                indexer.indexData(section.name, subsection.name, list, searchIndex, newSubsection);
+            }
         })
 
         return (


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA subtask 1385. Search for section names and should see section results. Search for subsection names and should see subsection results now. Searching for a section won't return all indexed items within that section anymore (unless they all have the section name in the name or value.

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [ ] Existing tests passed

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
