### PR TITLE
Merge context and matching score

### DIFF
--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -73,6 +73,24 @@ class ContextManager {
             // so we'll get the correct shortcuts that way
             childResults = shortcutManager.getValidChildShortcutsInContext(shortcut, false);
             childResults.forEach((child) => {
+                // DP added this to the loop
+                //  Adds knownparentecontexts to shortcuts that don't have them, 
+                //  N.B. it adds this data by reference, not locally
+                const childObj = shortcutManager.getShortcutMetadata(child)
+                const childParent = childObj.knownParentContexts
+                const shortcutId = shortcut.getId();
+                // Add this shortcut to knownParentContexts where needed
+                if(Lang.isString(childParent) && childParent !== shortcutId) {
+                    // console.log('is a string, looks different');
+                    childObj.knownParentContexts = shortcutId;
+                } else if (Lang.isUndefined(childParent)) {
+                    // console.log('is undefined ');
+                    childObj.knownParentContexts = [shortcutId];
+                } else if (Lang.isArray(childParent) &&!childParent.includes(shortcutId)) {
+                    // console.log('is an array, doesnt include the one we care about');
+                    childObj.knownParentContexts.push(shortcutId);
+                }
+
                 if (!result.includes(child)) result.push(child);
             });
         });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1159,8 +1159,9 @@ class FluxNotesEditor extends React.Component {
         const shortcuts = this.contextManager.getCurrentlyValidShortcuts(this.props.shortcutManager);
 
         // Check if shortcutTrigger is a shortcut trigger in the list of currently valid shortcuts
-        return shortcuts.some((shortcut) => {
-            const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcut);
+        return shortcuts.some((shortcutObj) => {
+            const shortcutId = shortcutObj.id
+            const triggers = this.props.shortcutManager.getTriggersForShortcut(shortcutId);
             return triggers.some((trigger) => {
                 return trigger.name.toLowerCase() === shortcutTrigger.toLowerCase();
             });

--- a/src/notes/SuggestionPortalPlaceholderSearchIndex.jsx
+++ b/src/notes/SuggestionPortalPlaceholderSearchIndex.jsx
@@ -3,11 +3,15 @@ import Fuse from 'fuse.js';
 import Lang from 'lodash';
 
 class SuggestionPortalPlaceholderSearchIndex extends SuggestionPortalSearchIndex  {
+    constructor(list, initialChar, shortcutManager) { 
+        super(list, initialChar, shortcutManager)
+        this.currentlyValidPlaceholders = [];
+    }
     updateIndex = (contextManager) => { 
         const placeholders = this.shortcutManager.getAllPlaceholderShortcuts();
         // If shortcuts haven't updated, we don't need to update our fuse index
-        if (Lang.isEqual(placeholders, this.currentlyValidShortcuts)) return
-        this.currentlyValidShortcuts = placeholders;
+        if (Lang.isEqual(placeholders, this.currentlyValidPlaceholders)) return
+        this.currentlyValidPlaceholders = placeholders;
         const relevantShortcuts = [];
 
         placeholders.forEach((placeholder) => {

--- a/src/notes/SuggestionPortalSearchIndex.jsx
+++ b/src/notes/SuggestionPortalSearchIndex.jsx
@@ -5,7 +5,6 @@ class SuggestionPortalSearchIndex {
     constructor(list, initialChar, shortcutManager) { 
         this.initialChar = initialChar;
         this.shortcutManager = shortcutManager;
-        this.currentlyValidShortcuts = [];
         // Metdata common to all suggestionSearchIndexs
         this.fuseOptions = {
             includeScore: true,

--- a/src/notes/SuggestionPortalSearchIndex.jsx
+++ b/src/notes/SuggestionPortalSearchIndex.jsx
@@ -33,10 +33,10 @@ class SuggestionPortalSearchIndex {
         if(a.data.score < b.data.score){
             return -1;
         } 
-        if(a.item.suggestion.toLowerCase() > b.item.suggestion.toLowerCase()){
+        if(a.suggestion.toLowerCase() > b.suggestion.toLowerCase()){
             return 1;
         } 
-        if(a.item.suggestion.toLowerCase() < b.item.suggestion.toLowerCase()){
+        if(a.suggestion.toLowerCase() < b.suggestion.toLowerCase()){
             return -1;
         } 
         return 0;

--- a/src/notes/SuggestionPortalSearchIndex.jsx
+++ b/src/notes/SuggestionPortalSearchIndex.jsx
@@ -10,7 +10,7 @@ class SuggestionPortalSearchIndex {
         this.fuseOptions = {
             includeScore: true,
             includeMatches: true,
-            threshold: 0.6,
+            threshold: 0.3,
             location: 0,
             distance: 100,
             maxPatternLength: 32,
@@ -28,11 +28,10 @@ class SuggestionPortalSearchIndex {
     }
 
     sortSuggestionsAlphabetically = (a, b) => {
-            
-        if(a.score > b.score) {
+        if(a.data.score > b.data.score) {
             return 1;
         }
-        if(a.score < b.score){
+        if(a.data.score < b.data.score){
             return -1;
         } 
         if(a.item.suggestion.toLowerCase() > b.item.suggestion.toLowerCase()){
@@ -57,26 +56,28 @@ class SuggestionPortalSearchIndex {
         if (results.length === 0 && Lang.isEmpty(searchText)) {
             return this.shortcutsFuse.list.slice(0, maxLength).map((suggestionObj) => {
                 suggestionObj.data = {
-                    score: 1,
+                    score: 0.1,
                     matches: [],
                 }
                 return suggestionObj
             });
         }
 
-        results.sort(this.sortSuggestionsAlphabetically);
 
-        return results.slice(0, maxLength).map((result) => { 
+        const resultFormatted = results.map((result) => { 
             return {
                 key: result.item.key,
                 value: result.item.value,
                 suggestion: result.item.suggestion,
                 data: {
-                    score: result.score,
+                    // Use the bonus score to drag the most recent shortcuts to the top and weight the older ones to the bottom
+                    score: result.score + result.item.scoreBonusBasedOnContext,
                     matches: result.matches,
                 },
             };
-        });
+        }).sort(this.sortSuggestionsAlphabetically).slice(0,maxLength);;
+
+        return resultFormatted
     }
 }
 

--- a/src/notes/SuggestionPortalShortcutSearchIndex.jsx
+++ b/src/notes/SuggestionPortalShortcutSearchIndex.jsx
@@ -25,11 +25,12 @@ class SuggestionPortalShortcutSearchIndex extends SuggestionPortalSearchIndex  {
             // ActiveContexts is sorted from most recent to least recent
             // We want shortcuts for the most recent shortcuts to have the smallest bonus score, so as to appear earlier
             let scoreBonusBasedOnContext = _.findIndex(activeContexts, (context) => {
-                return context.getId() === shortcutObj.parentId;
+                // Quirk: We want global contexts to all be treated equally, regardless of incidence. 
+                return context.getId() === shortcutObj.parentId && !context.isGlobalContext();
             });
 
             if (scoreBonusBasedOnContext === -1)  {
-                // no matching context means it's in the parent context 
+                // no matching context means it's in the parent context or is a global context
                 // we want those to come last; they get the biggest bonus 
                 scoreBonusBasedOnContext = activeContexts.length
             }

--- a/src/notes/SuggestionPortalShortcutSearchIndex.jsx
+++ b/src/notes/SuggestionPortalShortcutSearchIndex.jsx
@@ -1,6 +1,7 @@
 import SuggestionPortalSearchIndex from './SuggestionPortalSearchIndex';
 import Fuse from 'fuse.js';
 import Lang from 'lodash';
+import _ from 'lodash';
 
 class SuggestionPortalShortcutSearchIndex extends SuggestionPortalSearchIndex  {
     updateIndex = (contextManager) => {
@@ -8,24 +9,42 @@ class SuggestionPortalShortcutSearchIndex extends SuggestionPortalSearchIndex  {
         // If shortcuts haven't updated, we don't need to update our fuse index
         if (Lang.isEqual(allShortcuts, this.currentlyValidShortcuts)) return
         this.currentlyValidShortcuts = allShortcuts;
-
-        const relevantShortcuts = [];
+        // Let's compile a list of shortcuts we care about, formatted for searching
+        const relevantShortcutsFormattedForSearch = [];
+        // We'll need to the active contexts to determine bonus scores, to improve sorting order.
+        const activeContexts = contextManager.getActiveContexts();
         allShortcuts.forEach((shortcut) => {
+            const shortcutMetadata = this.shortcutManager.getShortcutMetadata(shortcut);
+            if(Lang.isEmpty(shortcutMetadata.knownParentContexts)) console.log("No parents:", shortcutMetadata);
             const triggers = this.shortcutManager.getTriggersForShortcut(shortcut);
+            // Scores get sorted from smallest to greatest
+            // ActiveContexts is sorted from most recent to least recent
+            // We want shortcuts for the most recent shortcuts to have the smallest bonus score, so as to appear earlier
+            let scoreBonusBasedOnContext = _.findIndex(activeContexts, (context) => {
+                return context.getId() === shortcutMetadata.knownParentContexts;
+            });
+
+            if (scoreBonusBasedOnContext === -1)  {
+                // no matching context means it's in the parent context 
+                // we want those to come last; they get the biggest bonus 
+                scoreBonusBasedOnContext = activeContexts.length
+            }
             triggers.forEach((trigger) => {
                 const triggerPrefix = trigger.name.substring(0,1);
                 const triggerNoPrefix = trigger.name.substring(1)
                 if (this.initialChar === triggerPrefix) {
-                    relevantShortcuts.push({
+                    relevantShortcutsFormattedForSearch.push({
                         key: triggerNoPrefix,
                         value: trigger,
                         suggestion: triggerNoPrefix,
+                        knownParentContexts: shortcutMetadata.knownParentContexts,
+                        scoreBonusBasedOnContext 
                     });
                 }
             });
         });
 
-        this.shortcutsFuse = new Fuse(relevantShortcuts, this.fuseOptions); 
+        this.shortcutsFuse = new Fuse(relevantShortcutsFormattedForSearch, this.fuseOptions); 
     }
 };
 


### PR DESCRIPTION
Uses the associated parent context of a shortcut suggestion in determining the suggestion's score. Specifically, the more recent the context, the smaller the score added (since the suggestions with the lowest score are listed highest in the suggestions).

Also gives the suggestionPortalPlaceholderIndex its own array of values to suggest separate from the array that the Shortcut index uses. 