### PR TITLE
Fixes reinitialization of data on an existing note

### DIFF
--- a/src/model/oncology/FluxTNMStage.js
+++ b/src/model/oncology/FluxTNMStage.js
@@ -9,6 +9,7 @@ import FluxObservation from '../finding/FluxObservation';
 import FluxMitoticRate from './FluxMitoticRate';
 import lookup from '../../lib/tnmstage_lookup.jsx';
 import staging from '../../lib/staging.jsx';
+import Lang from 'lodash';
 
 // FluxTNMStage class to hide codeableconcepts
 class FluxTNMStage extends FluxObservation {
@@ -29,7 +30,11 @@ class FluxTNMStage extends FluxObservation {
      *  This will return the displayText string from CodeableConcept value
      */
     get stage() {
-        return this._observation.value.coding[0].displayText.value;
+        if (Lang.isEmpty(this._observation.value))  { 
+            return null;
+        } else { 
+            return this._observation.value.coding[0].displayText.value;
+        }
     }
 
     /**

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1505,7 +1505,7 @@ class FluxNotesEditor extends React.Component {
         let signed = false;
 
         // If a note is selected, update the note header with information from the selected note
-        if (this.props.selectedNote) {
+        if (!Lang.isEmpty(this.props.selectedNote)) {
             noteTitle = this.props.selectedNote.subject;
             source = this.props.selectedNote.hospital;
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -703,7 +703,7 @@ class FluxNotesEditor extends React.Component {
                 this.resetEditorAndContext();
             }
 
-            // If the updated editor note is an actual note (existing note), then clear the editor and insert the
+            // If the updated editor note is an pre-existing note on the patient record, then clear the editor and insert the
             // content of the selected note into the editor and set the editor to read only
             else {
                 this.resetEditorAndContext();

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -364,47 +364,47 @@ export default class NotesPanel extends Component {
         return (
             <div className="panel-content dashboard-panel">
                 <FluxNotesEditor
+                    arrayOfPickLists={this.state.arrayOfPickLists}
+                    changeShortcutType={this.changeShortcutType}
                     closeNote={this.closeNote}
                     contextManager={this.props.contextManager}
+                    contextTrayItemToInsert={this.state.contextTrayItemToInsert}
                     currentViewMode={this.props.currentViewMode}
                     errors={this.props.errors}
                     handleUpdateEditorWithNote={this.handleUpdateEditorWithNote}
+                    handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
                     isNoteViewerEditable={this.props.isNoteViewerEditable}
                     itemInserted={this.props.itemInserted}
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     noteAssistantMode={this.state.noteAssistantMode}
+                    openNoteSearchSuggestions={this.props.openNoteSearchSuggestions}
+                    openSourceNoteEntryId={this.props.openSourceNoteEntryId}
                     patient={this.props.patient}
                     saveNote={this.saveNote}
+                    searchIndex={this.props.searchIndex}
                     selectedNote={this.state.selectedNote}
+                    selectedPickListOptions={this.state.selectedPickListOptions}
                     setForceRefresh={this.props.setForceRefresh}
-                    setNoteViewerEditable={this.props.setNoteViewerEditable}
                     setLayout={this.props.setLayout}
+                    setNoteViewerEditable={this.props.setNoteViewerEditable}
+                    setOpenSourceNoteEntryId={this.props.setOpenSourceNoteEntryId}
+                    setUndoTemplateInsertion={this.setUndoTemplateInsertion}
+                    shortcutKey={this.state.shortcutKey}
+                    shortcutType={this.state.shortcutType}
                     shortcutManager={this.props.shortcutManager}
                     shouldEditorContentUpdate={this.state.noteAssistantMode !== 'pick-list-options-panel'}
-                    selectedPickListOptions={this.state.selectedPickListOptions}
+                    shouldRevertTemplate={this.state.shouldRevertTemplate}
+                    shouldUpdateShortcutType={this.state.shouldUpdateShortcutType}
                     structuredFieldMapManager={this.props.structuredFieldMapManager}
                     summaryItemToInsert={this.props.summaryItemToInsert}
                     summaryItemToInsertSource={this.props.summaryItemToInsertSource}
-                    contextTrayItemToInsert={this.state.contextTrayItemToInsert}
+                    updateErrors={this.props.updateErrors}
+                    updatedEditorNote={this.state.updatedEditorNote}
                     updateLocalDocumentText={this.updateLocalDocumentText}
                     // Pass in note that the editor is to be updated with
-                    updatedEditorNote={this.state.updatedEditorNote}
-                    updateErrors={this.props.updateErrors}
                     updateSelectedNote={this.updateSelectedNote}
                     updateNoteAssistantMode={this.updateNoteAssistantMode}
-                    arrayOfPickLists={this.state.arrayOfPickLists}
-                    handleUpdateArrayOfPickLists={this.handleUpdateArrayOfPickLists}
                     updateContextTrayItemToInsert={this.updateContextTrayItemToInsert}
-                    shouldRevertTemplate={this.state.shouldRevertTemplate}
-                    setUndoTemplateInsertion={this.setUndoTemplateInsertion}
-                    shouldUpdateShortcutType={this.state.shouldUpdateShortcutType}
-                    shortcutKey={this.state.shortcutKey}
-                    shortcutType={this.state.shortcutType}
-                    changeShortcutType={this.changeShortcutType}
-                    openSourceNoteEntryId={this.props.openSourceNoteEntryId}
-                    setOpenSourceNoteEntryId={this.props.setOpenSourceNoteEntryId}
-                    searchIndex={this.props.searchIndex}
-                    openNoteSearchSuggestions={this.props.openNoteSearchSuggestions}
                 />
             </div>
         );

--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -50,21 +50,6 @@ export default class CreatorBase extends EntryShortcut {
         this.setAttributeValue = this.setAttributeValue.bind(this);
     }
 
-    initialize(contextManager, trigger = undefined, updatePatient = true) {
-        super.initialize(contextManager, trigger, updatePatient);
-
-        if (contextManager) {
-            this.establishParentContext(contextManager);
-        }        
-        // defaulting
-        const metadataVOA = this.metadata["valueObjectAttributes"];
-        metadataVOA.forEach((attrib) => {
-            if (attrib.isSettable && attrib.type !== "list") {
-                this.setAttributeValue(attrib.name, null, true, updatePatient);
-            }
-        });
-    }
-
     isContext() {
         return this.metadata.isContext;
     }

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -10,7 +10,7 @@ export default class EntryShortcut extends Shortcut {
 
     getAttributeValue(name) {
     }
-    
+
     setAttributeValue(name, value, publishChanges = true, updatePatient = true) {
     }
 
@@ -47,6 +47,22 @@ export default class EntryShortcut extends Shortcut {
         }
     }
 
+    initialize(contextManager, trigger = undefined, updatePatient = true) {
+        super.initialize(contextManager, trigger, updatePatient);
+        if (contextManager) {
+            this.establishParentContext(contextManager);
+        }
+        // defaulting
+        const metadataVOA = this.metadata["valueObjectAttributes"];
+        if (updatePatient) {
+            metadataVOA.forEach((attrib) => {
+                if (attrib.isSettable && attrib.type !== "list") {
+                    this.setAttributeValue(attrib.name, null, true, updatePatient);
+                }
+            });
+        }
+    }
+
     hasData() {
         const voaList = this.metadata["valueObjectAttributes"];
         let value, isSettable;
@@ -58,7 +74,7 @@ export default class EntryShortcut extends Shortcut {
                 if (Lang.isNull(value) || Lang.isUndefined(value) || value === '' || (Lang.isArray(value) && value.length === 0)) {
                 } else {
                     result = true;
-                }                
+                }
             }
         });
         return result;

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -54,13 +54,12 @@ export default class EntryShortcut extends Shortcut {
         }
         // defaulting
         const metadataVOA = this.metadata["valueObjectAttributes"];
-        if (updatePatient) {
-            metadataVOA.forEach((attrib) => {
-                if (attrib.isSettable && attrib.type !== "list") {
-                    this.setAttributeValue(attrib.name, null, true, updatePatient);
-                }
-            });
-        }
+        metadataVOA.forEach((attrib) => {
+            const curVal = this.getAttributeValue(attrib.name)
+            if (Lang.isEmpty(curVal) && attrib.isSettable && attrib.type !== "list") {
+                this.setAttributeValue(attrib.name, null, true, updatePatient);
+            }
+        });
     }
 
     hasData() {

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -54,12 +54,14 @@ export default class EntryShortcut extends Shortcut {
         }
         // defaulting
         const metadataVOA = this.metadata["valueObjectAttributes"];
-        metadataVOA.forEach((attrib) => {
-            const curVal = this.getAttributeValue(attrib.name)
-            if (Lang.isEmpty(curVal) && attrib.isSettable && attrib.type !== "list") {
-                this.setAttributeValue(attrib.name, null, true, updatePatient);
-            }
-        });
+        if (updatePatient) { 
+            metadataVOA.forEach((attrib) => {
+                const curVal = this.getAttributeValue(attrib.name)
+                if (Lang.isEmpty(curVal) && attrib.isSettable && attrib.type !== "list") {
+                    this.setAttributeValue(attrib.name, null, true, updatePatient);
+                }
+            });
+        }       
     }
 
     hasData() {

--- a/src/shortcuts/SingleHashtagKeyword.jsx
+++ b/src/shortcuts/SingleHashtagKeyword.jsx
@@ -10,7 +10,7 @@ export default class SingleHashtagKeyword extends EntryShortcut {
         this.metadata = metadata;
         //this.text = this.getPrefixCharacter() + this.metadata["name"];
         this.patient = patient;
-        if (Lang.isUndefined(shortcutData) || !shortcutData || shortcutData.length === 0) {
+        if (Lang.isUndefined(shortcutData) || !shortcutData || Lang.isEmpty(shortcutData)) {
             this.object = FluxObjectFactory.createInstance({}, this.metadata["valueObject"], patient);
             this.isObjectNew = true;
         } else {
@@ -48,21 +48,6 @@ export default class SingleHashtagKeyword extends EntryShortcut {
         });
         this.onUpdate = onUpdate;
         this.setAttributeValue = this.setAttributeValue.bind(this);
-    }
-
-    initialize(contextManager, trigger = undefined, updatePatient = true) {
-        super.initialize(contextManager, trigger, updatePatient);
-
-        if (contextManager) {
-            this.establishParentContext(contextManager);
-        }        
-        // defaulting
-        const metadataVOA = this.metadata["valueObjectAttributes"];
-        metadataVOA.forEach((attrib) => {
-            if (attrib.isSettable && attrib.type !== "list") {
-                this.setAttributeValue(attrib.name, null, true, updatePatient);
-            }
-        });
     }
 
     isContext() {

--- a/src/shortcuts/UpdaterBase.jsx
+++ b/src/shortcuts/UpdaterBase.jsx
@@ -62,16 +62,6 @@ export default class UpdaterBase extends EntryShortcut {
     initialize(contextManager, trigger = undefined, updatePatient = true) {
         super.initialize(contextManager, trigger, updatePatient);
 
-        if (contextManager) {
-            this.establishParentContext(contextManager);
-        }
-        // defaulting
-        const metadataVOA = this.metadata["valueObjectAttributes"];
-        metadataVOA.forEach((attrib) => {
-            if (attrib.isSettable && attrib.type !== "list") {
-                this.setAttributeValue(attrib.name, null, true, updatePatient);
-            }
-        });
         const idMetadataVOA = this.metadata["idAttributes"];
         idMetadataVOA.forEach((attrib) => {
             this.setAttributeValue(attrib.name, null, true, updatePatient);

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -706,32 +706,44 @@ describe('6 FluxNotesEditor', function() {
         }
 
         const wrapper = mount(<FluxNotesEditor
-            closeNote={() => {}}
-            updatedEditorNote={{ content: '' }}
-            shortcutManager={shortcutManager}
+            arrayOfPickLists={[]}
+            changeShortcutType={() => {}} 
+            closeNote={() => {}} 
             contextManager={contextManager}
-            structuredFieldMapManager={structuredFieldMapManager}
-            newCurrentShortcut={mockNewCurrentShortcut}
-            updatedEditorNote={null}
-            searchIndex={searchIndex}
+            contextTrayItemToInsert={() => {}} 
+            currentViewMode={''}
+            errors={[]}
             handleUpdateEditorWithNote={jest.fn()}
-            isNoteViewerVisible={true}
+            handleUpdateArrayOfPickLists={jest.fn()}
             isNoteViewerEditable={true}
-            setFullAppState={jest.fn()}
-            setFullAppStateWithCallback={jest.fn()}
+            isNoteViewerVisible={true}
+            itemInserted={jest.fn()}
+            newCurrentShortcut={mockNewCurrentShortcut}
+            noteAssistantMode={''}
+            openNoteSearchSuggestions={jest.fn()}
+            openSourceNoteEntryId={''}
+            patient={patient}
+            saveNote={jest.fn()}
+            searchIndex={searchIndex}
+            selectedNote={{}}
+            selectedPickListOptions={jest.fn()}
+            setForceRefresh={jest.fn()}
             setLayout={jest.fn()}
-            shouldEditorContentUpdate={true}
             setNoteViewerEditable={jest.fn()}
             setNoteViewerVisible={jest.fn()}
             setOpenSourceNoteEntryId={jest.fn()}
-            currentViewMode={''}
-            errors={[]}
-            itemInserted={jest.fn()}
-            noteAssistantMode={''}
-            patient={{}}
-            saveNote={jest.fn()}
+            setUndoTemplateInsertion={jest.fn()}
+            shortcutKey={{}}
+            shortcutManager={shortcutManager}
+            shortcutType={{}}
+            shouldEditorContentUpdate={true}
+            shouldRevertTemplate={jest.fn()}
+            shouldUpdateShortcutType={jest.fn()}
+            structuredFieldMapManager={structuredFieldMapManager}
             summaryItemToInsert={''}
+            summaryItemToInsertSource={''}
             updateErrors={jest.fn()}
+            updatedEditorNote={{ content: '' }}
             updateLocalDocumentText={jest.fn()}
             updateSelectedNote={jest.fn()}
             updateNoteAssistantMode={jest.fn()}


### PR DESCRIPTION
Avoids the re-initialization of data on an existing notes, avoiding the case where data with no written as-of date uses the default date of "today" on load. Old instructions for reproducing: 

- Go to the pilot1 endpoint
- Note in the summary panel that disease status is "Stable, neither improving nor worsening". Note also in the disease progression line chart that there are 7 data points in the chart and the date of the latest data point is Aug 23
- Open the Aug 23 existing note
- At this point the targeted data panel has been updated. If you look under the summary section, disease status is now "Stable", without the extra string "neither improving nor worsening" indicating that this has been updated. Look at the disease progression line chart. The latest data point is now Oct 10, which has replaced the Aug 23 data point that we saw prior to opening the existing note


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
