### PR TITLE
All visualizers now use data_cache to get their data instead of re-calling itemsfunction

### DIFF
--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -145,7 +145,7 @@ class PatientSearch extends React.Component {
 
     getStructuredDataSuggestions = (inputValue) => {
         let suggestions = [];
-        const regex = new RegExp(inputValue, "gi");
+        const regex = new RegExp(escapeRegExp(inputValue), "gi");
         this.props.searchIndex.searchableData.forEach(obj => {
             let suggestion = {
                 section: obj.section,

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -40,7 +40,7 @@ class BandedLineChartVisualizer extends Component {
 
     // Turns dates into numeric representations for graphing
     processForGraphing = (data, xVar, xVarNumber) => {
-        const dataCopy = Lang.clone(data);
+        const dataCopy = Lang.cloneDeep(data);
 
         Collection.map(dataCopy, (d) => {
             d[xVarNumber] = Number(new Date(d[xVar]))
@@ -111,7 +111,7 @@ class BandedLineChartVisualizer extends Component {
         const xVar = "start_time";
         const xVarNumber = `${xVar}Number`;
         const yVar = subsection.name;
-        const data = subsection.itemsFunction(patient, condition, subsection);
+        const data = subsection.data_cache;
         // process dates into numbers for graphing
         const processedData = this.processForGraphing(data, xVar, xVarNumber);
         if (Lang.isUndefined(processedData) || processedData.length === 0) {

--- a/src/summary/MedicationRangeChartVisualizer.jsx
+++ b/src/summary/MedicationRangeChartVisualizer.jsx
@@ -67,8 +67,7 @@ class MedicationRangeChartVisualizer extends Component {
     }
 
     renderedSubsection(subsection, index) {
-        const {patient, condition} = this.props;
-        const items = subsection.itemsFunction(patient, condition, subsection);
+        const items = subsection.data_cache;
         
         if (items.length === 0) return <h2 key={index}>None</h2>;
         const rows = items.map((med, i) => this.renderMedication(med, i));

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -76,32 +76,7 @@ class NarrativeNameValuePairsVisualizer extends Component {
     // for the given subsection object, return the list of data items it specifies
     // includes resolve value functions (value) per item (items) and item list functions (itemsFunction)
     getList(subsection) {
-        const {patient, condition, conditionSection, loginUser} = this.props;
-        if (patient == null || condition == null || conditionSection == null) {
-            return [];
-        }
-
-        const items = subsection.items;
-        const itemsFunction = subsection.itemsFunction;
-        let list = null;
-
-        if (Lang.isUndefined(items)) {
-            list = itemsFunction(patient, condition, subsection);
-        } else {
-            list = items.map((item, i) => {
-                if (Lang.isNull(item.value)) {
-                    return {name: item.name, value: null};
-                } else {
-                    let val = item.value(patient, condition, loginUser);
-                    if (val) {
-                        return {name: item.name, value: val[0], shortcut: item.shortcut, unsigned: val[1], source: val[2]};
-                    } else {
-                        return {name: item.name, value: null};
-                    }
-                }
-            });
-        }
-        return list;
+        return subsection.data_cache;
     }
             
     /* returns a list of snippets of the narrative. Each snippet object has the following attributes:

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -83,7 +83,7 @@ class ProgressionLineChartVisualizer extends Component {
 
     // Turns dates into numeric representations for graphing
     processForGraphing = (data) => {
-        return Lang.clone(data).map((d, i) => {
+        return Lang.cloneDeep(data).map((d, i) => {
             const code = d[this.yVarField];
             const numberBasedOnCode = this.codeToValueMap[code];
 
@@ -178,7 +178,7 @@ class ProgressionLineChartVisualizer extends Component {
     }
 
     renderProgressionChart = (patient, condition, conditionSection) => { 
-        const { progressions, potentialDiagnosisDates } = conditionSection.data[0].itemsFunction(patient, condition, conditionSection);
+        const { progressions, potentialDiagnosisDates } = conditionSection.data[0].data_cache;
         // process dates into numbers for graphing
         const processedData = this.processForGraphing(progressions);
         const processedPotentialDiagnosisDates = this.processPotentialDiagnosisDates(potentialDiagnosisDates)

--- a/src/summary/ScatterPlotVisualizer.jsx
+++ b/src/summary/ScatterPlotVisualizer.jsx
@@ -38,7 +38,7 @@ class ScatterPlotVisualizer extends Component {
 
     renderScatterPlot = (patient, condition, conditionSection) => {
 
-        const myData = conditionSection.data[0].itemsFunction(patient, condition, conditionSection);
+        const myData = conditionSection.data[0].data_cache;
         if (Lang.isObject(myData)) {
             let categoryMap = {};
             myData.forEach(function (series) {

--- a/src/summary/TabularListVisualizer.jsx
+++ b/src/summary/TabularListVisualizer.jsx
@@ -46,38 +46,23 @@ export default class TabularListVisualizer extends Component {
     renderedSubsections(subsections) {
         if (subsections.length === 0) return null;
 
-        const { patient, condition, sectionTransform } = this.props;
         const isSingleColumn = !this.props.isWide;
 
-        // get the data once!
-        // either the transform gets it and puts it in .data_cache for each subsection
-        // or our else clause below gets the data using getList and puts it in
-        // .data_cache for each subsection
-        let transformedSubsections = subsections.map((subsection) => {
-            if (!Lang.isUndefined(sectionTransform) && !Lang.isNull(sectionTransform)) {
-                return sectionTransform(patient, condition, subsection);
-            } else {
-                subsection.data_cache = this.getList(subsection);
-                return subsection;
-            }
-        });
-        // data in transformedSubsections[subsection index].data_cache
-
-        const numColumns = (transformedSubsections[0].data_cache.length === 0) ? 1 : transformedSubsections[0].data_cache[0].length;
+        const numColumns = (subsections[0].data_cache.length === 0) ? 1 : subsections[0].data_cache[0].length;
 
         // currently including 2 column sections with a single subsection to use full width. could change to only use left side
         // easily if we get feedback that people don't like this.
-        if (isSingleColumn || numColumns > 2 || transformedSubsections.length === 1) {
-            return transformedSubsections.map((subsection, index) => {
+        if (isSingleColumn || numColumns > 2 || subsections.length === 1) {
+            return subsections.map((subsection, index) => {
                 return this.renderedSubsection(subsection, index);
             });
         }
 
         // We are doing 2 columns of sections
-        // Grab the sections from transformedSubsections and create 2 arrays, one for the first half of the sections and another
+        // Grab the sections from subsections and create 2 arrays, one for the first half of the sections and another
         // for the second half of sections
         let numRows = 0;
-        transformedSubsections.forEach((subsection) => {
+        subsections.forEach((subsection) => {
            numRows += subsection.data_cache.length + 1;
         });
 
@@ -86,7 +71,7 @@ export default class TabularListVisualizer extends Component {
         let firstColumnRows = 0;
         let firstHalfSections = [];
         let secondHalfSections = [];
-        transformedSubsections.forEach((subsection) => {
+        subsections.forEach((subsection) => {
             if (firstColumnRows === 0 || ((firstColumnRows + subsection.data_cache.length) <= halfRows)) {
                 firstColumnRows += subsection.data_cache.length;
                 subsection.column = 1;

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -119,19 +119,6 @@ export default class TargetedDataSection extends Component {
         }
     }
 
-    getSubsections(section) {
-        const { patient, condition } = this.props;
-
-        if (patient == null || condition == null || section == null) return [];
-
-        let subsections = [];
-        section.data.forEach((subsection) => {
-            subsections.push(subsection);
-        });
-
-        return subsections;
-    }
-
     // renderSection checks the type of data that is being passed and chooses the correct component to render the data
     // TODO: Add a List type and a tabular renderer for it for Procedures section. case where left column is data
     //       and not just a label
@@ -143,11 +130,10 @@ export default class TargetedDataSection extends Component {
         if (Lang.isNull(viz)) return null;
         const sectionTransform = viz.transform;
         const Visualizer = viz.visualizer;
-        const subsections = this.getSubsections(section);
-
         if (section.resetData) section.resetData();
         searchIndex.removeDataBySection(section.name);
 
+        const subsections = patient === null || condition === null || section === null ? [] : section.data;
         subsections.forEach(subsection => {
             let items = subsection.items;
             let itemsFunction = subsection.itemsFunction;
@@ -178,6 +164,7 @@ export default class TargetedDataSection extends Component {
                     });
                 }
             }
+            subsection.data_cache = list;
             const indexer = this.props.visualizerManager.getIndexer(typeToIndex);
             if (!Lang.isUndefined(subsection.nameFunction)) subsection.name = subsection.nameFunction();
             if (indexer) {

--- a/src/timeline/TimelineEventsVisualizer.jsx
+++ b/src/timeline/TimelineEventsVisualizer.jsx
@@ -71,7 +71,7 @@ class TimelineEventsVisualizer extends Component {
         let items = [];
         if (section.resetData) section.resetData();
         section.data.forEach((item, i) => {
-            items = items.concat(item.itemsFunction(patient, condition)); //, this.getMaxGroup(items) + 1));
+            items = items.concat(item.data_cache || []);
         });
 
         // Assign every item an ID and onClick handler


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Sub task 1362. We now only make a call to get the data once, in TargetedDataSection, and that data gets passed on for each subsection as the data_cache prop which is used in the individual visualizers.

Best way to test is to just make sure all the data in the targeted data panel is the same and we can still do everything with the targeted data panel that we could do before (view source, insert into a note, etc.).

## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
