### PR TITLE
Correctly resize line charts

### DIFF
--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -15,27 +15,12 @@ class BandedLineChartVisualizer extends Component {
     constructor(props) {
         super(props);
 
-        this.updateState = true;
+        // this.updateState = true;
         // This var will be used 
         this.state = {
             chartWidth: 600,
             chartHeight: 400,
         }
-    }
-
-    // Make sure to update data and resize the component when its contents update.
-    componentDidUpdate = () => {
-        if (this.updateState) {
-            this.updateState = false;
-        } else {
-            this.updateState = true;
-            setTimeout(this.resize, 450);
-        }
-    }
-
-    // Adds appropriate event listeners for tracking resizing
-    componentDidMount = () => {
-        setTimeout(this.resize, 450);
     }
 
     // Turns dates into numeric representations for graphing
@@ -67,7 +52,6 @@ class BandedLineChartVisualizer extends Component {
             }
             return rangeValues;
         }, [processedData[0][xVarNumber], processedData[0][xVarNumber]]);
-
     }
 
     // Use min/max info to build ticks for the 
@@ -94,17 +78,7 @@ class BandedLineChartVisualizer extends Component {
         return (value) => {
             return `${value} ${unit}`;
         }
-    }
-
-    // Updates the dimensions of the chart
-    resize = () => {
-        if (!this.chartParentDiv) return;
-        const chartParentDivWidth = this.chartParentDiv.offsetWidth;
-
-        this.setState({
-            chartWidth: chartParentDivWidth,
-        })
-    }
+    }  
 
     renderSubsectionChart = (subsection, patient, condition) => {
         // FIXME: Should start_time be a magic string?
@@ -171,10 +145,7 @@ class BandedLineChartVisualizer extends Component {
         }
 
         return (
-            <div
-                ref={(chartParentDiv) => {
-                    this.chartParentDiv = chartParentDiv;
-                }}
+            <div          
                 key={yVar}
             >
                 <div className="sub-section-heading">
@@ -183,7 +154,7 @@ class BandedLineChartVisualizer extends Component {
                     </h2>
                 </div>
                 <ResponsiveContainer
-                  height={this.state.chartHeight}
+                    height={this.state.chartHeight}
                 >                 
                     <LineChart
                         data={processedData}

--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {LineChart, Line, XAxis, YAxis, Tooltip, ReferenceArea} from 'recharts';
+import {LineChart, Line, XAxis, YAxis, Tooltip, ReferenceArea, ResponsiveContainer} from 'recharts';
 import moment from 'moment';
 import {scaleLinear} from "d3-scale";
 import Collection from 'lodash';
@@ -182,30 +182,32 @@ class BandedLineChartVisualizer extends Component {
                         <span>{`${yVar}`}</span><span>{` (${yUnit})`}</span>
                     </h2>
                 </div>
-                <LineChart
-                    width={this.state.chartWidth}
-                    height={this.state.chartHeight}
-                    data={processedData}
-                    margin={{top: 5, right: 20, left: 10, bottom: 5}}
-                >
-                    <XAxis
-                        dataKey={xVarNumber}
-                        type="number"
-                        domain={[]}
-                        ticks={this.getTicks(processedData, xVarNumber)}
-                        tickFormatter={this.dateFormat}
-                    />
-                    <YAxis
-                        dataKey={yVar}
-                        domain={[0, 'dataMax']}
-                    />
-                    <Tooltip
-                        labelFormatter={this.xVarFormatFunction}
-                        formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
-                    />
-                    <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0}/>
-                    {renderedBands}
-                </LineChart>
+                <ResponsiveContainer
+                  height={this.state.chartHeight}
+                >                 
+                    <LineChart
+                        data={processedData}
+                        margin={{top: 5, right: 20, left: 10, bottom: 5}}
+                    >
+                        <XAxis
+                            dataKey={xVarNumber}
+                            type="number"
+                            domain={[]}
+                            ticks={this.getTicks(processedData, xVarNumber)}
+                            tickFormatter={this.dateFormat}
+                        />
+                        <YAxis
+                            dataKey={yVar}
+                            domain={[0, 'dataMax']}
+                        />
+                        <Tooltip
+                            labelFormatter={this.xVarFormatFunction}
+                            formatter={this.createYVarFormatFunctionWithUnit(yUnit)}
+                        />
+                        <Line type="monotone" dataKey={yVar} stroke="#295677" yAxisId={0}/>
+                        {renderedBands}
+                    </LineChart>
+                </ResponsiveContainer>
             </div>
         );
     }


### PR DESCRIPTION
This PR addresses issue 877.

Added responsive container around line chart to handle resizing correctly. Implemented same fix that was used to fix the resizing issue for the progression line chart.

_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- N/A Cheat sheet is updated
- N/A Demo script is updated 
- N/A Documentation on Wiki has been updated 
- N/A Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- N/A Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- N/A Added Enzyme-UI tests for slim mode 
- N/A Added Enzyme-UI tests for full mode
- N/A Added backend tests for new functionality added
- N/A Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
