### PR TITLE
set context based on location of placeholder instead of cursor

### DIFF
--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -134,6 +134,20 @@ class ContextManager {
         });
     }
 
+    getContextsBeforeShortcut(shortcut, contextType = undefined) {
+        if (!shortcut.getKey()) return; // if the key hasn't been set for a shortcut yet then it shouldn't be added
+        let contextsBeforeShortcut = [];
+        this.contexts.forEach((context) => {
+            // check if provided shortcut is after the context. If yes, we have a valid context for the shortcut
+            if (!this.isBlock1BeforeBlock2(shortcut.getKey(), 0, context.getKey(), 0)) {
+                if (Lang.isUndefined(contextType) || Lang.isNull(contextType) || context.getShortcutType() === contextType) {
+                    contextsBeforeShortcut.push(context);
+                }
+            }
+        });
+        return contextsBeforeShortcut;
+    }
+
     addShortcutToContext(shortcut) {
         if (!shortcut.getKey()) return; // if the key hasn't been set for a shortcut yet then it shouldn't be added
         //console.log("adding shortcut to context: " + shortcut.getShortcutType());

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -23,14 +23,23 @@ export default class EntryShortcut extends Shortcut {
         return !Lang.isUndefined(this.parentContext) && !Lang.isNull(this.parentContext);
     }
 
-    establishParentContext(contextManager) {
+    establishParentContext(contextManager, relativeToShortcut = undefined) {
         super.initialize(contextManager);
         const knownParent = this.metadata["knownParentContexts"];
 
-        if (knownParent) {
-            this.parentContext = contextManager.getActiveContextOfType(knownParent);
-        } else   {
-            this.parentContext = contextManager.getCurrentContext();
+        if (Lang.isUndefined(relativeToShortcut)) {
+            if (knownParent) {
+                this.parentContext = contextManager.getActiveContextOfType(knownParent);
+            } else {
+                this.parentContext = contextManager.getCurrentContext();
+            }
+        } else {
+            const potentialParents = contextManager.getContextsBeforeShortcut(this, knownParent);
+            if (potentialParents && potentialParents.length > 0) {
+                this.parentContext = potentialParents[0];
+            } else {
+                this.parentContext = undefined;
+            }
         }
 
         if (!Lang.isUndefined(this.parentContext)) {

--- a/src/shortcuts/Placeholder.jsx
+++ b/src/shortcuts/Placeholder.jsx
@@ -84,7 +84,7 @@ class Placeholder {
 
     setAttributeValue(name, value, index = 0, source) {
         if (!this._entryShortcuts[index].hasParentContext()) {
-            this._entryShortcuts[index].establishParentContext(this._contextManager);
+            this._entryShortcuts[index].establishParentContext(this._contextManager, this);
         }
 
         if (!this._entryShortcuts[index].hasParentContext()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,9 +2976,9 @@ flexboxgrid@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/flexboxgrid/-/flexboxgrid-6.3.1.tgz#e99898afc07b7047722bb81a958a5fba4d4e20fd"
 
-flux_notes_treatment_options_rest_client@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/flux_notes_treatment_options_rest_client/-/flux_notes_treatment_options_rest_client-1.1.1.tgz#4b9497ccc7b9a9cd859661e147f4f3caf12ea20b"
+flux_notes_treatment_options_rest_client@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/flux_notes_treatment_options_rest_client/-/flux_notes_treatment_options_rest_client-1.1.2.tgz#1cd2ddd8372116fef194c793e8e05e445f8a3495"
   dependencies:
     superagent "3.5.2"
 


### PR DESCRIPTION
Fixed JIRA 1474. Saw another demo of FNOV where they ran into this bug again so I felt we had to fix it for them. This merely fixes the setting of context for placeholders to be based on placeholder location instead of based on current cursor. It leaves setting of context for normal shortcut creation the same to avoid issues even though technically speaking it could be done the same way. When we establish the context for a shortcut though, I don't think the slate js inline key has been set which is needed to determine before/after of content...


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [X] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [X] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
