### PR TITLE
Fix picklist options panel height

### DIFF
--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -20,10 +20,9 @@ $note-assitant-width-3: 160px;
            20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars
            5px is the height of the container's top margin
            42px is the height of the toggle buttons
-           51px is the height of the delete button 
+           60px is the height of the delete button and action buttons
         */
-        max-height: calc(100vh - 92px - 20px - 5px - 42px - 51px); // - 51px original, played with 30px
-    }
+        max-height: calc(100vh - 92px - 20px - 5px - 42px - 60px); 
     
     .toggle-buttons-container {
         display: flex !important;

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -20,9 +20,9 @@ $note-assitant-width-3: 160px;
            20px is the height of the top margin of post encounter view content and a little extra for potential scroll bars
            5px is the height of the container's top margin
            42px is the height of the toggle buttons
-           56px is the height of the delete button 
+           51px is the height of the delete button 
         */
-        max-height: calc(100vh - 92px - 20px - 5px - 42px - 51px);
+        max-height: calc(100vh - 92px - 20px - 5px - 42px - 51px); // - 51px original, played with 30px
     }
     
     .toggle-buttons-container {

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -23,6 +23,7 @@ $note-assitant-width-3: 160px;
            60px is the height of the delete button and action buttons
         */
         max-height: calc(100vh - 92px - 20px - 5px - 42px - 60px); 
+    }
     
     .toggle-buttons-container {
         display: flex !important;

--- a/src/panels/PickListOptionsPanel.css
+++ b/src/panels/PickListOptionsPanel.css
@@ -6,10 +6,9 @@
 
 /* ------------------------- OPTIONS ------------------------------ */
 #pickList-options {
-    /* 80vh for modal,  40px for modal padding, 20 for panel margin, 55px for action buttons height  */
+    /* 80vh for modal,  40px for modal padding, 20 for panel margin, 60px for action buttons height  */
     height: calc(80vh - 40px - 20px - 60px);
     max-height: calc(80vh - 40px - 20px - 60px);
-    overflow-y: auto;
 }
 
 /* ------------------------- SHORTCUT OPTIONS ------------------------------ */

--- a/src/panels/PickListOptionsPanel.css
+++ b/src/panels/PickListOptionsPanel.css
@@ -6,9 +6,9 @@
 
 /* ------------------------- OPTIONS ------------------------------ */
 #pickList-options {
-    /* 80vh for modal,  40px for modal padding, 20 for panel margin, 40px for action buttons height  */
-    height: calc(80vh - 40px - 20px - 40px);
-    max-height: calc(80vh - 40px - 20px - 40px);
+    /* 80vh for modal,  40px for modal padding, 20 for panel margin, 55px for action buttons height  */
+    height: calc(80vh - 40px - 20px - 60px);
+    max-height: calc(80vh - 40px - 20px - 60px);
     overflow-y: auto;
 }
 
@@ -93,6 +93,11 @@
     display: flex;
     margin-top: 30px;
     max-height: 40px;
+    justify-content: center;
+    position: absolute;
+    bottom: 6px;
+    background-color: #fff;
+    width: 160px;
 }
 
 #pickList-options-panel #pickList-action-buttons button {
@@ -103,6 +108,7 @@
     min-width: inherit;
     flex: 1;
     margin-right: 8px;
+    margin-bottom: 10px;
 }
 
 #pickList-options-panel button#cancel-btn {


### PR DESCRIPTION
This PR addresses issue 1340. To address the issue of the picklist options panel being too tall and requiring users to scroll to get to the Cancel and Ok buttons, two approaches were taken. The picklist options panel height was adjusted and also, functionality was added so that the Cancel and Ok buttons are always visible despite having to scroll (similar to the delete note button). 

@Dtphelan1 helped with some fine tweaking of the styling.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- N/A Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added Enzyme-UI tests for slim mode 
- N/A Added Enzyme-UI tests for full mode
- N/A Added backend tests for new functionality added
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
