### PR TITLE
Remove searchable data when switching conditions

### DIFF
--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -22,6 +22,15 @@ export default class TargetedDataSubpanel extends Component {
         this._forceRefresh= false;
     }
 
+    componentWillReceiveProps(nextProps) {
+        // If the condition has changed, remove TDP data from the search index since it will change
+        if (!_.isEqual(this.props.condition, nextProps.condition)) {
+            this.props.conditionMetadata.sections.forEach(section => {
+                this.props.searchIndex.removeDataBySection(section.name);
+            });
+        }
+    }
+
     shouldComponentUpdate(nextProps, nextState) { 
         // Seven current reasons to update:
         // - There is a change to the entries this component cares about


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

For Jira 1464. The search indexer wasn't removing TDP data when the condition was switched. Added a call to remove data for all the sections in the TDP for the previous condition when the condition is changed.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
