### PR TITLE
Remove section data before indexing if targeted data section is re-re…

### DIFF
--- a/src/patientControl/SearchIndex.js
+++ b/src/patientControl/SearchIndex.js
@@ -12,6 +12,10 @@ class SearchIndex {
     addSearchableData(data) {
         this._searchableData.push(data);
     }
+
+    removeDataBySection(section) {
+        Lang.remove(this._searchableData, data => data.section === section);
+    }
 }
 
 export default SearchIndex;

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -146,6 +146,7 @@ export default class TargetedDataSection extends Component {
         const subsections = this.getSubsections(section);
 
         if (section.resetData) section.resetData();
+        searchIndex.removeDataBySection(section.name);
 
         subsections.forEach(subsection => {
             let items = subsection.items;


### PR DESCRIPTION
…ndered

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Subtask 1372. Data was being indexed multiple times if the target data section re-rendered. Added a call to remove section data from the searchIndex before re-indexing in the rendering.

## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
