### PR TITLE
Store filter preference

### DIFF
--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -224,6 +224,7 @@ export default class TargetedDataSection extends Component {
     getFilterValue = (filter, subsectionName) => {
         const { section } = this.props;
         const subsectionFilters = this.props.preferenceManager.getPreference(`${this.props.section.name}-${subsectionName}-${filter.id}`);
+        if(Lang.isNull(subsectionFilters)) return true;
         return subsectionFilters;   
         
     }  

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -202,7 +202,7 @@ export default class TargetedDataSection extends Component {
     updateFilterValue = (filter, subsectionName) => {
         const { section } = this.props;
         const { filters } = this.state;
-
+    
         // Update subsection data to reflect changed filter value
         const currentSubsection = section.data.find(subsection => subsection.name === subsectionName);
         const currentSubsectionFilter = currentSubsection.filters.find(f => f.name === filter.name);
@@ -212,10 +212,22 @@ export default class TargetedDataSection extends Component {
         const selectedFilter = filters[`${this.props.section.name}-${subsectionName}`].find(f => f.name === filter.name);
         selectedFilter.value = !filter.value;
 
+        this.props.preferenceManager.setPreference(`${this.props.section.name}-${subsectionName}`, filters[`${this.props.section.name}-${subsectionName}`]);
         // Set state and re-index data to properly search currently visible data
         this.setState({ filters });
         this.indexSectionData(section);
     }
+ 
+    getFilterValue = (filter, subsectionName) => {
+        // Check preference manager for stored filter
+        const subsectionFilters = this.props.preferenceManager.getPreference(`${this.props.section.name}-${subsectionName}`);
+        if (subsectionFilters) {
+            const selectedFilter = subsectionFilters.find(f => f.name === filter.name);
+            return selectedFilter.value;
+        } else {
+            return filter.value;
+        }
+    } 
 
     renderFilters = () => {
         let totalNumFilters = 0;
@@ -243,7 +255,7 @@ export default class TargetedDataSection extends Component {
                             return (
                                 <MenuItem key={filter.name}>
                                     <Checkbox
-                                        checked={filter.value}
+                                        checked={this.getFilterValue(filter, subsection.name)}
                                         onChange={() => this.updateFilterValue(filter, subsection.name)}
                                         value={filter.name}
                                         className="checkbox"/>

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -208,11 +208,11 @@ export default class TargetedDataSection extends Component {
         // Get the current filter value 
         const currentVal = this.getFilterValue(filter, subsectionName);
         // Update the filter value in preference manager
-        this.props.preferenceManager.setPreference(`${this.props.section.name}-${subsectionName}-${filter.id}`,  !currentVal);
+        this.props.preferenceManager.setPreference(`${section.name}-${subsectionName}-${filter.id}`,  !currentVal);
       
 
         // Update state to also reflect changed filter value
-        const selectedFilter = filters[`${this.props.section.name}-${subsectionName}`].find(f => f.name === filter.name);
+        const selectedFilter = filters[`${section.name}-${subsectionName}`].find(f => f.name === filter.name);
         selectedFilter.value = !currentVal;
  
         // Set state and re-index data to properly search currently visible data
@@ -223,7 +223,7 @@ export default class TargetedDataSection extends Component {
  
     getFilterValue = (filter, subsectionName) => {
         const { section } = this.props;
-        const subsectionFilters = this.props.preferenceManager.getPreference(`${this.props.section.name}-${subsectionName}-${filter.id}`);
+        const subsectionFilters = this.props.preferenceManager.getPreference(`${section.name}-${subsectionName}-${filter.id}`);
         if(Lang.isNull(subsectionFilters)) return true;
         return subsectionFilters;   
         

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -202,32 +202,31 @@ export default class TargetedDataSection extends Component {
     updateFilterValue = (filter, subsectionName) => {
         const { section } = this.props;
         const { filters } = this.state;
-    
+      
         // Update subsection data to reflect changed filter value
-        const currentSubsection = section.data.find(subsection => subsection.name === subsectionName);
-        const currentSubsectionFilter = currentSubsection.filters.find(f => f.name === filter.name);
-        currentSubsectionFilter.value = !filter.value;
+ 
+        // Get the current filter value 
+        const currentVal = this.getFilterValue(filter, subsectionName);
+        // Update the filter value in preference manager
+        this.props.preferenceManager.setPreference(`${this.props.section.name}-${subsectionName}-${filter.id}`,  !currentVal);
+      
 
         // Update state to also reflect changed filter value
         const selectedFilter = filters[`${this.props.section.name}-${subsectionName}`].find(f => f.name === filter.name);
-        selectedFilter.value = !filter.value;
-
-        this.props.preferenceManager.setPreference(`${this.props.section.name}-${subsectionName}`, filters[`${this.props.section.name}-${subsectionName}`]);
+        selectedFilter.value = !currentVal;
+ 
         // Set state and re-index data to properly search currently visible data
         this.setState({ filters });
         this.indexSectionData(section);
+        
     }
  
     getFilterValue = (filter, subsectionName) => {
-        // Check preference manager for stored filter
-        const subsectionFilters = this.props.preferenceManager.getPreference(`${this.props.section.name}-${subsectionName}`);
-        if (subsectionFilters) {
-            const selectedFilter = subsectionFilters.find(f => f.name === filter.name);
-            return selectedFilter.value;
-        } else {
-            return filter.value;
-        }
-    } 
+        const { section } = this.props;
+        const subsectionFilters = this.props.preferenceManager.getPreference(`${this.props.section.name}-${subsectionName}-${filter.id}`);
+        return subsectionFilters;   
+        
+    }  
 
     renderFilters = () => {
         let totalNumFilters = 0;
@@ -296,7 +295,9 @@ export default class TargetedDataSection extends Component {
                 newSubsection = subsection;
                 typeToIndex = type;
                 if (Lang.isUndefined(items)) {
+                
                     list = itemsFunction(patient, condition, subsection);
+                   
                 } else {
                     list = items.map((item, i) => {
                         if (Lang.isNull(item.value)) {

--- a/src/summary/metadata/TimelineSection.jsx
+++ b/src/summary/metadata/TimelineSection.jsx
@@ -4,6 +4,9 @@ import moment from 'moment';
 
 export default class TimelineSection extends MetadataSection {
     getMetadata(preferencesManager, condition, roleType, role, specialty) {
+        const sectionName = 'Timeline';
+        const overTheCounter = 'OverTheCounterMedications';
+
         return {
             name: "Timeline",
             shortName: "Timeline",
@@ -12,8 +15,14 @@ export default class TimelineSection extends MetadataSection {
             data: [
                 {
                     name: "Medications",
+
                     filters: [
-                        { name: 'Over The Counter Medications', value: true }
+                        { name: 'Over The Counter Medications', 
+                            id: overTheCounter,
+                          value: (subsection) => {
+                            return preferencesManager.getPreference(`${sectionName}-${subsection.name}-${overTheCounter}`);
+                            } 
+                        }
                     ],
                     itemsFunction: this.getMedicationItems
                 },
@@ -34,6 +43,7 @@ export default class TimelineSection extends MetadataSection {
     }
 
     nextGroupNumber = 1;
+
 
     resetTimelineData = () => {
         this.nextGroupNumber = 1;
@@ -79,13 +89,13 @@ export default class TimelineSection extends MetadataSection {
     getMedicationItems = (patient, condition, subsection) => {
         if (Lang.isNull(patient) || Lang.isNull(condition)) return [];
         let meds = patient.getMedicationsForConditionReverseChronologicalOrder(condition);
-
         if (subsection.filters) {
             subsection.filters.forEach(filter => {
                 switch (filter.name) {
+                    
                     case 'Over The Counter Medications':
                     // If Show Over The Counter meds is not selected, need to filter them out.
-                    if (filter.value === false) {
+                    if (filter.value(subsection) === false) {
                             meds = meds.filter(med => {
                                 // Don't filter out medications if we don't know if they are OTC or not.
                                 if (med.overTheCounter === undefined) {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

JIRA 1525 

Timeline filter uses preference manager to store the filter preferences.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
