### PR TITLE
Fix stop medication bug

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -443,7 +443,7 @@ class FluxNotesEditor extends React.Component {
         if (text.length === 0) {
             const block = state.document.getPreviousSibling(anchorKey);
             if (block) {
-                text =  block.text;
+                text = block.text;
                 anchorOffset = text.length;
             }
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -443,7 +443,7 @@ class FluxNotesEditor extends React.Component {
         if (text.length === 0) {
             const block = state.document.getPreviousSibling(anchorKey);
             if (block) {
-                text = block.getFirstText().text;
+                text =  block.text;
                 anchorOffset = text.length;
             }
         }


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

For Jira 1539 and the first bullet point of #506. We were trying to get the text typed before the "@" when selecting an active medication and the call we were making always returned empty string. Changing it to use the .text property of the anchor block fixes the bug.

To replicate the bug on master:

* Open a new note
* Type "#stop medication"
* Type "@"
* Do not type any other text and hit enter
* Select a medication. The medication name will disappear and there will be a console error

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
