### PR TITLE
Open note scrolling

### DIFF
--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -63,7 +63,30 @@ export default class NoteAssistant extends Component {
             this.openNote(!newNote.signed, newNote)
             this.props.setSearchSelectedItem(null);
         }
+        if (nextProps.updatedEditorNote && this.refs[nextProps.updatedEditorNote.entryInfo.entryId]) {
+            const isVisible = this.isScrolledIntoView(this.refs[nextProps.updatedEditorNote.entryInfo.entryId]);
+            if (!isVisible) {
+                this.refs[nextProps.updatedEditorNote.entryInfo.entryId].scrollIntoView();
+            }
+        }
     }
+
+    isScrolledIntoView(elem){
+        let el = elem;
+        var rect = el.getBoundingClientRect(), top = rect.top, height = rect.height;
+        el = el.parentNode;
+        let bottom = top + height;
+      do {
+        rect = el.getBoundingClientRect();
+        if ((top > rect.bottom || top < rect.top)) return false;
+        // Check if the element is out of view due to a container scrolling
+        if (bottom < rect.top || bottom > rect.bottom) return false
+        el = el.parentNode;
+      } while (el !== document.body);
+      // Check its within the document viewport
+      return top <= document.documentElement.clientHeight;
+    }
+
 
     // Sorts the notes in chronological order with the most recent first (so that it shows up first in the clinical notes list)
     notesTimeSorter(a, b) {
@@ -298,7 +321,7 @@ export default class NoteAssistant extends Component {
         }
 
         return (
-            <div className={`note in-progress-note${selected ? " selected" : ""}`} key={i} onClick={() => {
+            <div ref={note.entryInfo.entryId} className={`note in-progress-note${selected ? " selected" : ""}`} key={i} onClick={() => {
                 this.openNote(true, note)
             }}>
                 <div className="in-progress-text">In progress note</div>
@@ -366,13 +389,15 @@ export default class NoteAssistant extends Component {
         }
 
         return (
-            <div className={`note existing-note${selected ? " selected" : ""}`} key={i} onClick={() => {
+            <div ref={item.entryInfo.entryId} className={`note existing-note${selected ? " selected" : ""}`} key={i} onClick={() => {
+                
                 this.openNote(false, item)
             }}>
                 <div className="existing-note-date">{item.signedOn}</div>
                 <div className="existing-note-subject">{item.subject}</div>
 
                 {this.renderMetaDataText(item)}
+               
             </div>
         );
     }

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -25,6 +25,7 @@ import PatientRecord from '../../../src/patient/PatientRecord.jsx';
 import FluxInjury from '../../../src/model/condition/FluxInjury';
 
 import SearchIndex from '../../../src/patientControl/SearchIndex';
+import FluxClinicalNote from '../../../src/model/core/FluxClinicalNote';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -203,7 +204,8 @@ describe('5 FullApp', function() {
         const wrapper = mount(<FullApp 
             display='Flux Notes' 
             dataSource='HardCodedReadOnlyDataSource' 
-            patientId='788dcbc3-ed18-470c-89ef-35ff91854c7e' />);
+            patientId='788dcbc3-ed18-470c-89ef-35ff91854c7e' />,
+            { attachTo: document.body });
 
         // Mimic post-encounter view
         const newNoteButton = wrapper.find('.note-new');
@@ -480,10 +482,12 @@ describe('6 FluxNotesEditor', function() {
             setSearchSelectedItem={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
-        />);
+        />,
+        { attachTo: document.body });
         expect(notesPanelWrapper).to.have.lengthOf(1);
         expect(notesPanelWrapper.find(FluxNotesEditor)).to.have.lengthOf(1);
-        notesPanelWrapper.setState({ updatedEditorNote: { content: '@name' } });
+        const note = new FluxClinicalNote({ EntryId: "7000", content: '@name' });
+        notesPanelWrapper.setState({ updatedEditorNote: note });
 
         expect(notesPanelWrapper.find('.structured-field-inserter')).to.have.length(1);
         expect(notesPanelWrapper.find('.structured-field-inserter').text()).to.contain(patient.getName());
@@ -801,13 +805,14 @@ describe('6 FluxNotesEditor', function() {
             setOpenClinicalNote={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
-        />);
+        />,
+        { attachTo: document.body });
         const fluxNotesEditor = notesPanelWrapper.find(FluxNotesEditor);
         expect(fluxNotesEditor).to.have.lengthOf(1);
         expect(notesPanelWrapper.find(NoteAssistant)).to.have.lengthOf(1);
 
         const arrayOfStructuredDataToEnter = ["#deceased "];
-        const updatedEditorNote = { content: arrayOfStructuredDataToEnter.join(' ') };
+        const updatedEditorNote = new FluxClinicalNote({ EntryId: "7000",content: arrayOfStructuredDataToEnter.join(' ') });
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
         fluxNotesEditor.instance().onFocus();
         //fluxNotesEditor.setProps({ updatedEditorNote });
@@ -863,7 +868,8 @@ describe('6 FluxNotesEditor', function() {
             setOpenClinicalNote={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
-        />);
+        />,
+        { attachTo: document.body });
         const fluxNotesEditor = notesPanelWrapper.find(FluxNotesEditor);
         expect(fluxNotesEditor).to.have.lengthOf(1);
         expect(notesPanelWrapper.find(NoteAssistant)).to.have.lengthOf(1);
@@ -871,7 +877,7 @@ describe('6 FluxNotesEditor', function() {
         const arrayOfStructuredDataToEnter = ["@condition[[Invasive ductal carcinoma of breast]] ", "#PR ", "#Positive "];
         const arrayOfExpectedStructuredDataInserter = ["Invasive ductal carcinoma of breast "]
         const arrayOfExpectedStructuredDataCreator = ["PR ", "Positive "]
-        const updatedEditorNote = { content: arrayOfStructuredDataToEnter.join(' ') };
+        const updatedEditorNote = new FluxClinicalNote({ EntryId: "7000", content: arrayOfStructuredDataToEnter.join(' ') });
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
         fluxNotesEditor.instance().onFocus();
         //fluxNotesEditor.setProps({ updatedEditorNote });


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1341 
Opening a note when note editor is closed will not reset position of scrollbar. 
If note selected is out of view, will scroll into view. Updated backend FullApp test to pass with new changes. 

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
