### PR TITLE
Blur search field on click

### DIFF
--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -222,6 +222,15 @@ class PatientSearch extends React.Component {
         } else {
             this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
         }
+        this.autoSuggestInput.blur();
+    }
+
+    onSuggestionHighlighted = ({suggestion}) => {
+        if (!Lang.isNull(suggestion)) {
+            if (suggestion.source !== "clinicalNote") {
+                this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
+            }
+        }
     }
 
     // When the input is focused, Autosuggest will consult this function when to render suggestions
@@ -240,7 +249,7 @@ class PatientSearch extends React.Component {
     renderInputComponent = (inputProps) => (
         <div>
             <span className="fa fa-search search-icon"></span>
-            <input {...inputProps} />
+            <input {...inputProps} ref={(c) => { this.autoSuggestInput = c; }} />
         </div>
     );
 
@@ -258,6 +267,7 @@ class PatientSearch extends React.Component {
                 <Autosuggest
                     getSuggestionValue={this.getSuggestionValue}
                     inputProps={inputProps}
+                    onSuggestionHighlighted={this.onSuggestionHighlighted}
                     onSuggestionsClearRequested={this.onSuggestionsClearRequested}
                     onSuggestionSelected={this.onSuggestionSelected}
                     onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -213,7 +213,7 @@ class PatientSearch extends React.Component {
   
 
     // Will be called every time suggestion is selected via mouse or keyboard.
-    onSuggestionSelected = (event, { suggestion, suggestionValue, suggestionIndex, sectionIndex, method }) => { 
+    onSuggestionSelected = (event, { suggestion, suggestionValue, suggestionIndex, sectionIndex, method }) => {
         if (suggestion.source === "clinicalNote") {
             const contextNotes = this.props.patient.getNotes();
             const selectedNote = contextNotes.find(note => note.entryInfo.entryId === suggestion.note.entryInfo.entryId);
@@ -222,7 +222,7 @@ class PatientSearch extends React.Component {
         } else {
             this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
         }
-        this.autoSuggestInput.blur();
+        this.refs.autosuggest.input.blur();
     }
 
     onSuggestionHighlighted = ({suggestion}) => {
@@ -249,7 +249,7 @@ class PatientSearch extends React.Component {
     renderInputComponent = (inputProps) => (
         <div>
             <span className="fa fa-search search-icon"></span>
-            <input {...inputProps} ref={(c) => { this.autoSuggestInput = c; }} />
+            <input {...inputProps} />
         </div>
     );
 
@@ -265,6 +265,7 @@ class PatientSearch extends React.Component {
         return (
             <div id="patient-search">
                 <Autosuggest
+                    ref="autosuggest"
                     getSuggestionValue={this.getSuggestionValue}
                     inputProps={inputProps}
                     onSuggestionHighlighted={this.onSuggestionHighlighted}
@@ -275,6 +276,7 @@ class PatientSearch extends React.Component {
                     renderSuggestion={this.renderSuggestion}
                     shouldRenderSuggestions={this.shouldRenderSuggestions}
                     suggestions={suggestions}
+                    focusInputOnSuggestionClick={false}
                 />
             </div>
         );


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1386. blur search field after selecting search result.

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [ ] Existing tests passed


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
