### PR TITLE
remove # prefixes when displaying shortcuts

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1494,7 +1494,7 @@ class FluxNotesEditor extends React.Component {
                     />
                     <div className='editor-content'>
                         <Slate.Editor
-                            className="editor-panel"
+                            className={this.props.selectedNote.signed ? "editor-panel" : "editor-panel in-progress-note"}
                             placeholder={'Enter your clinical note here or choose a template to start from...'}
                             plugins={this.plugins}
                             readOnly={!this.props.isNoteViewerEditable}

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1475,6 +1475,9 @@ class FluxNotesEditor extends React.Component {
         }
 
         const callback = {}
+        const editorClassName = (this.props.selectedNote && this.props.selectedNote.signed)
+            ? "editor-panel"
+            : "editor-panel in-progress-note";
         /**
          * Render the editor, toolbar, dropdown and description for note
          */
@@ -1494,7 +1497,7 @@ class FluxNotesEditor extends React.Component {
                     />
                     <div className='editor-content'>
                         <Slate.Editor
-                            className={this.props.selectedNote.signed ? "editor-panel" : "editor-panel in-progress-note"}
+                            className={editorClassName}
                             placeholder={'Enter your clinical note here or choose a template to start from...'}
                             plugins={this.plugins}
                             readOnly={!this.props.isNoteViewerEditable}

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -111,25 +111,26 @@
 }
 
 // ******** StructuredFieldPlugin.jsx uses this
-.structured-field-inserter {
-    // background-color: #d9ebf9;
-    // border-bottom: 1px solid #ddd;
-    color: grey;
+// Highlighted during template hovering
+.structured-field-highlighted {
+    font-weight: bold;
+}
 
-    &-highlighted {
-        font-weight: bold;
-    }
+// Inserter values are grayed out
+.structured-field-inserter {
+    color: $state;
 }
 
 .structured-field-creator {
-    // background-color: #d9ebf9;
-    border-bottom: 1.5px dashed rgba(1, 130, 215, 0.8);
-
-    &-highlighted {
-        font-weight: bold;
-    }
+    border-bottom: 1px solid $shr-context-line;
 }
 
+.in-progress-note { 
+    .structured-field-creator {
+        background-color: rgba(0, 0, 0, 0);
+        border-bottom: 1.5px dashed $shr-context-line;
+    }
+}
 .placeholder {
     background-color: #dddddd;
 }

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -111,8 +111,19 @@
 }
 
 // ******** StructuredFieldPlugin.jsx uses this
-.structured-field {
-    background-color: #d9ebf9;
+.structured-field-inserter {
+    // background-color: #d9ebf9;
+    // border-bottom: 1px solid #ddd;
+    color: #919191;
+
+    &-highlighted {
+        font-weight: bold;
+    }
+}
+
+.structured-field-creator {
+    // background-color: #d9ebf9;
+    border-bottom: 1.5px dashed rgba(1, 130, 215, 0.8);
 
     &-highlighted {
         font-weight: bold;

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -114,7 +114,7 @@
 .structured-field-inserter {
     // background-color: #d9ebf9;
     // border-bottom: 1px solid #ddd;
-    color: #919191;
+    color: grey;
 
     &-highlighted {
         font-weight: bold;

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -1,4 +1,5 @@
 import Placeholder from '../shortcuts/Placeholder';
+import InsertValue from '../shortcuts/InsertValue';
 import React from 'react';
 import Slate from '../lib/slate';
 import Lang from 'lodash';
@@ -57,11 +58,19 @@ function StructuredFieldPlugin(opts) {
         nodes: {
             structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
-                return <span contentEditable={false} className='structured-field' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                if (shortcut instanceof InsertValue) {
+                    return <span contentEditable={false} className='structured-field-inserter' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                } else {
+                    return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                }
             },
             highlighted_structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
-                return <span contentEditable={false} className='structured-field structured-field-highlighted' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                if (shortcut instanceof InsertValue) {
+                    return <span contentEditable={false} className='structured-field-inserter structured-field-highlighted' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                } else {
+                    return <span contentEditable={false} className='structured-field-creator structured-field-highlighted' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                }
             },
             placeholder: props => {
                 const placeholder = props.node.get('data').get('placeholder');

--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -185,7 +185,7 @@ export default class CreatorBase extends EntryShortcut {
     }
 
     getText() {
-        return this.getPrefixCharacter() + this.metadata["name"];
+        return this.metadata["name"];
     }
 
     getResultText() {

--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -120,7 +120,7 @@ export default class CreatorChild extends Shortcut {
     }
 
     getText() {
-        return `${this.getPrefixCharacter()}${this.text}`;
+        return this.text;
     }
 
     getShortcutType() {

--- a/src/shortcuts/CreatorIntermediary.jsx
+++ b/src/shortcuts/CreatorIntermediary.jsx
@@ -101,7 +101,7 @@ export default class CreatorIntermediary extends Shortcut {
     }
 
     getText() {
-        return "#" + this.metadata["name"];
+        return this.metadata["name"];
     }
 
     getId() {

--- a/src/shortcuts/Keyword.jsx
+++ b/src/shortcuts/Keyword.jsx
@@ -105,7 +105,7 @@ export default class Keyword extends Shortcut {
     }
 
     getText() {
-        return `${this.getPrefixCharacter()}${this.text}`;
+        return this.text;
     }
 
     getShortcutType() {

--- a/src/shortcuts/NLPHashtag.jsx
+++ b/src/shortcuts/NLPHashtag.jsx
@@ -229,7 +229,7 @@ export default class NLPHashtag extends Shortcut {
     }
 
     getText() {
-        return this.getPrefixCharacter() + this.metadata["name"];
+        return this.metadata["name"];
     }
 
     getResultText() {

--- a/src/shortcuts/SingleHashtagKeyword.jsx
+++ b/src/shortcuts/SingleHashtagKeyword.jsx
@@ -185,7 +185,7 @@ export default class SingleHashtagKeyword extends EntryShortcut {
     }
 
     getText() {
-        return this.getPrefixCharacter() + this.metadata["name"];
+        return this.metadata["name"];
     }
 
     getResultText() {

--- a/src/shortcuts/UpdaterBase.jsx
+++ b/src/shortcuts/UpdaterBase.jsx
@@ -217,7 +217,7 @@ export default class UpdaterBase extends EntryShortcut {
     }
 
     getText() {
-        return this.getPrefixCharacter() + this.metadata["name"];
+        return this.metadata["name"];
     }
 
     getId() {

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -350,7 +350,7 @@ describe('6 FluxNotesEditor', function() {
         wrapper.setProps({ updatedEditorNote });
 
         // Check structured phrases
-        const structuredField = wrapper.find('.structured-field');
+        const structuredField = wrapper.find('.structured-field-inserter');
         expect(structuredField.at(0).text()).to.equal(`Test Name `);
         expect(structuredField.at(1).text()).to.equal(`49 `);
         expect(structuredField.at(2).text()).to.equal(`Female `);
@@ -483,8 +483,8 @@ describe('6 FluxNotesEditor', function() {
         expect(notesPanelWrapper.find(FluxNotesEditor)).to.have.lengthOf(1);
         notesPanelWrapper.setState({ updatedEditorNote: { content: '@name' } });
 
-        expect(notesPanelWrapper.find('.structured-field')).to.have.length(1);
-        expect(notesPanelWrapper.find('.structured-field').text()).to.contain(patient.getName());
+        expect(notesPanelWrapper.find('.structured-field-inserter')).to.have.length(1);
+        expect(notesPanelWrapper.find('.structured-field-inserter').text()).to.contain(patient.getName());
     });
 
     it('6.3 renders notes panel, clicking "@condition" and choosing "Invasive ductal carcinoma of breast" creates a new condition section in the context tray and adds structured data.', () => {
@@ -544,8 +544,8 @@ describe('6 FluxNotesEditor', function() {
         const conditionSection = notesPanelWrapper.find('.context-tray').find('div').find('[title="Invasive ductal carcinoma of breast"]');
         expect(conditionSection).to.have.lengthOf(1);
 
-        expect(notesPanelWrapper.find('.structured-field')).to.have.length(1);
-        expect(notesPanelWrapper.find('.structured-field').text()).to.contain('Invasive ductal carcinoma of breast');
+        expect(notesPanelWrapper.find('.structured-field-inserter')).to.have.length(1);
+        expect(notesPanelWrapper.find('.structured-field-inserter').text()).to.contain('Invasive ductal carcinoma of breast');
     });
 
     it('6.4 Typing an inserterShortcut that is not currently valid in the editor does not result in a structured data insertion ', () => {
@@ -603,7 +603,7 @@ describe('6 FluxNotesEditor', function() {
         wrapper.setProps({ updatedEditorNote });
 
         // Check structured phrases
-        const structuredField = wrapper.find('.structured-field');
+        const structuredField = wrapper.find('.structured-field-creator');
         expect(structuredField).to.have.lengthOf(0)
 
         // Check full text
@@ -659,22 +659,32 @@ describe('6 FluxNotesEditor', function() {
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
 
         // let noteContent = ' #staging t2 n2 m1';
-        const arrayOfStructuredDataToEnter = ["@condition[[Invasive ductal carcinoma of breast]] ", "#staging ", "t2 ", "n2 ", "m1 "]
-        const arrayOfExpectedStructuredData = ["Invasive ductal carcinoma of breast ", "#staging ", "t2 ", "n2 ", "m1 "]
+        const arrayOfStructuredDataToEnter = ["@condition[[Invasive ductal carcinoma of breast]] ", "#staging ", "t2 ", "n2 ", "m1 "];
+        const arrayOfExpectedStructuredDataInserters = ["Invasive ductal carcinoma of breast "];
+        const arrayOfExpectedStructuredDataCreators = ["staging ", "t2 ", "n2 ", "m1 "];
         const updatedEditorNote = { content: arrayOfStructuredDataToEnter.join(' ') };
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
         wrapper.setProps({ updatedEditorNote });
 
-        // Check structured phrases
-        const structuredField = wrapper.find('.structured-field');
-        expect(structuredField).to.have.lengthOf(arrayOfExpectedStructuredData.length)
-        for (let index = 0; index < arrayOfExpectedStructuredData.length; index++) {
-            expect(structuredField.at(index).text()).to.contain(arrayOfExpectedStructuredData[index]);
+        // Check structured phrases inserters
+        const structuredFieldInserter = wrapper.find('.structured-field-inserter');
+        expect(structuredFieldInserter).to.have.lengthOf(arrayOfExpectedStructuredDataInserters.length)
+        for (let index = 0; index < arrayOfExpectedStructuredDataInserters.length; index++) {
+            expect(structuredFieldInserter.at(index).text()).to.contain(arrayOfExpectedStructuredDataInserters[index]);
+        }
+        // Check structured phrases creators
+        const structuredFieldCreator = wrapper.find('.structured-field-creator');
+        expect(structuredFieldCreator).to.have.lengthOf(arrayOfExpectedStructuredDataCreators.length)
+        for (let index = 0; index < arrayOfExpectedStructuredDataCreators.length; index++) {
+            expect(structuredFieldCreator.at(index).text()).to.contain(arrayOfExpectedStructuredDataCreators[index]);
         }
         // Check full text
         const editorContent = wrapper.find('.editor-content');
-        for (let index = 0; index < arrayOfExpectedStructuredData.length; index++) {
-            expect(editorContent.text()).to.contain(arrayOfExpectedStructuredData[index]);
+        for (let index = 0; index < arrayOfExpectedStructuredDataInserters.length; index++) {
+            expect(editorContent.text()).to.contain(arrayOfExpectedStructuredDataInserters[index]);
+        }
+        for (let index = 0; index < arrayOfExpectedStructuredDataCreators.length; index++) {
+            expect(editorContent.text()).to.contain(arrayOfExpectedStructuredDataCreators[index]);
         }
     });
 
@@ -727,13 +737,13 @@ describe('6 FluxNotesEditor', function() {
 
         // let noteContent = ' #staging t2 n2 m1';
         const arrayOfStructuredDataToEnter = ["#12/20/2015 "];
-        const arrayOfExpectedStructuredData = ["#12/20/2015 "];
+        const arrayOfExpectedStructuredData = ["12/20/2015 "];
         const updatedEditorNote = { content: arrayOfStructuredDataToEnter.join(' ') };
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
         wrapper.setProps({ updatedEditorNote });
 
         // Check structured phrases
-        const structuredField = wrapper.find('.structured-field');
+        const structuredField = wrapper.find('.structured-field-creator');
         expect(structuredField).to.have.lengthOf(arrayOfExpectedStructuredData.length)
         for (let index = 0; index < arrayOfExpectedStructuredData.length; index++) {
             expect(structuredField.at(index).text()).to.contain(arrayOfExpectedStructuredData[index]);
@@ -798,8 +808,8 @@ describe('6 FluxNotesEditor', function() {
         notesPanelWrapper.setState({ updatedEditorNote });
 
 
-        expect(notesPanelWrapper.find('.structured-field')).to.have.length(1);
-        expect(notesPanelWrapper.find('.structured-field').text()).to.contain('#deceased');        
+        expect(notesPanelWrapper.find('.structured-field-creator')).to.have.length(1);
+        expect(notesPanelWrapper.find('.structured-field-creator').text()).to.contain('deceased');        
 
         const deceasedChild = notesPanelWrapper.find('.context-tray').find('div.context-options-header[title="Date"]');
         expect(deceasedChild).to.have.lengthOf(1);
@@ -851,7 +861,8 @@ describe('6 FluxNotesEditor', function() {
         expect(notesPanelWrapper.find(NoteAssistant)).to.have.lengthOf(1);
 
         const arrayOfStructuredDataToEnter = ["@condition[[Invasive ductal carcinoma of breast]] ", "#PR ", "#Positive "];
-        const arrayOfExpectedStructuredData = ["Invasive ductal carcinoma of breast ", "#PR ", "#Positive "]
+        const arrayOfExpectedStructuredDataInserter = ["Invasive ductal carcinoma of breast "]
+        const arrayOfExpectedStructuredDataCreator = ["PR ", "Positive "]
         const updatedEditorNote = { content: arrayOfStructuredDataToEnter.join(' ') };
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
         fluxNotesEditor.instance().onFocus();
@@ -859,15 +870,24 @@ describe('6 FluxNotesEditor', function() {
         notesPanelWrapper.setState({ updatedEditorNote });
 
         // Check structured phrases
-        const structuredField = notesPanelWrapper.find('.structured-field');
-        expect(structuredField).to.have.lengthOf(arrayOfExpectedStructuredData.length)
-        for (let index = 0; index < arrayOfExpectedStructuredData.length; index++) {
-            expect(structuredField.at(index).text()).to.contain(arrayOfExpectedStructuredData[index]);
+        const structuredFieldInserter = notesPanelWrapper.find('.structured-field-inserter');
+        expect(structuredFieldInserter).to.have.lengthOf(arrayOfExpectedStructuredDataInserter.length)
+        for (let index = 0; index < arrayOfExpectedStructuredDataInserter.length; index++) {
+            expect(structuredFieldInserter.at(index).text()).to.contain(arrayOfExpectedStructuredDataInserter[index]);
+        }
+        const structuredFieldCreator = notesPanelWrapper.find('.structured-field-creator');
+        expect(structuredFieldCreator).to.have.lengthOf(arrayOfExpectedStructuredDataCreator.length)
+        for (let index = 0; index < arrayOfExpectedStructuredDataCreator.length; index++) {
+            expect(structuredFieldCreator.at(index).text()).to.contain(arrayOfExpectedStructuredDataCreator[index]);
         }
         // Check full text
-        const editorContent = notesPanelWrapper.find('.editor-content');
-        for (let index = 0; index < arrayOfExpectedStructuredData.length; index++) {
-            expect(editorContent.text()).to.contain(arrayOfExpectedStructuredData[index]);
+        const editorContentInserter = notesPanelWrapper.find('.editor-content');
+        for (let index = 0; index < arrayOfExpectedStructuredDataInserter.length; index++) {
+            expect(editorContentInserter.text()).to.contain(arrayOfExpectedStructuredDataInserter[index]);
+        }
+        const editorContentCreator = notesPanelWrapper.find('.editor-content');
+        for (let index = 0; index < arrayOfExpectedStructuredDataCreator.length; index++) {
+            expect(editorContentCreator.text()).to.contain(arrayOfExpectedStructuredDataCreator[index]);
         }
     });
 
@@ -1054,21 +1074,27 @@ describe('6 FluxNotesEditor', function() {
 
         // let noteContent = ' #staging t2 n2 m1';
         const arrayOfShortcutText = ["@condition[[Invasive ductal carcinoma of breast]] ", "#toxicity ", "#nausea ", "#disease status ", "#imaging "];
-        const arrayOfParsedShortcutText = ["Invasive ductal carcinoma of breast ", "#toxicity ", "#nausea ", "#disease status ", "#imaging "]
+        const arrayOfParsedShortcutTextInserter = ["Invasive ductal carcinoma of breast "]
+        const arrayOfParsedShortcutTextCreator = ["toxicity ", "nausea ", "disease status ", "imaging "]
         const updatedEditorNote = { content: arrayOfShortcutText.join(' ') };
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
         wrapper.setProps({ updatedEditorNote });
 
         // Check structured phrases
-        const structuredField = wrapper.find('.structured-field');
-        expect(structuredField).to.have.lengthOf(arrayOfParsedShortcutText.length)
-        for (let index = 0; index < arrayOfParsedShortcutText.length; index++) {
-            expect(structuredField.at(index).text()).to.contain(arrayOfParsedShortcutText[index]);
+        const structuredFieldInserter = wrapper.find('.structured-field-inserter');
+        expect(structuredFieldInserter).to.have.lengthOf(arrayOfParsedShortcutTextInserter.length)
+        for (let index = 0; index < arrayOfParsedShortcutTextInserter.length; index++) {
+            expect(structuredFieldInserter.at(index).text()).to.contain(arrayOfParsedShortcutTextInserter[index]);
+        }
+        const structuredFieldCreator = wrapper.find('.structured-field-creator');
+        expect(structuredFieldCreator).to.have.lengthOf(arrayOfParsedShortcutTextCreator.length)
+        for (let index = 0; index < arrayOfParsedShortcutTextCreator.length; index++) {
+            expect(structuredFieldCreator.at(index).text()).to.contain(arrayOfParsedShortcutTextCreator[index]);
         }
         // Check full text
-        const editorContent = wrapper.find('.editor-content');
-        for (let index = 0; index < arrayOfParsedShortcutText.length; index++) {
-            expect(editorContent.text()).to.contain(arrayOfParsedShortcutText[index]);
+        const editorContentCreator = wrapper.find('.editor-content');
+        for (let index = 0; index < arrayOfParsedShortcutTextCreator.length; index++) {
+            expect(editorContentCreator.text()).to.contain(arrayOfParsedShortcutTextCreator[index]);
         }
     });
 

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -1145,7 +1145,7 @@ describe('6 FluxNotesEditor', function() {
         clinicalNotesButton.at(0).props().onClick();
         notesPanelWrapper.update();
 
-        const inProgressNotes = notesPanelWrapper.find('.in-progress-note');
+        const inProgressNotes = notesPanelWrapper.find('.note.in-progress-note');
     
         // There are no unsigned notes on the patient's record initially
         expect(inProgressNotes).to.have.length(0);
@@ -1157,7 +1157,7 @@ describe('6 FluxNotesEditor', function() {
         clinicalNotesButton.at(0).props().onClick();
         notesPanelWrapper.update();
     
-        const inProgressNotesAfter = notesPanelWrapper.find('.in-progress-note');
+        const inProgressNotesAfter = notesPanelWrapper.find('.note.in-progress-note');
         expect(inProgressNotesAfter).to.have.length(1);
     });
 


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA 1373. no more hashtags when we render creator shortcuts. Still renders with same background color right now. Looking for thoughts on whether we think clinicians would want/expect the inserter shortcuts (record --> note) and creator shortcuts (record <-- note) to be differentiated visually.

Please post thoughts. I'm going to look at the concepts for styling our notes and see what they suggest.

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
