### PR TITLE
xAxis ticks now have min, max, and 4 additionally equally spaced ticks

### DIFF
--- a/src/patientControl/DiseaseStatusValuesIndexer.js
+++ b/src/patientControl/DiseaseStatusValuesIndexer.js
@@ -17,7 +17,7 @@ class DiseaseStatusValuesIndexer extends BaseIndexer {
                 section,
                 subsection: "",
                 valueTitle: progression.start_time,
-                value: progression.status
+                value: progression.disease_status_string
             });
         });
     }

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -139,7 +139,6 @@ class PatientSearch extends React.Component {
             }
             return suggestions;
         }, []); 
-
         return suggestions;
     }
 

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -8,13 +8,11 @@ import {
     ReferenceLine,
 } from 'recharts';
 import moment from 'moment';
-import {scaleLinear} from "d3-scale";
 import Collection from 'lodash';
 import Lang from 'lodash';
 import PropTypes from 'prop-types';
 
 import './ProgressionLineChartVisualizer.css';
-
 /*
  A BandedLineGraphVisualizer that graphs a set of data over time
  */
@@ -149,12 +147,22 @@ class ProgressionLineChartVisualizer extends Component {
     // Use min/max info to build ticks for the 
     // Assumes processed data
     getXAxisTicks = (xAxisDomain, processedPotentialDiagnosisDates) => {
+        // Ticks are going to contain the min and max values
+        let ticks = [...xAxisDomain];
         const totalNumberOfTicks = 6;
-        const scale = scaleLinear().domain(xAxisDomain).range([0, 1]);
-        const ticks = scale.ticks(totalNumberOfTicks - processedPotentialDiagnosisDates.length);
-        for (const obj of processedPotentialDiagnosisDates) {
-            ticks.push(obj.date);
+        // Minus the ticks at the beginning and the end
+        const totalNumberOfIntermediateTicks = totalNumberOfTicks - xAxisDomain.length
+        for (let numberOfTicks = 1; numberOfTicks <= totalNumberOfIntermediateTicks; numberOfTicks++) {
+            // Get the total length of the domain
+            const domainLength = xAxisDomain[1] - xAxisDomain[0] 
+            // Get the distance from one tick to the next, which means geometrically: 
+            // if we have n ticks, we have n - 1 subsections of equal length between ticks
+            const tickLength = Math.round(domainLength / 5)
+            // Add that to our zero point -- the min value of our domain
+            const tickLocation = xAxisDomain[0] + (numberOfTicks * tickLength)
+            ticks.push(tickLocation)
         }
+        // Sort since the axis doesn't sort on its own
         return ticks.sort();
     } 
 

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -151,16 +151,18 @@ class ProgressionLineChartVisualizer extends Component {
         let ticks = [...xAxisDomain];
         const totalNumberOfTicks = 6;
         // Minus the ticks at the beginning and the end
-        const totalNumberOfIntermediateTicks = totalNumberOfTicks - xAxisDomain.length
+        const totalNumberOfIntermediateTicks = totalNumberOfTicks - xAxisDomain.length;
+        // Get the total length of the domain
+        const domainLength = xAxisDomain[1] - xAxisDomain[0];
+        // Get the distance from one tick to the next, which means geometrically: 
+        // if we have n ticks, we have n - 1 subsections of equal length between ticks
+        const tickLength = Math.round(domainLength / 5);
         for (let numberOfTicks = 1; numberOfTicks <= totalNumberOfIntermediateTicks; numberOfTicks++) {
-            // Get the total length of the domain
-            const domainLength = xAxisDomain[1] - xAxisDomain[0] 
-            // Get the distance from one tick to the next, which means geometrically: 
-            // if we have n ticks, we have n - 1 subsections of equal length between ticks
-            const tickLength = Math.round(domainLength / 5)
-            // Add that to our zero point -- the min value of our domain
-            const tickLocation = xAxisDomain[0] + (numberOfTicks * tickLength)
-            ticks.push(tickLocation)
+            // Tick offset increases by one tickLength for each successive tick 
+            const tickOffset = (numberOfTicks * tickLength);
+            // Add that offset to our zero point -- the min value of our domain
+            const tickLocation = xAxisDomain[0] + tickOffset;
+            ticks.push(tickLocation);
         }
         // Sort since the axis doesn't sort on its own
         return ticks.sort();

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -146,17 +146,17 @@ class ProgressionLineChartVisualizer extends Component {
 
     // Use min/max info to build ticks for the 
     // Assumes processed data
-    getXAxisTicks = (xAxisDomain, processedPotentialDiagnosisDates) => {
+    getXAxisTicks = (xAxisDomain, processedPotentialDiagnosisDates, isWide) => {
         // Ticks are going to contain the min and max values
         let ticks = [...xAxisDomain];
-        const totalNumberOfTicks = 6;
+        const totalNumberOfTicks = isWide ? 6 : 3;
         // Minus the ticks at the beginning and the end
         const totalNumberOfIntermediateTicks = totalNumberOfTicks - xAxisDomain.length;
         // Get the total length of the domain
         const domainLength = xAxisDomain[1] - xAxisDomain[0];
         // Get the distance from one tick to the next, which means geometrically: 
         // if we have n ticks, we have n - 1 subsections of equal length between ticks
-        const tickLength = Math.round(domainLength / 5);
+        const tickLength = Math.round(domainLength / (totalNumberOfTicks - 1));
         for (let numberOfTicks = 1; numberOfTicks <= totalNumberOfIntermediateTicks; numberOfTicks++) {
             // Tick offset increases by one tickLength for each successive tick 
             const tickOffset = (numberOfTicks * tickLength);
@@ -220,7 +220,7 @@ class ProgressionLineChartVisualizer extends Component {
         const yTicks = [ -1, 0, 1, 2, 3 ];
         // Get xAxisInfo 
         const xAxisDomain = this.getXAxisDomain(processedData, processedPotentialDiagnosisDates);
-        const xTicks = this.getXAxisTicks(xAxisDomain, processedPotentialDiagnosisDates);
+        const xTicks = this.getXAxisTicks(xAxisDomain, processedPotentialDiagnosisDates, this.props.isWide);
         return (
             <div 
                 ref={(chartParentDiv) => {this.chartParentDiv = chartParentDiv;}}


### PR DESCRIPTION
Title about sums it up. We've moved the date of diagnosis to the label on the line, which makes it easier to decide which ticks to use and to ensure that as many of them display as possible. 

There is a minor issue which is that, on small screens with a note open, the min-tick along with a few others don't display because of how the component decides to automatically handle the overlap of ticks, by automatically generating them itself. Additionally, the diagnosis date label bleeds over into the y-axis on such a small screen. 

Wasn't sure if we wanted to make these JIRA's or include them in the scope of this task. Will defer to @gregquinn2001  here. 