### PR TITLE
Treatment options section render smaller size if server not running o…

### DIFF
--- a/src/summary/ScatterPlotVisualizer.jsx
+++ b/src/summary/ScatterPlotVisualizer.jsx
@@ -13,15 +13,24 @@ class ScatterPlotVisualizer extends Component {
 
         this.updateState = true;
         this.state = {
-            chartWidth: 600,
-            chartHeight: 400,
-        }
+            chartWidth: "600px",
+            chartHeight: "600px",
+        } 
     }
 
     componentDidMount() {
         const { patient, condition, conditionSection } = this.props;
         this.renderScatterPlot(patient, condition, conditionSection);
     }
+
+     componentDidUpdate = () => {
+        if (this.updateState) {
+            this.updateState = false;
+        } else {
+            this.updateState = true;
+            setTimeout(this.resize, 450);
+        }
+    } 
 
     randomizeXPoints = (categoryList, data) => {
         let alive = [], dead = [];
@@ -36,9 +45,18 @@ class ScatterPlotVisualizer extends Component {
         return [alive, dead];
     }
 
+    resize = () => {
+        this.setState({
+            chartHeight: "30px"
+        })
+    }
+
     renderScatterPlot = (patient, condition, conditionSection) => {
 
         const myData = conditionSection.data[0].data_cache;
+        if (myData === "Server unavailable" || myData === "No relevant data found for patient") {
+            this.resize();
+        }
         if (Lang.isObject(myData)) {
             let categoryMap = {};
             myData.forEach(function (series) {
@@ -290,7 +308,7 @@ class ScatterPlotVisualizer extends Component {
 
         return (
             <div ref='scattering'
-                style={{ height: 600 }} className='scatter-plot-subsection'>
+                style={{ height: `${this.state.chartHeight}` }} className='scatter-plot-subsection'>
             </div>
         );
     }

--- a/src/summary/ScatterPlotVisualizer.jsx
+++ b/src/summary/ScatterPlotVisualizer.jsx
@@ -23,15 +23,6 @@ class ScatterPlotVisualizer extends Component {
         this.renderScatterPlot(patient, condition, conditionSection);
     }
 
-     componentDidUpdate = () => {
-        if (this.updateState) {
-            this.updateState = false;
-        } else {
-            this.updateState = true;
-            setTimeout(this.resize, 450);
-        }
-    } 
-
     randomizeXPoints = (categoryList, data) => {
         let alive = [], dead = [];
         data[0].forEach(function (item) {

--- a/src/summary/ScatterPlotVisualizer.jsx
+++ b/src/summary/ScatterPlotVisualizer.jsx
@@ -54,7 +54,8 @@ class ScatterPlotVisualizer extends Component {
     renderScatterPlot = (patient, condition, conditionSection) => {
 
         const myData = conditionSection.data[0].data_cache;
-        if (myData === "Server unavailable" || myData === "No relevant data found for patient") {
+        // myData will be a string if server isn't running or no relevant data is found
+        if (Lang.isString(myData)) {
             this.resize();
         }
         if (Lang.isObject(myData)) {

--- a/src/summary/SummaryMetadata.jsx
+++ b/src/summary/SummaryMetadata.jsx
@@ -723,7 +723,7 @@ export default class SummaryMetadata {
                     // adding new section for treatment options
                     {
                         name: "Treatment Options",
-                        shortName: "Treatment Options",
+                        shortName: "Treatments",
                         type: "ClusterPoints",
                         data: [
                             {
@@ -1364,7 +1364,7 @@ export default class SummaryMetadata {
                     // adding new section for treatment options
                     {
                         name: "Treatment Options",
-                        shortName: "Treatment Options",
+                        shortName: "Treatments",
                         type: "ClusterPoints",
                         data: [
                             {


### PR DESCRIPTION
…r no data is available

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1335. Treatment option section renders in smaller size if server is not running or no relevant data is found for patient. 

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
