### PR TITLE
implemented Preference Manager

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -23,6 +23,7 @@ import PatientControlPanel from '../panels/PatientControlPanel';
 import SearchIndex from '../patientControl/SearchIndex';
 
 import '../styles/FullApp.css';
+import PreferenceManager from '../preferences/PreferenceManager';
 
 const theme = createMuiTheme({
     palette: {
@@ -154,6 +155,7 @@ export class FullApp extends Component {
         const userProfile = this.securityManager.getDemoUser(this.props.clinicianId);
         if (userProfile) {
             this.setState({loginUser: userProfile});
+            this.preferenceManager = new PreferenceManager(userProfile);
         } else {
             console.error("Login failed");
         }
@@ -382,6 +384,7 @@ export class FullApp extends Component {
                             handleSummaryItemSelected={this.handleSummaryItemSelected}
                             itemInserted={this.itemInserted}
                             loginUser={this.state.loginUser}
+                            preferenceManager={this.preferenceManager}
                             newCurrentShortcut={this.newCurrentShortcut}
                             onContextUpdate={this.onContextUpdate}
                             openSourceNoteEntryId={this.state.openSourceNoteEntryId}

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -185,6 +185,7 @@ export default class ClinicianDashboard extends Component {
                         isTargetedDataSubpanelVisible={isTargetedDataSubpanelVisible}
                         isWide={isTargetedDataPanelWide}
                         loginUser={this.props.loginUser}
+                        preferenceManager={this.props.preferenceManager}
                         summaryMetadata={this.props.summaryMetadata}
                         setForceRefresh={this.props.setForceRefresh}
                         targetedDataPanelSize={this.state.targetedDataPanelSize}
@@ -241,6 +242,7 @@ ClinicianDashboard.propTypes = {
     handleSummaryItemSelected: PropTypes.func.isRequired,
     itemInserted: PropTypes.func.isRequired,
     loginUser: PropTypes.object.isRequired,
+    preferenceManager: PropTypes.object.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     onContextUpdate: PropTypes.func.isRequired,
     openSourceNoteEntryId: PropTypes.oneOfType([

--- a/src/panels/TargetedDataPanel.jsx
+++ b/src/panels/TargetedDataPanel.jsx
@@ -51,6 +51,7 @@ export default class TargetedDataPanel extends Component {
                                 condition={this.props.appState.condition}
                                 isWide={this.props.isWide}
                                 loginUser={this.props.loginUser}
+                                preferenceManager={this.props.preferenceManager}
                                 patient={this.props.appState.patient} 
                                 setForceRefresh={this.props.setForceRefresh}                                                              
                                 summaryMetadata={this.props.summaryMetadata.getMetadata()}
@@ -77,6 +78,7 @@ TargetedDataPanel.proptypes = {
     isTargetedDataSubpanelVisible: PropTypes.bool,
     isWide: PropTypes.bool.isRequired,
     loginUser: PropTypes.object.isRequired,
+    preferenceManager: PropTypes.object.isRequired,
     summaryMetadata: PropTypes.object.isRequired,
     setForceRefresh: PropTypes.func.isRequired,
     targetedDataPanelSize: PropTypes.string.isRequired,

--- a/src/preferences/IPreferenceStore.jsx
+++ b/src/preferences/IPreferenceStore.jsx
@@ -1,0 +1,13 @@
+class IPreferenceStore {
+    setPreference(name, value) {
+    }
+
+    getPreference(name) {
+        return null;
+    }
+
+    removePreference(name) {
+    }
+}
+
+export default IPreferenceStore;

--- a/src/preferences/LocalStoragePreferenceStore.jsx
+++ b/src/preferences/LocalStoragePreferenceStore.jsx
@@ -1,0 +1,17 @@
+import IPreferenceStore from './IPreferenceStore';
+
+class LocalStoragePreferenceStore extends IPreferenceStore {
+    setPreference(name, value) {
+        localStorage.setItem(name, JSON.stringify(value));
+    }
+
+    getPreference(name) {
+        return JSON.parse(localStorage.getItem(name));
+    }
+
+    removePreference(name) {
+        localStorage.removeItem(name);
+    }
+}
+
+export default LocalStoragePreferenceStore;

--- a/src/preferences/LocalStoragePreferenceStore.jsx
+++ b/src/preferences/LocalStoragePreferenceStore.jsx
@@ -2,15 +2,25 @@ import IPreferenceStore from './IPreferenceStore';
 
 class LocalStoragePreferenceStore extends IPreferenceStore {
     setPreference(name, value) {
-        localStorage.setItem(name, JSON.stringify(value));
+        try {
+            localStorage.setItem(name, JSON.stringify(value));
+        } catch (e) {
+        }
     }
 
     getPreference(name) {
-        return JSON.parse(localStorage.getItem(name));
+        try {
+            return JSON.parse(localStorage.getItem(name));
+        } catch (e) {
+            return null;
+        }
     }
 
     removePreference(name) {
-        localStorage.removeItem(name);
+        try {
+            localStorage.removeItem(name);
+        } catch (e) {
+        }
     }
 }
 

--- a/src/preferences/PreferenceManager.jsx
+++ b/src/preferences/PreferenceManager.jsx
@@ -1,0 +1,30 @@
+import LocalStoragePreferenceStore from './LocalStoragePreferenceStore';
+
+class PreferenceManager {
+    constructor(user) {
+        this._user = user;
+        this._preferenceStore = this._getPreferenceStore();
+    }
+
+    _getPreferenceStore() {
+        return new LocalStoragePreferenceStore();
+    }
+
+    /*
+     * name = name of preference to store
+     * value = value for the named preference item
+    */
+    setPreference(name, value) {
+        this._preferenceStore.setPreference(name, value);
+    }
+
+    removePreference(name) {
+        this._preferenceStore.removePreference(name);
+    }
+
+    getPreference(name) {
+        return this._preferenceStore.getPreference(name);
+    }
+}
+
+export default PreferenceManager;

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -30,6 +30,11 @@ export default class TargetedDataSection extends Component {
     determineDefaultVisualizer = (section, clinicalEvent, optionsForSection) => {
         if (optionsForSection.length === 0) return 'tabular';
         let result = null;
+        const preferredVisualizer = this.props.preferenceManager.getPreference(this.props.section.name);
+        if (preferredVisualizer) {
+            result = this.determineIfDefaultVisualizerItemAffectsCurrentSituation(preferredVisualizer, clinicalEvent, optionsForSection);
+            if (!Lang.isNull(result)) return result;
+        }
         if (section.defaultVisualizer) {
             if (Lang.isArray(section.defaultVisualizer)) {
                 let defaultResult = null;
@@ -69,6 +74,7 @@ export default class TargetedDataSection extends Component {
         this.props.searchIndex.removeDataBySection(this.props.section.name);
         this.indexSectionData(this.props.section);
         this.setState({ chosenVisualizer });
+        this.props.preferenceManager.setPreference(this.props.section.name, chosenVisualizer);
     }
 
     checkVisualization = () => {
@@ -247,5 +253,6 @@ TargetedDataSection.propTypes = {
     isWide: PropTypes.bool.isRequired,
     clinicalEvent: PropTypes.string.isRequired,
     loginUser: PropTypes.object.isRequired,
+    preferenceManager: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
 }

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -164,6 +164,7 @@ export default class TargetedDataSubpanel extends Component {
                         isWide={isWide}
                         actions={actions}
                         loginUser={this.props.loginUser}
+                        preferenceManager={this.props.preferenceManager}
                         searchIndex={this.props.searchIndex}
                         moveToSubsectionFromSearch={this.props.moveToSubsectionFromSearch}
                     />
@@ -198,4 +199,5 @@ TargetedDataSubpanel.propTypes = {
     actions: PropTypes.array,
     searchIndex: PropTypes.object.isRequired,
     loginUser: PropTypes.object.isRequired,
+    preferenceManager: PropTypes.object.isRequired,
 };

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -26,6 +26,7 @@ import FluxInjury from '../../../src/model/condition/FluxInjury';
 
 import SearchIndex from '../../../src/patientControl/SearchIndex';
 import FluxClinicalNote from '../../../src/model/core/FluxClinicalNote';
+import PreferenceManager from '../../../src/preferences/PreferenceManager';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -89,9 +90,10 @@ describe('3 TargetedDataControl', function() {
         }
         const defaultOrTabular = options.length > 0 ? options[0] : 'tabular';
 
+        const preferenceManager = new PreferenceManager(null);
         const visualizerManager = new VisualizerManager();
         const searchIndex = new SearchIndex();
-        const wrapper = shallow(<TargetedDataSection patient={null} condition={null} section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='post-encounter' searchIndex={searchIndex} />);
+        const wrapper = shallow(<TargetedDataSection patient={null} condition={null} section={section} type={section.type} visualizerManager={visualizerManager} preferenceManager={preferenceManager} isWide={false} clinicalEvent='post-encounter' searchIndex={searchIndex} />);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))
@@ -115,9 +117,10 @@ describe('4 TargetedDataControl - correct default visualizer Medications', funct
         });
         const expectedDefault = 'chart';
 
+        const preferenceManager = new PreferenceManager(null);
         const visualizerManager = new VisualizerManager();
         const searchIndex = new SearchIndex();
-        const wrapper = shallow(<TargetedDataSection patient={null} condition={null} section={section} type={section.type} visualizerManager={visualizerManager} isWide={false} clinicalEvent='pre-encounter' searchIndex={searchIndex} />);
+        const wrapper = shallow(<TargetedDataSection patient={null} condition={null} section={section} type={section.type} visualizerManager={visualizerManager} preferenceManager={preferenceManager} isWide={false} clinicalEvent='pre-encounter' searchIndex={searchIndex} />);
 
         // Initial state
         expect(wrapper.state('defaultVisualizer'))


### PR DESCRIPTION
and used it to remember chosen visualizers across browser refreshes

JIRA 1459
Added preference manager that can be used to store preferences for current user. Initial implementation just stores preference values as strings in local storage. Preferences stay with a machine therefore instead of actually for a user. Eventually, a preference store that is user-specific instead and independent of where the user logs in from should be implemented.

## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [X] Recognizes any potential shortcomings/bugs in the description 

**Code Quality**

- [X] 4-space indents - convert any tabs to spaces
- [X] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [X] Code is commented

**Tests**

- [X] Existing tests passed

## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
