### PR TITLE
check if the section is ROS and if so do not display the condition

### DIFF
--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -446,7 +446,6 @@ export default class TargetedDataSection extends Component {
         const selectedCondition = condition && condition.type;
         const encounterView = clinicalEvent === "encounter";
         const notFiltered = !Lang.isUndefined(section.notFiltered) && section.notFiltered;
-        const ros = section.shortName === 'ROS';
 
         const viz = this.getAndIndexSectionData(section);
         
@@ -464,7 +463,7 @@ export default class TargetedDataSection extends Component {
             <div id="targeted-data-section">
                 <h2 className="section-header">
                     <span className={`section-header__name${highlightClass}`}>{section.name}</span><span>&nbsp;{this.state.sectionNameSuffix}</span>
-                    {!encounterView && !notFiltered && !ros && <span className="section-header__condition">{selectedCondition}</span>}
+                    {!encounterView && !notFiltered && <span className="section-header__condition">{selectedCondition}</span>}
                     {SHOW_FILTER_AS_MENU && this.renderFilters(patient, condition)}
                     {this.renderVisualizationOptions(visualizationOptions)}
                 </h2>

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -446,6 +446,7 @@ export default class TargetedDataSection extends Component {
         const selectedCondition = condition && condition.type;
         const encounterView = clinicalEvent === "encounter";
         const notFiltered = !Lang.isUndefined(section.notFiltered) && section.notFiltered;
+        const ros = section.shortName === 'ROS';
 
         const viz = this.getAndIndexSectionData(section);
         
@@ -463,7 +464,7 @@ export default class TargetedDataSection extends Component {
             <div id="targeted-data-section">
                 <h2 className="section-header">
                     <span className={`section-header__name${highlightClass}`}>{section.name}</span><span>&nbsp;{this.state.sectionNameSuffix}</span>
-                    {!encounterView && !notFiltered && <span className="section-header__condition">{selectedCondition}</span>}
+                    {!encounterView && !notFiltered && !ros && <span className="section-header__condition">{selectedCondition}</span>}
                     {SHOW_FILTER_AS_MENU && this.renderFilters(patient, condition)}
                     {this.renderVisualizationOptions(visualizationOptions)}
                 </h2>

--- a/src/summary/metadata/ReviewOfSystemsSection.jsx
+++ b/src/summary/metadata/ReviewOfSystemsSection.jsx
@@ -7,6 +7,7 @@ export default class ReviewOfSystemsSection extends MetadataSection {
             shortName: "ROS",
             type: "NameValuePairsOnly",
             isWide: false,
+            notFiltered: true,
             data: [
                 {
                     name: "",                   


### PR DESCRIPTION
Added a check if the section is ROS and if it is hide the condition. Condition should still be displayed for other sections.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
