### PR TITLE
Highlight open note search results

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -93,7 +93,8 @@ export class FullApp extends Component {
             snackbarMessage: "",
             summaryItemToInsert: '',
             summaryItemToInsertSource: '',
-            forceRefresh: false
+            forceRefresh: false,
+            openNoteSearchSuggestions: []
         };
 
         /*  actions is a list of actions passed to the visualizers
@@ -347,6 +348,10 @@ export class FullApp extends Component {
         return this.dashboard.moveTargetedDataPanelToSubsection(sectionName, subsectionName);
     }
 
+    setOpenNoteSearchSuggestions = (suggestions) => {
+        this.setState({ openNoteSearchSuggestions: suggestions });
+    }
+
     render() {
         // Get the Current Dashboard based on superRole of user
         const CurrentDashboard = this.dashboardManager.getDashboardForSuperRole(this.state.loginUser.getSuperRole());
@@ -370,6 +375,8 @@ export class FullApp extends Component {
                                     supportLogin={true}
                                     searchIndex={this.searchIndex}
                                     moveTargetedDataPanelToSubsection={this.moveTargetedDataPanelToSubsection}
+                                    openNoteSearchSuggestions={this.state.openNoteSearchSuggestions}
+                                    setOpenNoteSearchSuggestions={this.setOpenNoteSearchSuggestions}
                                 />
                             </Col>
                         </Row>
@@ -405,6 +412,7 @@ export class FullApp extends Component {
                             updateErrors={this.updateErrors}
                             ref={(dashboard) => { this.dashboard = dashboard; }}
                             searchIndex={this.searchIndex}
+                            openNoteSearchSuggestions={this.state.openNoteSearchSuggestions}
                         />
                         <Modal 
                             aria-labelledby="simple-modal-title"

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -226,6 +226,7 @@ export default class ClinicianDashboard extends Component {
                         summaryItemToInsertSource={this.props.appState.summaryItemToInsertSource}
                         updateErrors={this.props.updateErrors}
                         ref={(np) => { this.notesPanel = np; }}
+                        openNoteSearchSuggestions={this.props.openNoteSearchSuggestions}
                     />
                 </div>
             </div>

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -246,6 +246,7 @@ ClinicianDashboard.propTypes = {
     preferenceManager: PropTypes.object.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     onContextUpdate: PropTypes.func.isRequired,
+    openNoteSearchSuggestions: PropTypes.array.isRequired,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -246,7 +246,7 @@ ClinicianDashboard.propTypes = {
     preferenceManager: PropTypes.object.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     onContextUpdate: PropTypes.func.isRequired,
-    openNoteSearchSuggestions: PropTypes.array.isRequired,
+    openNoteSearchSuggestions: PropTypes.array,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1708,6 +1708,7 @@ FluxNotesEditor.propTypes = {
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
     itemInserted: PropTypes.func.isRequired,
+    openNoteSearchSuggestions: PropTypes.array.isRequired,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -828,9 +828,9 @@ class FluxNotesEditor extends React.Component {
             if (foundNode) {
                 const nodeRef = document.getNode(foundNode.key);
                 nodeRef.getTexts().forEach(textNode => {
-                    let match;
                     const regex = new RegExp(suggestion.inputValue, "gi");
-                    while (match = regex.exec(textNode.text)) {
+                    let match = regex.exec(textNode.text)
+                    while (match) {
                         const offset = match.index;
                         const range = {
                             anchorKey: textNode.key,
@@ -841,6 +841,7 @@ class FluxNotesEditor extends React.Component {
                             isBackward: false,
                         };
                         transform.select(range).addMark('highlighted');
+                        match = regex.exec(textNode.text);
                     }
                 });
             }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -772,8 +772,7 @@ class FluxNotesEditor extends React.Component {
         }
     }
 
-    unhighlightPlaintextResults = (transform) => {
-        const {document} = this.state.state;
+    unhighlightPlaintextResults = (transform, document) => {
 
         const fullDocRange = {
             anchorKey: document.getFirstText().key,
@@ -784,32 +783,32 @@ class FluxNotesEditor extends React.Component {
             isBackward: false
         }
 
-        return transform.select(fullDocRange).removeMark('highlighted');
+        return transform.select(fullDocRange).removeMark('highlighted').deselect();
     }
 
-    unhighlightAllResults = () => {
+    unhighlightAllResults = (document) => {
         let transform = this.state.state.transform();
         this.structuredFieldMapManager.keyToShortcutMap.forEach(sf => {
             transform.setNodeByKey(sf.key, "structured_field");
         });
-        transform = this.unhighlightPlaintextResults(transform);
+        transform = this.unhighlightPlaintextResults(transform, document);
         this.setState({ state: transform.blur().apply() });
     }
 
     highlightOpenNoteResults = (suggestions) => {
 
+        const {document} = this.state.state;
+
         // Unhighlight all results when suggestions are cleared
         if (suggestions.length === 0) {
-            this.unhighlightAllResults();
+            this.unhighlightAllResults(document);
             return;
         }
 
         let transform = this.state.state.transform();
-        const {document} = this.state.state;
 
         // Remove any existing plaintext highlights
-        this.unhighlightPlaintextResults(transform);
-
+        this.unhighlightPlaintextResults(transform, document);
 
         // Highlight each suggestion
         suggestions.forEach(suggestion => {
@@ -840,7 +839,7 @@ class FluxNotesEditor extends React.Component {
                             isFocused: false,
                             isBackward: false,
                         };
-                        transform.select(range).addMark('highlighted');
+                        transform.select(range).addMark('highlighted').deselect();
                         match = regex.exec(textNode.text);
                     }
                 });

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -823,27 +823,23 @@ class FluxNotesEditor extends React.Component {
             });
 
             // Highlight matching plaintext
-            const foundNode = this.findNodeContainingIndex(suggestion.indices[0], document);
-            if (foundNode) {
-                const nodeRef = document.getNode(foundNode.key);
-                nodeRef.getTexts().forEach(textNode => {
-                    const regex = new RegExp(suggestion.inputValue, "gi");
-                    let match = regex.exec(textNode.text)
-                    while (match) {
-                        const offset = match.index;
-                        const range = {
-                            anchorKey: textNode.key,
-                            anchorOffset: offset,
-                            focusKey: textNode.key,
-                            focusOffset: offset + suggestion.inputValue.length,
-                            isFocused: false,
-                            isBackward: false,
-                        };
-                        transform.select(range).addMark('highlighted').deselect();
-                        match = regex.exec(textNode.text);
-                    }
-                });
-            }
+            document.getTexts().forEach(textNode => {
+                const regex = new RegExp(suggestion.inputValue, "gi");
+                let match = regex.exec(textNode.text)
+                while (match) {
+                    const offset = match.index;
+                    const range = {
+                        anchorKey: textNode.key,
+                        anchorOffset: offset,
+                        focusKey: textNode.key,
+                        focusOffset: offset + suggestion.inputValue.length,
+                        isFocused: false,
+                        isBackward: false,
+                    };
+                    transform.select(range).addMark('highlighted').deselect();
+                    match = regex.exec(textNode.text);
+                }
+            });
         });
         this.setState({ state: transform.blur().apply() });
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1708,7 +1708,7 @@ FluxNotesEditor.propTypes = {
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
     itemInserted: PropTypes.func.isRequired,
-    openNoteSearchSuggestions: PropTypes.array.isRequired,
+    openNoteSearchSuggestions: PropTypes.array,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -870,6 +870,7 @@ class FluxNotesEditor extends React.Component {
     getLengthOfNode = (node) => {
         let length = 0;
         if (node.type === 'line') {
+            length += 1; // Add 1 for each new line in the note
             node.nodes.forEach(node => {
                 length += this.getLengthOfNode(node);
             });

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -111,18 +111,25 @@
 }
 
 // ******** StructuredFieldPlugin.jsx uses this
-// Highlighted during template hovering
-.structured-field-highlighted {
-    font-weight: bold;
-}
 
-// Inserter values are grayed out
-.structured-field-inserter {
-    color: $state;
-}
+.structured-field {
+    // Highlighted during template hovering
+    &-highlighted {
+        font-weight: bold;
+    }
 
-.structured-field-creator {
-    border-bottom: 1px solid $shr-context-line;
+    // Inserter values are grayed out
+    &-inserter {
+        color: $state;
+    }
+
+    &-creator {
+        border-bottom: 1px solid $shr-context-line;
+    }
+
+    &-search-result {
+        background-color: $highlight-yellow;
+    }
 }
 
 .in-progress-note { 

--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -3,7 +3,6 @@
 $note-assitant-width-1: 175px;
 $note-assitant-width-2: 170px;
 $note-assitant-width-3: 160px; 
-$highlight-yellow: rgb(255, 255, 70);
 
 /* Wrapper */
 .note-assistant-wrapper {

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -72,6 +72,14 @@ function StructuredFieldPlugin(opts) {
                     return <span contentEditable={false} className='structured-field-creator structured-field-highlighted' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
             },
+            structured_field_search_result: props => {
+                let shortcut = props.node.get('data').get('shortcut');
+                if (shortcut instanceof InsertValue) {
+                    return <span contentEditable={false} className='structured-field-inserter structured-field-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                } else {
+                    return <span contentEditable={false} className='structured-field-creator structured-field-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                }
+            },
             placeholder: props => {
                 const placeholder = props.node.get('data').get('placeholder');
                 return <span contentEditable={false} className='placeholder'>{placeholder.getTextToDisplayInNote()}</span>;

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -404,6 +404,7 @@ export default class NotesPanel extends Component {
                     openSourceNoteEntryId={this.props.openSourceNoteEntryId}
                     setOpenSourceNoteEntryId={this.props.setOpenSourceNoteEntryId}
                     searchIndex={this.props.searchIndex}
+                    openNoteSearchSuggestions={this.props.openNoteSearchSuggestions}
                 />
             </div>
         );

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -486,7 +486,7 @@ NotesPanel.propTypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     noteClosed: PropTypes.bool.isRequired,
     openClinicalNote: PropTypes.object,
-    openNoteSearchSuggestions: PropTypes.array.isRequired,
+    openNoteSearchSuggestions: PropTypes.array,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -486,6 +486,7 @@ NotesPanel.propTypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     noteClosed: PropTypes.bool.isRequired,
     openClinicalNote: PropTypes.object,
+    openNoteSearchSuggestions: PropTypes.array.isRequired,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -61,6 +61,7 @@ class PatientControlPanel extends Component {
                                             setSearchSelectedItem={this.props.setSearchSelectedItem}
                                             searchIndex={this.props.searchIndex}
                                             moveTargetedDataPanelToSubsection={this.props.moveTargetedDataPanelToSubsection}
+                                            setOpenNoteSearchSuggestions={this.props.setOpenNoteSearchSuggestions}
                                         />
                                     </Col>
                                 </Row>

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -85,7 +85,7 @@ PatientControlPanel.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     supportLogin: PropTypes.bool.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    setOpenNoteSearchSuggestions: PropTypes.func.isRequired
+    setOpenNoteSearchSuggestions: PropTypes.func
 };
 
 export default PatientControlPanel;

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -85,6 +85,7 @@ PatientControlPanel.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     supportLogin: PropTypes.bool.isRequired,
     searchIndex: PropTypes.object.isRequired,
+    setOpenNoteSearchSuggestions: PropTypes.func.isRequired
 };
 
 export default PatientControlPanel;

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -55,6 +55,7 @@ class PatientSearch extends React.Component {
     // Used by AutoSuggest to get a list of suggestions based on the current search's InputValue
     getSuggestions = (inputValue) => {
         let suggestions = [];
+        let openNoteSuggestions = [];
         let results = this.props.searchIndex.search(inputValue);
         results.forEach(result => {
             let suggestion;
@@ -74,6 +75,7 @@ class PatientSearch extends React.Component {
                     score: result.score,
                     indices: result.indices
                 }
+                if (result.section === "Open Note" && result.valueTitle === "Content") openNoteSuggestions.push(suggestion);
             } else {
                 suggestion = {
                     section: result.section,
@@ -89,7 +91,7 @@ class PatientSearch extends React.Component {
             }
             suggestions.push(suggestion);
         });
-
+        this.props.setOpenNoteSearchSuggestions(openNoteSuggestions);
         return suggestions;
     }
 
@@ -119,6 +121,7 @@ class PatientSearch extends React.Component {
   
     // Autosuggest will call this function every time you need to clear suggestions.
     onSuggestionsClearRequested = () => {
+        this.props.setOpenNoteSearchSuggestions([]);
         this.setState({
             suggestions: []
         });
@@ -149,7 +152,7 @@ class PatientSearch extends React.Component {
 
     // When the input is focused, Autosuggest will consult this function when to render suggestions
     shouldRenderSuggestions = (value) => {
-        return value.trim().length > 2;
+        return value.trim().length > 1;
     }
 
     // Defines how to render the suggestion

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -208,7 +208,7 @@ PatientSearch.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    setOpenNoteSearchSuggestions: PropTypes.func.isRequired
+    setOpenNoteSearchSuggestions: PropTypes.func
 };
 
 export default PatientSearch;

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -207,7 +207,8 @@ class PatientSearch extends React.Component {
 PatientSearch.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     patient: PropTypes.object.isRequired,
-    searchIndex: PropTypes.object.isRequired
+    searchIndex: PropTypes.object.isRequired,
+    setOpenNoteSearchSuggestions: PropTypes.func.isRequired
 };
 
 export default PatientSearch;

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -21,6 +21,7 @@ class PatientSearch extends React.Component {
         // and they are initially empty because the Autosuggest is closed.
         this.state = {
             suggestions: [],
+            openNoteSuggestions: [],
             value: '',
             previousSuggestion: null
         };
@@ -91,7 +92,9 @@ class PatientSearch extends React.Component {
             }
             suggestions.push(suggestion);
         });
-        this.props.setOpenNoteSearchSuggestions(openNoteSuggestions);
+        this.setState({ openNoteSuggestions }, () => {
+            this.props.setOpenNoteSearchSuggestions(this.state.openNoteSuggestions);
+        });
         return suggestions;
     }
 
@@ -123,7 +126,8 @@ class PatientSearch extends React.Component {
     onSuggestionsClearRequested = () => {
         this.props.setOpenNoteSearchSuggestions([]);
         this.setState({
-            suggestions: []
+            suggestions: [],
+            openNoteSuggestions: []
         });
     };
   

--- a/src/patientControl/SearchIndex.js
+++ b/src/patientControl/SearchIndex.js
@@ -52,12 +52,13 @@ class SearchIndex {
         this._index.search(query, {
             fields: {
                 valueTitle: {
-                    expand: true
+                    expand: true,
                 },
                 value: {
-                    expand: true
+                    expand: true,
                 }
-            }
+            },
+            bool: 'AND'
         }).forEach(result => {
             let doc = this._index.documentStore.getDoc(result.ref);
             doc.score = result.score;
@@ -65,7 +66,7 @@ class SearchIndex {
             if (doc.section === "Open Note" && doc.valueTitle === "Content") {
                 const regex = new RegExp(escapeRegExp(query), "gim");
                 let contentMatches = regex.exec(doc.value);
-                while (contentMatches ) {
+                while (contentMatches) {
                     let tempDoc = Lang.cloneDeep(doc);
                     tempDoc.indices = [contentMatches.index, contentMatches.index + query.length - 1];
                     openNoteSuggestions.push(tempDoc);

--- a/src/patientControl/SearchSuggestion.jsx
+++ b/src/patientControl/SearchSuggestion.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 // import FontAwesome from 'react-fontawesome';
 import './SearchSuggestion.css';
 
+function escapeRegExp(text) {
+    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
 
 class SearchSuggestion extends React.Component {
 
@@ -11,7 +14,7 @@ class SearchSuggestion extends React.Component {
         const {inputValue, valueTitle, contentSnapshot, indices} = suggestion;
         const inputValueLowerCase = inputValue.toLowerCase();
         const fullText = `${valueTitle ? valueTitle + ': ' : ''}${contentSnapshot}`;
-        const regex = new RegExp(inputValueLowerCase, "g");
+        const regex = new RegExp(escapeRegExp(inputValueLowerCase), "g");
         const matchesTitle = regex.exec(valueTitle.toLowerCase());
         const matchesContent = regex.exec(contentSnapshot.toLowerCase());
         let preText = '', highlightedText = '', postText = '';

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -16,3 +16,6 @@ $shr-context-light: #E5F7FF;
 $timeline-event-blue: #D9EBF9;
 $timeline-event-orange: #FA9F8F;
 $timeline-event-yellow: #FBEEAD;
+
+// Custom variables
+$highlight-yellow: rgb(255, 255, 70);

--- a/test/backend/patientControl/PatientControl.test.js
+++ b/test/backend/patientControl/PatientControl.test.js
@@ -46,6 +46,7 @@ describe('PatientSearch', function () {
     it('Should update state.value when input is entered ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
+            setOpenNoteSearchSuggestions={jest.fn()}
             setSearchSelectedItem={jest.fn()}
             searchIndex={searchIndex}
         />);
@@ -61,6 +62,7 @@ describe('PatientSearch', function () {
     it('Should update state.suggestions when input is entered ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
+            setOpenNoteSearchSuggestions={jest.fn()}
             setSearchSelectedItem={jest.fn()}
             searchIndex={searchIndex}
         />);
@@ -79,6 +81,7 @@ describe('PatientSearch', function () {
     it('Should provide suggestions in a list when input is entered and inputBox is focused ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
+            setOpenNoteSearchSuggestions={jest.fn()}
             setSearchSelectedItem={jest.fn()}
             searchIndex={searchIndex}
         />);        


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

For Jira 1446, highlighting the open note search results in the editor. When the search results appear for an open clinical note, the matching text is highlighted in the note. This works for structured data or plaintext. For structured data, the entire text is highlighted but for plaintext only the matching part is highlighted.

One potential shortcoming is that the highlights go away when the user clicks away from the search. However the important thing is that they can still scroll through the highlighted results when the search bar is open

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
