### PR TITLE
Fixed tests to use searchIndex as a prop to correctly handle searchin…

### DIFF
--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -286,6 +286,7 @@ class PatientSearch extends React.Component {
 PatientSearch.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
+    searchIndex: PropTypes.object.isRequired
 };
 
 export default PatientSearch;

--- a/test/backend/patientControl/PatientControl.test.js
+++ b/test/backend/patientControl/PatientControl.test.js
@@ -9,6 +9,7 @@ import TestPatient from '../../TestPatient.json';
 const testPatientShrId = '123456'
 
 import PatientSearch from '../../../src/patientControl/PatientSearch'
+import SearchIndex from '../../../src/patientControl/SearchIndex';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -37,10 +38,13 @@ describe('PatientSearch', function () {
         didSetFullAppStateFunctionTrigger = true
     }
 
+    const searchIndex = new SearchIndex();
+
     it('Should update state.value when input is entered ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
             setSearchSelectedItem={jest.fn()}
+            searchIndex={searchIndex}
         />);
         expect(wrapper).to.exist;
         const inputField = wrapper.find('input.react-autosuggest__input')
@@ -55,6 +59,7 @@ describe('PatientSearch', function () {
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
             setSearchSelectedItem={jest.fn()}
+            searchIndex={searchIndex}
         />);
         const inputField = wrapper.find('input.react-autosuggest__input')
         inputField.simulate('change', { target: {value: inputValue}}); 
@@ -72,6 +77,7 @@ describe('PatientSearch', function () {
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
             setSearchSelectedItem={jest.fn()}
+            searchIndex={searchIndex}
         />);        
         const inputField = wrapper.find('input.react-autosuggest__input')
         inputField.simulate('change', { target: {value: inputValue}}); 
@@ -92,6 +98,7 @@ describe('PatientSearch', function () {
             patient={testPatientObj}
             setSearchSelectedItem={setSearchSelectedItem}
             setCondition={jest.fn()}
+            searchIndex={searchIndex}
         />);        
         const inputField = wrapper.find('input.react-autosuggest__input')
         inputField.simulate('change', { target: {value: inputValue}}); 

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -24,6 +24,8 @@ import hardCodedPatient from '../../../src/dataaccess/HardCodedPatient.json';
 import PatientRecord from '../../../src/patient/PatientRecord.jsx';
 import FluxInjury from '../../../src/model/condition/FluxInjury';
 
+import SearchIndex from '../../../src/patientControl/SearchIndex';
+
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('1 UpdateErrors', function () {
@@ -86,8 +88,9 @@ describe('3 TargetedDataControl', function() {
         }
         const defaultOrTabular = options.length > 0 ? options[0] : 'tabular';
 
-        const visualizerManager = new VisualizerManager()
-        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='post-encounter'/>);
+        const visualizerManager = new VisualizerManager();
+        const searchIndex = new SearchIndex();
+        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='post-encounter' searchIndex={searchIndex} />);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))
@@ -111,8 +114,9 @@ describe('4 TargetedDataControl - correct default visualizer Medications', funct
         });
         const expectedDefault = 'chart';
 
-        const visualizerManager = new VisualizerManager()
-        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='pre-encounter'/>);
+        const visualizerManager = new VisualizerManager();
+        const searchIndex = new SearchIndex();
+        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='pre-encounter' searchIndex={searchIndex} />);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -90,7 +90,7 @@ describe('3 TargetedDataControl', function() {
 
         const visualizerManager = new VisualizerManager();
         const searchIndex = new SearchIndex();
-        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='post-encounter' searchIndex={searchIndex} />);
+        const wrapper = shallow(<TargetedDataSection patient={null} condition={null} section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='post-encounter' searchIndex={searchIndex} />);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))
@@ -116,7 +116,7 @@ describe('4 TargetedDataControl - correct default visualizer Medications', funct
 
         const visualizerManager = new VisualizerManager();
         const searchIndex = new SearchIndex();
-        const wrapper = shallow(<TargetedDataSection section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='pre-encounter' searchIndex={searchIndex} />);
+        const wrapper = shallow(<TargetedDataSection patient={null} condition={null} section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='pre-encounter' searchIndex={searchIndex} />);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))


### PR DESCRIPTION
…g tests

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Subtask 1379. Backend tests were broken because we added a searchIndex prop that is supposed to be passed down from FullApp, but this was not present in the tests. All tests should pass now.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
