### PR TITLE
Added abdominal pain to key toxicities.

### DIFF
--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -5692,7 +5692,7 @@
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "signed": true,
         "subject": "Primary Care Check-up",
-        "content": "REASON FOR VISIT:\nCheck-up for @Condition[[Gastrointestinal stromal tumor]]\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature.\n\nASSESSMENT:\nHe is experiencing #toxicity[[{\"entryId\":\"5010\"}]] #Grade 3 #Stomach pain.\n\nPHYSICAL EXAM:\nVitals normal. Slight firmess in upper abdomen. No sensitivty to pressure.\n\nPLAN:\nOrder EGD with EUS.",
+        "content": "REASON FOR VISIT:\nCheck-up for @Condition[[Gastrointestinal stromal tumor]]\n\nHISTORY OF PRESENT ILLNESS:\n@name[[Ihanos Tnfinity6]] is a @age[[57]] year old white @gender[[Male]] presenting with abdominal pain. He has been feeling sharp pains in his stomach. CT scan showed large upper abdominal mass that seemed to be rising from gastric wall. 6cm along greatest curvature.\n\nASSESSMENT:\nHe is experiencing #toxicity[[{\"entryId\":\"5010\"}]] #Grade 3 #Abdominal pain.\n\nPHYSICAL EXAM:\nVitals normal. Slight firmess in upper abdomen. No sensitivty to pressure.\n\nPLAN:\nOrder EGD with EUS.",
         "EntryId": "5000",
         "hospital": "Smith952 Practice",
         "createdBy": "Dr. Smith952", 
@@ -5729,6 +5729,13 @@
         "EntryType": {
             "Value": "http://standardhealthrecord.org/spec/shr/adverse/ToxicReaction"
         },
+        "FocalSubjectReference": {
+            "_ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
+            "_EntryId": "8",
+            "_EntryType": {
+                "Value": "http://standardhealthrecord.org/spec/shr/oncology/GastrointestinalStromalTumor"
+            }
+        },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7f",
         "EntryId": "5010",
         "PersonOfRecord": {
@@ -5759,7 +5766,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Coding"
                     },
-                    "Value": "10042112",
+                    "Value": "10000081",
                     "CodeSystem": {
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"
@@ -5770,7 +5777,7 @@
                         "EntryType": {
                             "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"
                         },
-                        "Value": "Stomach pain"
+                        "Value": "Abdominal pain"
                     }
                 }
             ]

--- a/src/summary/metadata/SarcomaSummarySection.jsx
+++ b/src/summary/metadata/SarcomaSummarySection.jsx
@@ -292,6 +292,12 @@ export default class SarcomaSummarySection extends MetadataSection {
                             value: (patient, currentConditionEntry) => {
                                 return this.getKeyToxicityAndUnsignedFromCodes(patient, currentConditionEntry, ["10028323", "10028411"]);
                             }
+                        },
+                        {
+                            name: "Abdominal Pain",
+                            value: (patient, currentConditionEntry) => {
+                                return this.getKeyToxicityAndUnsignedFromCodes(patient, currentConditionEntry, ["10000081"]);
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Addresses JIRA-1506.

- Added abdominal pain to key toxicities subsection.
-  Changed stomach pain toxicity entry to abdominal pain.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

-  4-space indents - convert any tabs to spaces
-  Use public class field syntax for binding functions - ex. handleChange = () => { ... };
-  Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
