### PR TITLE
Removed 'Filter:' from shortcut view of context tray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 /src/patientControl/PatientSearch.css
 /src/styles/LandingPage.css
 /src/summary/ConditionSelection.css
+/src/context/ShortcutSearch.css
 
 #Visual Paradigm Project Files
 *.vpp.bak*

--- a/src/context/ShortcutSearch.jsx
+++ b/src/context/ShortcutSearch.jsx
@@ -10,11 +10,6 @@ export default class ShortcutSearch extends Component {
         return (
             <div id="shortcut-search">
                 <div className="shortcut-search-container">
-                    <div className="shortcut-search-title">
-                        <div>Filter:</div>
-                        {/* <div className="count">(showing {totalShown} of {countBeforeSearch})</div> */}
-                    </div>
-
                     <TextField
                         className="shortcut-search-text"
                         label="Search shortcuts"

--- a/src/context/ShortcutSearch.jsx
+++ b/src/context/ShortcutSearch.jsx
@@ -6,7 +6,6 @@ import './ShortcutSearch.css'
 
 export default class ShortcutSearch extends Component {
     render () { 
-        // let totalShown, countBeforeSearch;
         return (
             <div id="shortcut-search">
                 <div className="shortcut-search-container">

--- a/src/context/ShortcutSearch.scss
+++ b/src/context/ShortcutSearch.scss
@@ -1,20 +1,14 @@
+@import "../styles/variables";
+
 #shortcut-search {
     margin: 15px 0 5px 0;
-    background-color: #ffffff;
+    background-color: $background;
     text-align: left;
 }
 
 .shortcut-search-container {
     position: relative;
     display: inline-block;
-}
-
-.shortcut-search-title {
-    font-size: 0.9em;
-}
-
-.shortcut-search-title .count {
-    font-style: italic;
 }
 
 .shortcut-search-text {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Jira 1404. No longer want the word filter showing above the "Search Shortcuts" textbox.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
