### PR TITLE
Highlight notes real time

### DIFF
--- a/src/containers/CoreCancerPilotApp.jsx
+++ b/src/containers/CoreCancerPilotApp.jsx
@@ -80,7 +80,7 @@ export class CoreCancerPilotApp extends Component {
             snackbarMessage: "",
             superRole: 'Clinician', // possibly add that to security manager too
             forceRefresh: false,
-            tdpSearchSuggestions: []
+            searchSuggestions: []
         };
     }
 
@@ -166,8 +166,8 @@ export class CoreCancerPilotApp extends Component {
         return this.dashboard.moveTargetedDataPanelToSubsection(sectionName, subsectionName);
     }
 
-    setTDPSearchSuggestions = (suggestions) => {
-        this.setState({ tdpSearchSuggestions: suggestions })
+    setSearchSuggestions = (suggestions) => {
+        this.setState({ searchSuggestions: suggestions })
     }
 
     render() {
@@ -190,8 +190,7 @@ export class CoreCancerPilotApp extends Component {
                                     supportLogin={true}
                                     searchIndex={this.searchIndex}
                                     moveTargetedDataPanelToSubsection={this.moveTargetedDataPanelToSubsection}
-                                    setOpenNoteSearchSuggestions={() => {}}
-                                    setTDPSearchSuggestions={this.setTDPSearchSuggestions}
+                                    setSearchSuggestions={this.setSearchSuggestions}
                                 />
                             </Col>
                         </Row>
@@ -211,7 +210,7 @@ export class CoreCancerPilotApp extends Component {
                             summaryMetadata={this.summaryMetadata}
                             ref={(dashboard) => { this.dashboard = dashboard; }}
                             searchIndex={this.searchIndex}
-                            tdpSearchSuggestions={this.state.tdpSearchSuggestions}
+                            searchSuggestions={this.state.searchSuggestions}
                         />
                         <Modal 
                             aria-labelledby="simple-modal-title"

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -94,8 +94,7 @@ export class FullApp extends Component {
             summaryItemToInsert: '',
             summaryItemToInsertSource: '',
             forceRefresh: false,
-            openNoteSearchSuggestions: [],
-            tdpSearchSuggestions: []
+            searchSuggestions: []
         };
 
         /*  actions is a list of actions passed to the visualizers
@@ -354,12 +353,8 @@ export class FullApp extends Component {
         return this.dashboard.moveTargetedDataPanelToSubsection(sectionName, subsectionName);
     }
 
-    setOpenNoteSearchSuggestions = (suggestions) => {
-        this.setState({ openNoteSearchSuggestions: suggestions });
-    }
-
-    setTDPSearchSuggestions = (suggestions) => {
-        this.setState({ tdpSearchSuggestions: suggestions })
+    setSearchSuggestions = (suggestions) => {
+        this.setState({ searchSuggestions: suggestions });
     }
 
     render() {
@@ -385,9 +380,7 @@ export class FullApp extends Component {
                                     supportLogin={true}
                                     searchIndex={this.searchIndex}
                                     moveTargetedDataPanelToSubsection={this.moveTargetedDataPanelToSubsection}
-                                    openNoteSearchSuggestions={this.state.openNoteSearchSuggestions}
-                                    setOpenNoteSearchSuggestions={this.setOpenNoteSearchSuggestions}
-                                    setTDPSearchSuggestions={this.setTDPSearchSuggestions}
+                                    setSearchSuggestions={this.setSearchSuggestions}
                                 />
                             </Col>
                         </Row>
@@ -423,8 +416,7 @@ export class FullApp extends Component {
                             updateErrors={this.updateErrors}
                             ref={(dashboard) => { this.dashboard = dashboard; }}
                             searchIndex={this.searchIndex}
-                            openNoteSearchSuggestions={this.state.openNoteSearchSuggestions}
-                            tdpSearchSuggestions={this.state.tdpSearchSuggestions}
+                            searchSuggestions={this.state.searchSuggestions}
                         />
                         <Modal 
                             aria-labelledby="simple-modal-title"

--- a/src/dashboard/ClinicianDashboard.jsx
+++ b/src/dashboard/ClinicianDashboard.jsx
@@ -191,7 +191,7 @@ export default class ClinicianDashboard extends Component {
                         targetedDataPanelSize={this.state.targetedDataPanelSize}
                         ref={(tdp) => { this.targetedDataPanel = tdp; }}
                         searchIndex={this.props.searchIndex}
-                        tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                        searchSuggestions={this.props.searchSuggestions}
                     />
                 </div>
                 <div style={notesPanelStyles}>
@@ -227,7 +227,7 @@ export default class ClinicianDashboard extends Component {
                         summaryItemToInsertSource={this.props.appState.summaryItemToInsertSource}
                         updateErrors={this.props.updateErrors}
                         ref={(np) => { this.notesPanel = np; }}
-                        openNoteSearchSuggestions={this.props.openNoteSearchSuggestions}
+                        searchSuggestions={this.props.searchSuggestions}
                     />
                 </div>
             </div>
@@ -247,7 +247,6 @@ ClinicianDashboard.propTypes = {
     preferenceManager: PropTypes.object.isRequired,
     newCurrentShortcut: PropTypes.func.isRequired,
     onContextUpdate: PropTypes.func.isRequired,
-    openNoteSearchSuggestions: PropTypes.array,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,
@@ -268,5 +267,5 @@ ClinicianDashboard.propTypes = {
     summaryMetadata: PropTypes.object.isRequired,
     updateErrors: PropTypes.func.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    tdpSearchSuggestions: PropTypes.array
+    searchSuggestions: PropTypes.array
 };

--- a/src/dashboard/CoreCancerPilotDashboard.jsx
+++ b/src/dashboard/CoreCancerPilotDashboard.jsx
@@ -37,7 +37,7 @@ export default class CoreCancerPilotDashboard extends Component {
                         targetedDataPanelSize={'100%'}
                         ref={(tdp) => { this.targetedDataPanel = tdp; }}
                         searchIndex={this.props.searchIndex}
-                        tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                        searchSuggestions={this.props.searchSuggestions}
                     />
                 </div>
             </div>
@@ -58,5 +58,5 @@ CoreCancerPilotDashboard.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     summaryMetadata: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    tdpSearchSuggestions: PropTypes.array,
+    searchSuggestions: PropTypes.array,
 };

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -768,8 +768,9 @@ class FluxNotesEditor extends React.Component {
         }
 
         // If the open note search results have changed, we want to highlight the results in the note
-        if (!Lang.isEqual(this.props.openNoteSearchSuggestions, nextProps.openNoteSearchSuggestions)) {
-            this.highlightOpenNoteResults(nextProps.openNoteSearchSuggestions);
+        if (!Lang.isEqual(this.props.searchSuggestions, nextProps.searchSuggestions)) {
+            const openNoteSearchSuggestions = nextProps.searchSuggestions.filter(s => s.section === "Open Note");
+            this.highlightOpenNoteResults(openNoteSearchSuggestions);
         }
     }
 
@@ -1713,7 +1714,6 @@ FluxNotesEditor.propTypes = {
     handleUpdateEditorWithNote: PropTypes.func.isRequired,
     isNoteViewerEditable: PropTypes.bool.isRequired,
     itemInserted: PropTypes.func.isRequired,
-    openNoteSearchSuggestions: PropTypes.array,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,
@@ -1722,6 +1722,7 @@ FluxNotesEditor.propTypes = {
     noteAssistantMode: PropTypes.string.isRequired,
     patient: PropTypes.object.isRequired,
     saveNote: PropTypes.func.isRequired,
+    searchSuggestions: PropTypes.array,
     selectedNote: PropTypes.object,
     selectedPickListOptions: PropTypes.array.isRequired,
     setForceRefresh: PropTypes.func,

--- a/src/notes/NoteAssistant.jsx
+++ b/src/notes/NoteAssistant.jsx
@@ -23,7 +23,8 @@ export default class NoteAssistant extends Component {
             // false indicates a shortcut is being inserted
             // true indicates a template is being inserted
             insertingTemplate: false,
-            searchResultNoteId: null
+            searchResultNoteId: null,
+            highlightedNoteIds: []
         };
         // On creating of NoteAssistant, check if the note viewer is editable
         if (this.props.isNoteViewerEditable) {
@@ -69,6 +70,14 @@ export default class NoteAssistant extends Component {
             if (!isVisible) {
                 this.refs[nextProps.updatedEditorNote.entryInfo.entryId].scrollIntoView();
             }
+        }
+
+        const previousNoteAssistantSuggestions = this.props.searchSuggestions.filter(s => s.section === 'Clinical Notes' && s.valueTitle !== 'Subsection' && s.valueTitle !== 'Section');
+        const nextNoteAssistantSuggestions = nextProps.searchSuggestions.filter(s => s.section === 'Clinical Notes' && s.valueTitle !== 'Subsection' && s.valueTitle !== 'Section');
+
+        if (!Lang.isEqual(previousNoteAssistantSuggestions, nextNoteAssistantSuggestions)) {
+            const highlightedNoteIds = nextNoteAssistantSuggestions.map(s => s.note.entryInfo.entryId);
+            this.setState({ highlightedNoteIds });
         }
     }
 
@@ -408,7 +417,7 @@ export default class NoteAssistant extends Component {
     // For each clinical note, render the note image with the text
     renderClinicalNote(item, i) {
         let selected = Lang.isEqual(this.props.selectedNote, item);
-        let searchedFor = item.entryInfo.entryId === this.state.searchResultNoteId;
+        const searchedFor = Lang.includes(this.state.highlightedNoteIds, item.entryInfo.entryId);
         // if we have closed the note, selected = false
         if (Lang.isEqual(this.props.noteClosed, true)) {
             selected = false;
@@ -611,6 +620,7 @@ NoteAssistant.propTypes = {
     patient: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
+    searchSuggestions: PropTypes.array,
     selectedNote: PropTypes.object,
     setLayout: PropTypes.func.isRequired,
     setNoteClosed: PropTypes.func.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -377,11 +377,11 @@ export default class NotesPanel extends Component {
                     itemInserted={this.props.itemInserted}
                     newCurrentShortcut={this.props.newCurrentShortcut}
                     noteAssistantMode={this.state.noteAssistantMode}
-                    openNoteSearchSuggestions={this.props.openNoteSearchSuggestions}
                     openSourceNoteEntryId={this.props.openSourceNoteEntryId}
                     patient={this.props.patient}
                     saveNote={this.saveNote}
                     searchIndex={this.props.searchIndex}
+                    searchSuggestions={this.props.searchSuggestions}
                     selectedNote={this.state.selectedNote}
                     selectedPickListOptions={this.state.selectedPickListOptions}
                     setForceRefresh={this.props.setForceRefresh}
@@ -486,7 +486,6 @@ NotesPanel.propTypes = {
     newCurrentShortcut: PropTypes.func.isRequired,
     noteClosed: PropTypes.bool.isRequired,
     openClinicalNote: PropTypes.object,
-    openNoteSearchSuggestions: PropTypes.array,
     openSourceNoteEntryId: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,
@@ -494,6 +493,7 @@ NotesPanel.propTypes = {
     patient: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
     searchSelectedItem: PropTypes.object,
+    searchSuggestions: PropTypes.array,
     setNoteClosed: PropTypes.func.isRequired,
     setNoteViewerEditable: PropTypes.func.isRequired,
     setForceRefresh: PropTypes.func.isRequired,

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -459,6 +459,7 @@ export default class NotesPanel extends Component {
                     updateShowTemplateView={this.updateShowTemplateView}
                     setUndoTemplateInsertion={this.setUndoTemplateInsertion}
                     changeShortcutType={this.changeShortcutType}
+                    searchSuggestions={this.props.searchSuggestions}
                 />
             </div>
         );

--- a/src/panels/PatientControlPanel.jsx
+++ b/src/panels/PatientControlPanel.jsx
@@ -61,8 +61,7 @@ class PatientControlPanel extends Component {
                                             setSearchSelectedItem={this.props.setSearchSelectedItem}
                                             searchIndex={this.props.searchIndex}
                                             moveTargetedDataPanelToSubsection={this.props.moveTargetedDataPanelToSubsection}
-                                            setOpenNoteSearchSuggestions={this.props.setOpenNoteSearchSuggestions}
-                                            setTDPSearchSuggestions={this.props.setTDPSearchSuggestions}
+                                            setSearchSuggestions={this.props.setSearchSuggestions}
                                         />
                                     </Col>
                                 </Row>
@@ -86,8 +85,7 @@ PatientControlPanel.propTypes = {
     setSearchSelectedItem: PropTypes.func.isRequired,
     supportLogin: PropTypes.bool.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    setOpenNoteSearchSuggestions: PropTypes.func,
-    setTDPSearchSuggestions: PropTypes.func
+    setSearchSuggestions: PropTypes.func,
 };
 
 export default PatientControlPanel;

--- a/src/panels/TargetedDataPanel.jsx
+++ b/src/panels/TargetedDataPanel.jsx
@@ -70,7 +70,7 @@ export default class TargetedDataPanel extends Component {
                                     conditionMetadata={conditionMetadata}
                                     searchIndex={this.props.searchIndex}
                                     moveToSubsectionFromSearch={this.moveToSubsectionFromSearch.bind(this)}
-                                    tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                                    searchSuggestions={this.props.searchSuggestions}
                                     />
                             </div>
                         </div>
@@ -97,7 +97,7 @@ export default class TargetedDataPanel extends Component {
                                 conditionMetadata={conditionMetadata}
                                 searchIndex={this.props.searchIndex}
                                 moveToSubsectionFromSearch={this.moveToSubsectionFromSearch.bind(this)}
-                                tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                                searchSuggestions={this.props.searchSuggestions}
                                 />
                         </div>
                     </div>
@@ -124,5 +124,5 @@ TargetedDataPanel.proptypes = {
     setForceRefresh: PropTypes.func.isRequired,
     targetedDataPanelSize: PropTypes.string.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    tdpSearchSuggestions: PropTypes.array
+    searchSuggestions: PropTypes.array
 }

--- a/src/patientControl/PatientSearch.jsx
+++ b/src/patientControl/PatientSearch.jsx
@@ -59,8 +59,6 @@ class PatientSearch extends React.Component {
     // Used by AutoSuggest to get a list of suggestions based on the current search's InputValue
     getSuggestions = (inputValue) => {
         let suggestions = [];
-        let openNoteSuggestions = [];
-        let tdpSearchSuggestions = [];
         let results = this.props.searchIndex.search(inputValue);
         results.forEach(result => {
             let suggestion;
@@ -80,7 +78,6 @@ class PatientSearch extends React.Component {
                     score: result.score,
                     indices: result.indices
                 }
-                if (result.section === "Open Note" && result.valueTitle === "Content") openNoteSuggestions.push(suggestion);
             } else {
                 suggestion = {
                     section: result.section,
@@ -94,12 +91,10 @@ class PatientSearch extends React.Component {
                     score: result.score,
                     field: result.field
                 }
-                tdpSearchSuggestions.push(suggestion);
             }
             suggestions.push(suggestion);
         });
-        this.props.setOpenNoteSearchSuggestions(openNoteSuggestions);
-        this.props.setTDPSearchSuggestions(tdpSearchSuggestions);
+        this.props.setSearchSuggestions(suggestions);
         this.setState({ suggestions, loading: false });
     }
 
@@ -130,8 +125,7 @@ class PatientSearch extends React.Component {
   
     // Autosuggest will call this function every time you need to clear suggestions.
     onSuggestionsClearRequested = () => {
-        this.props.setOpenNoteSearchSuggestions([]);
-        this.props.setTDPSearchSuggestions([]);
+        this.props.setSearchSuggestions([]);
         this.setState({
             suggestions: [],
             openNoteSuggestions: []
@@ -219,7 +213,7 @@ PatientSearch.propTypes = {
     patient: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
     setOpenNoteSearchSuggestions: PropTypes.func,
-    setTDPSearchSuggestions: PropTypes.func
+    setSearchSuggestions: PropTypes.func
 };
 
 export default PatientSearch;

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -19,6 +19,8 @@ export default class TargetedDataSection extends Component {
             filters[`${this.props.section.name}-${subsection.name}`] = Lang.cloneDeep(subsection.filters) || [];
         });
 
+        this.tdpSearchSuggestions = [];
+
         // this.state.defaultVisualizer is the default visualization, this.state.chosenVisualizer changes when icons are clicked
         this.state = {
             defaultVisualizer: defaultVisualizer,
@@ -62,7 +64,12 @@ export default class TargetedDataSection extends Component {
             });
             this.setState({ filters });
         }
-    } 
+
+        const previousTDPSuggestions = this.props.searchSuggestions.filter(s => s.source === 'structuredData');
+        const nextTDPSuggestions = nextProps.searchSuggestions.filter(s => s.source === 'structuredData');
+
+        if (!Lang.isEqual(previousTDPSuggestions, nextTDPSuggestions)) this.tdpSearchSuggestions = nextTDPSuggestions;
+    }
 
     determineDefaultVisualizer = (section, clinicalEvent, optionsForSection) => {
         if (optionsForSection.length === 0) return 'tabular';
@@ -334,13 +341,13 @@ export default class TargetedDataSection extends Component {
                 loginUser={loginUser}
                 actions={actions}
                 searchIndex={searchIndex}
-                tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                tdpSearchSuggestions={this.tdpSearchSuggestions}
             />
         );
     }
 
     render() {
-        const { section, condition, clinicalEvent, tdpSearchSuggestions } = this.props;
+        const { section, condition, clinicalEvent } = this.props;
         const visualizationOptions = this.getOptions(section);
         const selectedCondition = condition && condition.type;
         const encounterView = clinicalEvent === "encounter";
@@ -349,8 +356,8 @@ export default class TargetedDataSection extends Component {
         const viz = this.indexSectionData(section);
         
         let highlightClass;
-        if (!Lang.isUndefined(tdpSearchSuggestions)) {
-            const matchingSection = tdpSearchSuggestions.find(s => {
+        if (!Lang.isUndefined(this.tdpSearchSuggestions)) {
+            const matchingSection = this.tdpSearchSuggestions.find(s => {
                 return s.valueTitle === 'Section' && s.section === section.name;
             });
             highlightClass = matchingSection ? ' section-header__highlighted' : '';
@@ -388,5 +395,5 @@ TargetedDataSection.propTypes = {
     loginUser: PropTypes.object.isRequired,
     preferenceManager: PropTypes.object.isRequired,
     searchIndex: PropTypes.object.isRequired,
-    tdpSearchSuggestions: PropTypes.array
+    searchSuggestions: PropTypes.array
 }

--- a/src/summary/TargetedDataSubpanel.jsx
+++ b/src/summary/TargetedDataSubpanel.jsx
@@ -44,7 +44,9 @@ export default class TargetedDataSubpanel extends Component {
         // Need to ignore patientRecords on entries, as they reference the clinical notes ignored above. 
         // Solution: Remove them during comparison, restore those value after comparison.
 
-        if (!_.isEqual(this.props.tdpSearchSuggestions, nextProps.tdpSearchSuggestions)) return true;
+        const previousTDPSuggestions = this.props.searchSuggestions.filter(s => s.source === 'structuredData');
+        const nextTDPSuggestions = nextProps.searchSuggestions.filter(s => s.source === 'structuredData');
+        if (!_.isEqual(previousTDPSuggestions, nextTDPSuggestions)) return true;
 
         const newRelevantPatientEntries = nextProps.patient.getEntriesOtherThanNotes();
         const arrayOfPatientRecords = newRelevantPatientEntries.reduce((accumulator, currentEntry, currentIndex) => { 
@@ -155,7 +157,7 @@ export default class TargetedDataSubpanel extends Component {
                         preferenceManager={this.props.preferenceManager}
                         searchIndex={this.props.searchIndex}
                         moveToSubsectionFromSearch={this.props.moveToSubsectionFromSearch}
-                        tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                        searchSuggestions={this.props.searchSuggestions}
                     />
 
                     {i < conditionMetadata.sections.length - 1 ? <Divider className="divider"/> : null}
@@ -189,5 +191,5 @@ TargetedDataSubpanel.propTypes = {
     searchIndex: PropTypes.object.isRequired,
     loginUser: PropTypes.object.isRequired,
     preferenceManager: PropTypes.object.isRequired,
-    tdpSearchSuggestions: PropTypes.array
+    searchSuggestions: PropTypes.array
 };

--- a/test/backend/patientControl/PatientControl.test.js
+++ b/test/backend/patientControl/PatientControl.test.js
@@ -57,9 +57,8 @@ describe('PatientSearch', function () {
     it('Should update state.value when input is entered ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
-            setOpenNoteSearchSuggestions={jest.fn()}
             setSearchSelectedItem={jest.fn()}
-            setTDPSearchSuggestions={jest.fn()}
+            setSearchSuggestions={jest.fn()}
             searchIndex={searchIndex}
         />);
         expect(wrapper).to.exist;
@@ -74,9 +73,8 @@ describe('PatientSearch', function () {
     it('Should update state.suggestions when input is entered ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
-            setOpenNoteSearchSuggestions={jest.fn()}
             setSearchSelectedItem={jest.fn()}
-            setTDPSearchSuggestions={jest.fn()}
+            setSearchSuggestions={jest.fn()}
             searchIndex={searchIndex}
         />);
 
@@ -94,9 +92,8 @@ describe('PatientSearch', function () {
     it('Should provide suggestions in a list when input is entered and inputBox is focused ', function () { 
         const wrapper = mount(<PatientSearch
             patient={testPatientObj}
-            setOpenNoteSearchSuggestions={jest.fn()}
             setSearchSelectedItem={jest.fn()}
-            setTDPSearchSuggestions={jest.fn()}
+            setSearchSuggestions={jest.fn()}
             searchIndex={searchIndex}
         />);
         // Assumes we're testing against TestPatient

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -405,6 +405,7 @@ describe('6 FluxNotesEditor', function() {
             updateSelectedNote={jest.fn()}
             updateNoteAssistantMode={jest.fn()}
             updateContextTrayItemToInsert={jest.fn()}
+            searchSuggestions={[]}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -546,6 +547,7 @@ describe('6 FluxNotesEditor', function() {
             setSearchSelectedItem={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />,
         { attachTo: document.body });
         expect(notesPanelWrapper).to.have.lengthOf(1);
@@ -602,6 +604,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenSourceNoteEntryId={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />, { attachTo: document.body });
         expect(notesPanelWrapper.find(FluxNotesEditor)).to.have.lengthOf(1);
         expect(notesPanelWrapper.find(NoteAssistant)).to.have.lengthOf(1);
@@ -669,6 +672,7 @@ describe('6 FluxNotesEditor', function() {
             updateSelectedNote={jest.fn()}
             updateNoteAssistantMode={jest.fn()}
             updateContextTrayItemToInsert={jest.fn()}
+            searchSuggestions={[]}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -748,6 +752,7 @@ describe('6 FluxNotesEditor', function() {
             updateSelectedNote={jest.fn()}
             updateNoteAssistantMode={jest.fn()}
             updateContextTrayItemToInsert={jest.fn()}
+            searchSuggestions={[]}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -829,6 +834,7 @@ describe('6 FluxNotesEditor', function() {
             updateSelectedNote={jest.fn()}
             updateNoteAssistantMode={jest.fn()}
             updateContextTrayItemToInsert={jest.fn()}
+            searchSuggestions={[]}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -897,6 +903,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenSourceNoteEntryId={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />,
         { attachTo: document.body });
         const fluxNotesEditor = notesPanelWrapper.find(FluxNotesEditor);
@@ -962,6 +969,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenSourceNoteEntryId={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />,
         { attachTo: document.body });
         const fluxNotesEditor = notesPanelWrapper.find(FluxNotesEditor);
@@ -1041,6 +1049,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenClinicalNote={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />);
         const fluxNotesEditor = notesPanelWrapper.find(FluxNotesEditor);
         expect(fluxNotesEditor).to.have.lengthOf(1);
@@ -1108,6 +1117,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenClinicalNote={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />);
         const fluxNotesEditor = notesPanelWrapper.find(FluxNotesEditor);
         expect(fluxNotesEditor).to.have.lengthOf(1);
@@ -1180,6 +1190,7 @@ describe('6 FluxNotesEditor', function() {
             updateSelectedNote={jest.fn()}
             updateNoteAssistantMode={jest.fn()}
             updateContextTrayItemToInsert={jest.fn()}
+            searchSuggestions={[]}
         />);
         expect(wrapper).to.exist;
         // wrapper.find('.editor-content').simulate('click'); //goes into on change
@@ -1253,6 +1264,7 @@ describe('6 FluxNotesEditor', function() {
             setOpenClinicalNote={jest.fn()}
             summaryItemToInsert={''}
             updateErrors={jest.fn()}
+            searchSuggestions={[]}
         />);
 
         const clinicalNotesButton = notesPanelWrapper.find('#notes-btn');


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Jira 1517. Note icons in the note assistant now highlight right when the search results are rendered instead of when they are moused over. All mousing over does now is scroll the note icon into view if it is not in view already. Test by searching for content that will match the results on the right (e.g. the title of the note). 

For this PR I also simplified the passing of props from FullApp for highlighting. Instead of individual arrays for open notes, tdp, etc., there is only one array passed down and the filtering of the relevant results is done at the component level. It's probably worth it to test other highlighting functionality to make sure it works alongside the notes. This change makes the highlighting functionality way more extensible.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
