### PR TITLE
Quick fix to date of visit

### DIFF
--- a/src/dataaccess/HardCodedSarcomaPatient.json
+++ b/src/dataaccess/HardCodedSarcomaPatient.json
@@ -1396,7 +1396,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/Reason"
                     },
-                    "Value": "Mr. Tnfinity6 requested a follow up due to significant diarrhea and fatigue, despite anti-diarrheal treatment, that makes it hard for him to do daily activities."
+                    "Value": "Mr. Tnfinity6 requested a follow up due to significant diarrhea and fatigue, despite anti-diarrheal treatment, that makes it hard for him to do daily activities"
                 }
             ],
             "Status": {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -311,7 +311,7 @@ class PatientRecord {
         const today = new moment().format("D MMM YYYY"); 
         // Try to find an encounter with a performance time of today
         return _.find(encounters, (encounter) => { 
-            return new moment(encounter.expectedPerformanceTime, "D MMM YYYY") === today;
+            return new moment(encounter.expectedPerformanceTime, "D MMM YYYY").format("D MMM YYYY") === today;
         }) !== undefined
     }
 


### PR DESCRIPTION
Checking for today's date was not working because the date formats were inconsistent. Fixed this and also removed period from visit reason because the periods are added in the note templates


_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._


## Submitter:

**Running the Application**

- [ ] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [ ] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
