### PR TITLE
Tooltip for reference line

### DIFF
--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -187,7 +187,7 @@ class ProgressionLineChartVisualizer extends Component {
             // Create blurbs of text based on whether or not we have data to display
             const disease_status_blurb = disease_status_string;
             const evidence_blurb =  !Lang.isEmpty(evidence) ? ` based on ${evidence}` : "";
-            const as_of_blurb = !Lang.isEmpty(start_time)   ? ` as of ${start_time}`  : "";
+            const as_of_blurb = !Lang.isEmpty(start_time)   ? ` on ${start_time}`  : "";
             return (
                 <div className="disease-status-tooltip">
                     <span>

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -214,8 +214,18 @@ class ProgressionLineChartVisualizer extends Component {
     renderProgressionChart = (patient, condition, conditionSection) => { 
         const { progressions, potentialDiagnosisDates } = conditionSection.data[0].data_cache;
         // process dates into numbers for graphing
-        const processedData = this.processForGraphing(progressions);
-        const processedPotentialDiagnosisDates = this.processPotentialDiagnosisDates(potentialDiagnosisDates)
+        let processedData = this.processForGraphing(progressions);
+        const processedPotentialDiagnosisDates = this.processPotentialDiagnosisDates(potentialDiagnosisDates);
+        processedPotentialDiagnosisDates.forEach((diagnosisDate, i) => {
+            processedData.push({
+                disease_status_string: "Diagnosed ",
+                evidence: "",
+                start_time: this.dateFormat(diagnosisDate.date),
+                start_time_number: diagnosisDate.date,
+                diagnosis_date : diagnosisDate.date,
+                label: `ref_${i}`
+            })
+        }); 
         // Get yAxisInfo 
         const yTicks = [ -1, 0, 1, 2, 3 ];
         // Get xAxisInfo 
@@ -253,6 +263,12 @@ class ProgressionLineChartVisualizer extends Component {
                         stroke="#295677" 
                         yAxisId={0}
                     />
+                     <Line 
+                        type="monotone"
+                        dataKey="diagnosis_date"
+                        stroke="none"
+                    />
+                   
                     {processedPotentialDiagnosisDates.map((diagnosisDate, i) => {
                         return (
                             <ReferenceLine 
@@ -264,7 +280,6 @@ class ProgressionLineChartVisualizer extends Component {
                             />
                         );
                     })}
-
                 </LineChart>
            </div>
         );


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Added diagnosis date to data used in line chart and generate a line using the diagnosis_date property of the data. Allows a tooltip to now show up for the reference line. 

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
