### PR TITLE
Note search indexer

### DIFF
--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -207,6 +207,7 @@ export default class ClinicianDashboard extends Component {
                         noteClosed={this.props.appState.noteClosed}
                         openClinicalNote={this.props.appState.openClinicalNote}
                         patient={this.props.appState.patient}
+                        searchIndex={this.props.searchIndex}
                         searchSelectedItem={this.props.searchSelectedItem}
                         setForceRefresh={this.props.setForceRefresh}
                         setFullAppStateWithCallback={this.props.setFullAppStateWithCallback}

--- a/src/model/core/FluxClinicalNote.js
+++ b/src/model/core/FluxClinicalNote.js
@@ -52,6 +52,10 @@ class FluxClinicalNote {
         this._signedOn = val;
     }
 
+    get createdOn() {
+        return this._entryInfo.creationTime.value;
+    }
+
     get signedBy() {
         return this._signedBy;
     }

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -202,7 +202,7 @@ export default class NoteAssistant extends Component {
         const allNotes = this.props.patient.getNotes();
         const numberOfPreviousSignedNotes = Lang.filter(allNotes, o => o.signed).length;
         const notesIndexer = new NotesIndexer();
-
+        this.props.searchIndex.removeDataBySection('Clinical Notes');
         notesIndexer.indexData('Clinical Notes', '', allNotes, this.props.searchIndex);
         switch (noteAssistantMode) {
             case "poc":

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -8,6 +8,7 @@ import FontAwesome from 'react-fontawesome';
 import ContextTray from '../context/ContextTray';
 import PickListOptionsPanel from '../panels/PickListOptionsPanel';
 import Button from '../elements/Button';
+import NotesIndexer from '../patientControl/NotesIndexer';
 import moment from 'moment';
 import './NoteAssistant.css';
 
@@ -100,7 +101,7 @@ export default class NoteAssistant extends Component {
 
     setInsertingTemplate = (insertingTemplate) => {
         this.setState({ insertingTemplate }); 
-        this.props.updateShowTemplateView(false);           
+        this.props.updateShowTemplateView(false);
     }
 
     onPointOfCareButtonClicked() {
@@ -200,7 +201,9 @@ export default class NoteAssistant extends Component {
     renderNoteAssistantContent(noteAssistantMode) {
         const allNotes = this.props.patient.getNotes();
         const numberOfPreviousSignedNotes = Lang.filter(allNotes, o => o.signed).length;
+        const notesIndexer = new NotesIndexer();
 
+        notesIndexer.indexData('Clinical Notes', '', allNotes, this.props.searchIndex);
         switch (noteAssistantMode) {
             case "poc":
                 return (
@@ -556,6 +559,7 @@ NoteAssistant.propTypes = {
     noteAssistantMode: PropTypes.string.isRequired,
     noteClosed: PropTypes.bool.isRequired,
     patient: PropTypes.object.isRequired,
+    searchIndex: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
     selectedNote: PropTypes.object,
     setLayout: PropTypes.func.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -424,6 +424,7 @@ export default class NotesPanel extends Component {
                     openExistingNote={this.openExistingNote}
                     patient={this.props.patient}
                     saveNote={this.saveNote}
+                    searchIndex={this.props.searchIndex}
                     searchSelectedItem={this.props.searchSelectedItem}
                     selectedNote={this.state.selectedNote}
                     setLayout={this.props.setLayout} 
@@ -475,6 +476,7 @@ NotesPanel.propTypes = {
     noteClosed: PropTypes.bool.isRequired,
     openClinicalNote: PropTypes.object,
     patient: PropTypes.object.isRequired,
+    searchIndex: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
     setNoteClosed: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,

--- a/src/patientControl/NotesIndexer.js
+++ b/src/patientControl/NotesIndexer.js
@@ -17,7 +17,7 @@ class NotesIndexer extends BaseIndexer {
                 note,
                 section,
                 subsection: notesSubsection,
-                valueTitle: `${note.subject} | Content`,
+                valueTitle: `Content`,
                 value: note.content,
             })
 
@@ -25,34 +25,41 @@ class NotesIndexer extends BaseIndexer {
                 note,
                 section,
                 subsection: notesSubsection,
-                valueTitle: `${note.subject} | Created by`,
-                value: note.createdBy,
-            });
-
-            searchIndex.addSearchableData({
-                note,
-                section,
-                subsection: notesSubsection,
-                valueTitle: `${note.subject} | Source`,
+                valueTitle: `Source`,
                 value: note.hospital,
             });
 
-            // If note is signed, index signedOn date else index created on date
             if (note.signed) {
                 searchIndex.addSearchableData({
                     note,
                     section,
                     subsection: notesSubsection,
-                    valueTitle: `${note.subject} | Signed on`,
+                    valueTitle: `Signed on`,
                     value: note.signedOn,
-                })
+                });
+
+                searchIndex.addSearchableData({
+                    note,
+                    section,
+                    subsection: notesSubsection,
+                    valueTitle: `Signed by`,
+                    value: note.signedBy,
+                });
             } else {
                 searchIndex.addSearchableData({
                     note,
                     section,
                     subsection: notesSubsection,
-                    valueTitle: `${note.subject} | Created on`,
+                    valueTitle: `Created on`,
                     value: note.createdOn,
+                });
+
+                searchIndex.addSearchableData({
+                    note,
+                    section,
+                    subsection: notesSubsection,
+                    valueTitle: `Created by`,
+                    value: note.createdBy,
                 });
             }
         });

--- a/src/patientControl/NotesIndexer.js
+++ b/src/patientControl/NotesIndexer.js
@@ -2,24 +2,29 @@ import BaseIndexer from './BaseIndexer';
 
 class NotesIndexer extends BaseIndexer {
     indexData(section, subsection, data, searchIndex) {
+        searchIndex.addSearchableData({
+            section,
+            subsection: '',
+            valueTitle: 'Section',
+            value: section,
+        });
+
+        searchIndex.addSearchableData({
+            section,
+            subsection: 'Signed Notes',
+            valueTitle: 'Subsection',
+            value: 'Signed Notes',
+        });
+
+        searchIndex.addSearchableData({
+            section,
+            subsection: 'In Progress Notes',
+            valueTitle: 'Subsection',
+            value: 'In Progress Notes',
+        });
+
         data.forEach(note => {
             const notesSubsection = note.signed ? 'Signed Notes' : 'In Progress Notes';
-
-            searchIndex.addSearchableData({
-                note,
-                section,
-                subsection: notesSubsection,
-                valueTitle: 'Section',
-                value: section,
-            });
-
-            searchIndex.addSearchableData({
-                note,
-                section,
-                subsection: notesSubsection,
-                valueTitle: 'Subsection',
-                value: notesSubsection,
-            });
 
             searchIndex.addSearchableData({
                 note,

--- a/src/patientControl/NotesIndexer.js
+++ b/src/patientControl/NotesIndexer.js
@@ -6,6 +6,7 @@ class NotesIndexer extends BaseIndexer {
             const notesSubsection = note.signed ? 'Signed Notes' : 'In Progress Notes';
 
             searchIndex.addSearchableData({
+                note,
                 section,
                 subsection: notesSubsection,
                 valueTitle: 'Note Title',
@@ -13,6 +14,15 @@ class NotesIndexer extends BaseIndexer {
             });
 
             searchIndex.addSearchableData({
+                note,
+                section,
+                subsection: notesSubsection,
+                valueTitle: `${note.subject} | Content`,
+                value: note.content,
+            })
+
+            searchIndex.addSearchableData({
+                note,
                 section,
                 subsection: notesSubsection,
                 valueTitle: `${note.subject} | Created by`,
@@ -20,18 +30,31 @@ class NotesIndexer extends BaseIndexer {
             });
 
             searchIndex.addSearchableData({
+                note,
                 section,
                 subsection: notesSubsection,
                 valueTitle: `${note.subject} | Source`,
                 value: note.hospital,
             });
 
-            searchIndex.addSearchableData({
-                section,
-                subsection: notesSubsection,
-                valueTitle: `${note.subject} | Created on`,
-                value: note.signedOn,
-            });
+            // If note is signed, index signedOn date else index created on date
+            if (note.signed) {
+                searchIndex.addSearchableData({
+                    note,
+                    section,
+                    subsection: notesSubsection,
+                    valueTitle: `${note.subject} | Signed on`,
+                    value: note.signedOn,
+                })
+            } else {
+                searchIndex.addSearchableData({
+                    note,
+                    section,
+                    subsection: notesSubsection,
+                    valueTitle: `${note.subject} | Created on`,
+                    value: note.createdOn,
+                });
+            }
         });
     }
 }

--- a/src/patientControl/NotesIndexer.js
+++ b/src/patientControl/NotesIndexer.js
@@ -1,0 +1,39 @@
+import BaseIndexer from './BaseIndexer';
+
+class NotesIndexer extends BaseIndexer {
+    indexData(section, subsection, data, searchIndex) {
+        data.forEach(note => {
+            const notesSubsection = note.signed ? 'Signed Notes' : 'In Progress Notes';
+
+            searchIndex.addSearchableData({
+                section,
+                subsection: notesSubsection,
+                valueTitle: 'Note Title',
+                value: note.subject,
+            });
+
+            searchIndex.addSearchableData({
+                section,
+                subsection: notesSubsection,
+                valueTitle: `${note.subject} | Created by`,
+                value: note.createdBy,
+            });
+
+            searchIndex.addSearchableData({
+                section,
+                subsection: notesSubsection,
+                valueTitle: `${note.subject} | Source`,
+                value: note.hospital,
+            });
+
+            searchIndex.addSearchableData({
+                section,
+                subsection: notesSubsection,
+                valueTitle: `${note.subject} | Created on`,
+                value: note.signedOn,
+            });
+        });
+    }
+}
+
+export default NotesIndexer;

--- a/src/patientControl/NotesIndexer.js
+++ b/src/patientControl/NotesIndexer.js
@@ -9,7 +9,7 @@ class NotesIndexer extends BaseIndexer {
                 note,
                 section,
                 subsection: notesSubsection,
-                valueTitle: 'Note Title',
+                valueTitle: 'Title',
                 value: note.subject,
             });
 

--- a/src/patientControl/NotesIndexer.js
+++ b/src/patientControl/NotesIndexer.js
@@ -9,6 +9,22 @@ class NotesIndexer extends BaseIndexer {
                 note,
                 section,
                 subsection: notesSubsection,
+                valueTitle: 'Section',
+                value: section,
+            });
+
+            searchIndex.addSearchableData({
+                note,
+                section,
+                subsection: notesSubsection,
+                valueTitle: 'Subsection',
+                value: notesSubsection,
+            });
+
+            searchIndex.addSearchableData({
+                note,
+                section,
+                subsection: notesSubsection,
                 valueTitle: 'Title',
                 value: note.subject,
             });

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -64,7 +64,6 @@ class PatientSearch extends React.Component {
                 suggestion = {
                     date: obj.note.signedOn || obj.note.createdOn,
                     subject: obj.note.subject,
-                    hospital: obj.note.hospital,
                     inputValue: inputValue,
                     note: obj.note,
                     valueTitle: obj.valueTitle,

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -6,7 +6,7 @@ import Lang from 'lodash';
 import './PatientSearch.css'
 
 function escapeRegExp(text) {
-  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
 
 class PatientSearch extends React.Component { 
@@ -25,63 +25,6 @@ class PatientSearch extends React.Component {
         };
     }
 
-    // Based on searchInput, check a note's meatdata for any matches  
-    searchNoteMetaData = (inputValue, note) => { 
-        const newSuggestion = this.createNewSuggestion(inputValue, note);
-        const regex = this.createRegexForSearching(inputValue)
-        const relevantNoteMetadata = (
-            note.signedOn + ' ' + 
-            note.entryInfo.creationTime.value + ' ' +
-            note.subject + ' ' +
-            note.hospital
-        ).toLowerCase();
-
-        const metadataMatches = regex.exec(relevantNoteMetadata);
-        if(metadataMatches) {
-            // Determine what we matched with -- track that in suggestions metadata.
-            let matchedMetaData; 
-            let date;
-            if (note.signedOn) {
-                date = note.signedOn;
-            } else {
-                date = note.entryInfo.creationTime.value;
-            }
-
-            if (date && date.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) {
-                matchedMetaData = "date";
-            } else if (note.subject && note.subject.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) {
-                matchedMetaData = "subject";
-            } else if (note.hospital && note.hospital.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) {
-                matchedMetaData = "hospital";
-            }
-            // Add additional metadata, push to suggestions
-            newSuggestion.contentSnapshot = note.content.slice(0, 25);
-            newSuggestion.matchedOn = matchedMetaData;
-            return newSuggestion
-        } else { 
-            // Return nothing
-            return null
-        }
-    }
-
-    // basic template for creating a newSuggestion
-    createNewSuggestion = (inputValue, note) => { 
-        let date;
-        if (note.signedOn) {
-            date = note.signedOn;
-        } else {
-            date = note.entryInfo.creationTime.value;
-        }
-        return { 
-            date: date,
-            subject: note.subject,
-            hospital: note.hospital,
-            inputValue: inputValue,
-            note: note,
-            source: "clinicalNote"
-        }
-    }
-
     // Creates a regex based on out input value and what we want to search on
     createRegexForSearching = (inputValue) => { 
         //  Establish some common variables for our regex
@@ -91,55 +34,8 @@ class PatientSearch extends React.Component {
         // combines for our pattern; adds capture group for snapshot of information
         const inputPattern = `(?:${spaceOrNewlineOrPeriod}${possibleTrigger}${escapedInput}|^${possibleTrigger}${escapedInput})`;
         const regex = new RegExp(inputPattern, "gim");
-        return regex
-    }
 
-    getNotesWithoutStyle = (notes) => {
-        const notesCopy = Lang.cloneDeep(notes);
-        notesCopy.forEach((note) => {
-            let noteContent = note.content;
-            // Remove HTML tags
-            noteContent = noteContent.replace(/<(div|\/div|strong|\/strong|em|\/em|u|\/u|ul|\/ul|ol|\/ol|li|\/li){0,}>/g, "");
-            // Remove brackets from @ structured phrases
-            noteContent = noteContent.replace(/@(.*?)\[\[(.*?)\]\]/g, (match, g1, g2) => g2);
-            // Removed brackets from # structured phrases
-            noteContent = noteContent.replace(/#(.*?)\[\[(.*?)\]\]/g, (match, g1, g2) => `#${g1}`);
-            note.content = noteContent;
-        });
-        return notesCopy;
-    }
-
-    getNoteSuggestions = (inputValue) => {
-        const notes = this.props.patient.getNotes();
-        const notesWithoutStyle = this.getNotesWithoutStyle(notes);
-        const suggestions =  notesWithoutStyle.reduce((suggestions, note) => {
-            // If we have long-enough input and there is content in the note
-            if (note.content && inputValue && inputValue.length >= 2) {
-                const regex = this.createRegexForSearching(inputValue)
-                // Search note content
-                const relevantNoteContent = (note.content);
-                let contentMatches = regex.exec(relevantNoteContent);
-                // NewSuggestion object -- to be pushed with relevant data if there's a match
-                if (contentMatches) { 
-                    let newSuggestion = this.createNewSuggestion(inputValue, note);
-                    // For each match, add a suggestion.
-                    while (contentMatches) { 
-                        // Want a snapshot of text; use index and continue 100 chars
-                        newSuggestion.contentSnapshot = relevantNoteContent.slice(contentMatches.index, contentMatches.index + 100)
-                        newSuggestion.matchedOn = "contentSnapshot";
-                        // Clone the object
-                        suggestions.push(Lang.clone(newSuggestion));
-                        contentMatches = regex.exec(relevantNoteContent);
-                    }
-                } else {
-                    // Search note metadata
-                    const newSuggestionBasedOnMetadata = this.searchNoteMetaData(inputValue, note);
-                    (newSuggestionBasedOnMetadata && suggestions.push(newSuggestionBasedOnMetadata))
-                }
-            }
-            return suggestions;
-        }, []); 
-        return suggestions;
+        return regex;
     }
 
     getNoteContentWithoutStyle = (noteContent) => {
@@ -155,23 +51,48 @@ class PatientSearch extends React.Component {
         return noteContentWithoutStyle;
     }
 
-    getStructuredDataSuggestions = (inputValue) => {
+    // Used by AutoSuggest to get a list of suggestions based on the current search's InputValue
+    getSuggestions = (inputValue) => {
         let suggestions = [];
         const regex = new RegExp(escapeRegExp(inputValue), "gi");
 
         this.props.searchIndex.searchableData.forEach(obj => {
             let suggestion;
 
+            // obj.note means this should be a clinicalNote suggestion
             if (obj.note) {
-                const noteContentWithoutStyle = this.getNoteContentWithoutStyle(obj.value);
-                const noteRegex = this.createRegexForSearching(inputValue);
+                suggestion = {
+                    date: obj.note.signedOn || obj.note.createdOn,
+                    subject: obj.note.subject,
+                    hospital: obj.note.hospital,
+                    inputValue: inputValue,
+                    note: obj.note,
+                    valueTitle: obj.valueTitle,
+                    contentSnapshot: obj.value,
+                    source: "clinicalNote",
+                };
 
-                suggestion = this.createNewSuggestion(inputValue, obj.note);
-                let contentMatches = noteRegex.exec(noteContentWithoutStyle);
-                if (contentMatches) {
-                    suggestion.matchedOn = 'contentSnapshot';
-                    suggestion.contentSnapshot = noteContentWithoutStyle.slice(contentMatches.index, contentMatches.index + 100);
-                    suggestions.push(suggestion);
+                // If searching content of note, remove styling from content before executing regex
+                if (obj.note.content === obj.value) {
+                    const noteContentWithoutStyle = this.getNoteContentWithoutStyle(obj.value);
+                    const noteRegex = this.createRegexForSearching(inputValue);
+                    let contentMatches = noteRegex.exec(noteContentWithoutStyle);
+
+                    while (contentMatches) { 
+                        // Want a snapshot of text; use index and continue 100 chars
+                        suggestion.contentSnapshot = noteContentWithoutStyle.slice(contentMatches.index, contentMatches.index + 100)
+                        suggestion.matchedOn = "contentSnapshot";
+                        // Clone the object
+                        suggestions.push(Lang.clone(suggestion));
+                        contentMatches = noteRegex.exec(noteContentWithoutStyle);
+                    }
+                } else {
+                    const contentMatches = regex.exec(obj.value);
+
+                    if (contentMatches) {
+                        suggestion.matchedOn = 'contentSnapshot';
+                        suggestions.push(suggestion);
+                    }
                 }
             } else {
                 suggestion = {
@@ -183,28 +104,22 @@ class PatientSearch extends React.Component {
                     matchedOn: "",
                     source: 'structuredData',
                 }
-                let contentMatches = regex.exec(obj.value);
+                const contentMatches = regex.exec(obj.value);
+
                 if (contentMatches) {
                     suggestion.matchedOn = "contentSnapshot";
                     suggestions.push(suggestion);
                 }
             }
-            let contentMatches = regex.exec(obj.valueTitle);
-            if (contentMatches) {
+
+            const contentMatches = regex.exec(obj.valueTitle);
+            if (!suggestion.matchOn && contentMatches) {
                 suggestion.matchedOn = "valueTitle";
                 suggestions.push(suggestion);
             }
         });
 
         return suggestions;
-    }
-
-    // Used by AutoSuggest to get a list of suggestions based on the current search's InputValue
-    getSuggestions = (inputValue) => {
-        let noteSuggestions = this.getNoteSuggestions(inputValue);
-        let structuredDataSuggestions = this.getStructuredDataSuggestions(inputValue);
-
-        return structuredDataSuggestions.concat(noteSuggestions);
     }
 
     // Teach Autosuggest how to calculate the input value for every given suggestion.
@@ -217,7 +132,6 @@ class PatientSearch extends React.Component {
     // and an onChange handler that updates this value (see below).
     // Suggestions also need to be provided to the Autosuggest,
     // and they are initially empty because the Autosuggest is closed.
-  
     onChange = (event, { newValue }) => {
         this.setState({
             value: newValue
@@ -242,18 +156,12 @@ class PatientSearch extends React.Component {
 
     // Will be called every time suggestion is selected via mouse or keyboard.
     onSuggestionSelected = (event, { suggestion, suggestionValue, suggestionIndex, sectionIndex, method }) => {
-        if (suggestion.source === "clinicalNote") {
-            const contextNotes = this.props.patient.getNotes();
-            const selectedNote = contextNotes.find(note => note.entryInfo.entryId === suggestion.note.entryInfo.entryId);
-
-            this.props.setSearchSelectedItem(selectedNote);
+        if (suggestion.note) {
+            this.props.setSearchSelectedItem(suggestion.note)
         } else {
-            if (suggestion.note) {
-                this.props.setSearchSelectedItem(suggestion.note)
-            } else {
-                this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
-            }
+            this.props.moveTargetedDataPanelToSubsection(suggestion.section, suggestion.subsection);
         }
+
         this.refs.autosuggest.input.blur();
     }
 

--- a/src/patientControl/SearchIndex.js
+++ b/src/patientControl/SearchIndex.js
@@ -6,7 +6,7 @@ class SearchIndex {
     }
 
     get searchableData() {
-        return Lang.uniqWith(this._searchableData, Lang.isEqual);
+        return this._searchableData;
     }
 
     addSearchableData(data) {

--- a/src/patientControl/SearchIndex.js
+++ b/src/patientControl/SearchIndex.js
@@ -6,7 +6,7 @@ class SearchIndex {
     }
 
     get searchableData() {
-        return this._searchableData;
+        return Lang.uniqWith(this._searchableData, Lang.isEqual);
     }
 
     addSearchableData(data) {

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -109,56 +109,14 @@ class SearchSuggestion extends React.Component {
             }
             
         } else if (suggestion.source === 'clinicalNote') {
-            let date = <span>{suggestion.date + ` `}</span>;
-            let subject = <span>{suggestion.subject + ` `}</span>;
-            let hospital = <span>{suggestion.hospital + ` `}</span>;
-            if(suggestion.matchedOn === "date"){
-                const dateLowerCase = suggestion.date.toLowerCase();
-                const indexOfMatch = dateLowerCase.indexOf(inputValueLowerCase);
-                const preText = suggestion.date.slice(0, indexOfMatch);
-                const highlightedText = suggestion.date.slice(indexOfMatch, preText.length + inputValue.length);
-                const postText = suggestion.date.slice(preText.length + inputValue.length, suggestion.date.length);
-                date = (
-                    <span>
-                    <span>{preText}</span>
-                    <span className="highlightedInputValue">{highlightedText}</span>
-                    <span>{postText + ` `}</span>
-                    </span>
-                );
-            } else if(suggestion.matchedOn === "subject"){
-                const subjectLowerCase = suggestion.subject.toLowerCase();
-                const indexOfMatch = subjectLowerCase.indexOf(inputValueLowerCase);
-                const preText = suggestion.subject.slice(0, indexOfMatch);
-                const highlightedText = suggestion.subject.slice(indexOfMatch, preText.length + inputValue.length);
-                const postText = suggestion.subject.slice(preText.length + inputValue.length, suggestion.subject.length);
-                subject = (
-                    <span>
-                    <span>{preText}</span>
-                    <span className="highlightedInputValue">{highlightedText}</span>
-                    <span>{postText + ` `}</span>
-                    </span>
-                );
-            } else if(suggestion.matchedOn === "hospital"){
-                const hospitalLowerCase = suggestion.hospital.toLowerCase();
-                const indexOfMatch = hospitalLowerCase.indexOf(inputValueLowerCase);
-                const preText = suggestion.hospital.slice(0, indexOfMatch);
-                const highlightedText = suggestion.hospital.slice(indexOfMatch, preText.length + inputValue.length);
-                const postText = suggestion.hospital.slice(preText.length + inputValue.length, suggestion.hospital.length);
-                hospital = (
-                    <span>
-                    <span>{preText}</span>
-                    <span className="highlightedInputValue">{highlightedText}</span>
-                    <span>{postText}</span>
-                    </span>
-                );
-            }
+            const date = <span>{suggestion.date + ` `}</span>;
+            const subject = <span>{suggestion.subject + ` `}</span>;
 
             suggestionLabel = (
                 <div className="suggestion-label">
                     <span className={"label-content"}>
-                        {date}
                         {subject}
-                        {hospital}
+                        {date}
                     </span>
                 </div>
             );

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -7,7 +7,7 @@ import './SearchSuggestion.css';
 class SearchSuggestion extends React.Component {
 
     renderSuggestionText() {
-        const { suggestion} = this.props;
+        const { suggestion } = this.props;
         const fullSnapshot = suggestion.contentSnapshot;
         const inputValue = suggestion.inputValue;
         // Lowercase versions for index finding
@@ -18,17 +18,9 @@ class SearchSuggestion extends React.Component {
         let preText = fullSnapshot.slice(0, indexOfMatch);
         let highlightedText = fullSnapshot.slice(indexOfMatch, preText.length + inputValue.length)
         let postText = fullSnapshot.slice(preText.length + inputValue.length, fullSnapshot.length);
-        
-        let suggestionText = ''; 
-        if (suggestion.matchedOn === "contentSnapshot" && suggestion.source === 'clinicalNote') {
-            suggestionText = (
-                <div className="suggestion-text">
-                    <span>{preText}</span>
-                    <span className="highlightedInputValue">{highlightedText}</span>
-                    <span>{postText}</span>
-                </div>
-            )
-        } else if(suggestion.matchedOn === "contentSnapshot" && suggestion.source === 'structuredData') { 
+
+        let suggestionText = '';
+        if (suggestion.matchedOn === "contentSnapshot") {
             let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle}: ` : '';
             suggestionText = (
                 <div className="suggestion-text">
@@ -38,7 +30,7 @@ class SearchSuggestion extends React.Component {
                     <span>{postText}</span>
                 </div>
             )
-        } else if (suggestion.matchedOn === "valueTitle"){ 
+        } else if (suggestion.matchedOn === "valueTitle") {
             let valueTitleLowerCase = suggestion.valueTitle.toLowerCase();
             indexOfMatch = valueTitleLowerCase.indexOf(inputValueLowerCase);
             preText = suggestion.valueTitle.slice(0, indexOfMatch);
@@ -53,22 +45,22 @@ class SearchSuggestion extends React.Component {
                     <span>{suggestion.contentSnapshot}</span>
                 </div>
             )
-        } else if (suggestion.matchedOn === "section" || suggestion.matchedOn === "subsection"){ 
+        } else if (suggestion.matchedOn === "section" || suggestion.matchedOn === "subsection") {
             let title = suggestion.valueTitle.length > 0 ? `${suggestion.valueTitle}: ` : '';
             suggestionText = (
                 <div className="suggestion-text">
-                {title + suggestion.contentSnapshot}</div> 
+                    {title + suggestion.contentSnapshot}</div>
             );
         } else {
             suggestionText = (
-                <div className="suggestion-text">{suggestion.contentSnapshot}</div> 
+                <div className="suggestion-text">{suggestion.contentSnapshot}</div>
             );
         }
         return suggestionText;
     }
 
     renderLabel = () => {
-        const { suggestion} = this.props;
+        const { suggestion } = this.props;
         const inputValue = suggestion.inputValue;
         const inputValueLowerCase = inputValue.toLowerCase();
    

--- a/test/backend/patientControl/PatientControl.test.js
+++ b/test/backend/patientControl/PatientControl.test.js
@@ -10,6 +10,7 @@ const testPatientShrId = '123456'
 
 import PatientSearch from '../../../src/patientControl/PatientSearch'
 import SearchIndex from '../../../src/patientControl/SearchIndex';
+import NotesIndexer from '../../../src/patientControl/NotesIndexer';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -39,6 +40,8 @@ describe('PatientSearch', function () {
     }
 
     const searchIndex = new SearchIndex();
+    const notesIndexer = new NotesIndexer();
+    notesIndexer.indexData('Clincal Notes', '', testPatientObj.getNotes(), searchIndex);
 
     it('Should update state.value when input is entered ', function () { 
         const wrapper = mount(<PatientSearch

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -452,6 +452,7 @@ describe('6 FluxNotesEditor', function() {
             return newShortcut;
         }
 
+        const searchIndex = new SearchIndex();
         const notesPanelWrapper = mount(<NotesPanel
             patient={patient}
             contextManager={contextManager}
@@ -469,6 +470,7 @@ describe('6 FluxNotesEditor', function() {
             itemInserted={jest.fn()}
             loginUsername={''}
             noteClosed={false}
+            searchIndex={searchIndex}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -500,6 +502,7 @@ describe('6 FluxNotesEditor', function() {
             return newShortcut;
         }
 
+        const searchIndex = new SearchIndex();
         const notesPanelWrapper = mount(<NotesPanel
             patient={patient}
             contextManager={contextManager}
@@ -517,6 +520,7 @@ describe('6 FluxNotesEditor', function() {
             itemInserted={jest.fn()}
             loginUsername={''}
             noteClosed={false}
+            searchIndex={searchIndex}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -768,6 +772,7 @@ describe('6 FluxNotesEditor', function() {
             return newShortcut;
         }
 
+        const searchIndex = new SearchIndex();
         const notesPanelWrapper = mount(<NotesPanel
             patient={patient}
             contextManager={contextManager}
@@ -785,6 +790,7 @@ describe('6 FluxNotesEditor', function() {
             itemInserted={jest.fn()}
             loginUsername={''}
             noteClosed={false}
+            searchIndex={searchIndex}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -828,6 +834,7 @@ describe('6 FluxNotesEditor', function() {
             return newShortcut;
         }
 
+        const searchIndex = new SearchIndex();
         const notesPanelWrapper = mount(<NotesPanel
             patient={patient}
             contextManager={contextManager}
@@ -845,6 +852,7 @@ describe('6 FluxNotesEditor', function() {
             itemInserted={jest.fn()}
             loginUsername={''}
             noteClosed={false}
+            searchIndex={searchIndex}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}
@@ -1111,6 +1119,7 @@ describe('6 FluxNotesEditor', function() {
             return newShortcut;
         }
 
+        const searchIndex = new SearchIndex();
         const notesPanelWrapper = mount(<NotesPanel
             patient={patient}
             contextManager={contextManager}
@@ -1128,6 +1137,7 @@ describe('6 FluxNotesEditor', function() {
             itemInserted={jest.fn()}
             loginUsername={''}
             noteClosed={false}
+            searchIndex={searchIndex}
             setFullAppStateWithCallback={jest.fn()}
             setLayout={jest.fn()}
             setOpenClinicalNote={jest.fn()}


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA-1380.

- Added indexer for clinical notes.
- Data indexed includes `Title`, `Content`, `Source`, `Signed on`, `Signed by`, `Created on`, and `Created by`.
-  Search results for clinical notes have a label with note title and note date.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
