### PR TITLE
Change landing page link to pilot1

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -92,7 +92,7 @@ export default class LandingPage extends Component {
                 <div className="landing-products">
                     <div className="landing-products-full">
                         <Paper className="landing-products-interaction">
-                            <a href="/demo2" id="link-to-full">
+                            <a href="/pilot1" id="link-to-full">
                                 <div className="landing-products-image">
                                     <img src="./landing/fluxnotes_gif_fullSize.gif" alt="Flux Notes Full" />
                                 </div>

--- a/test/backend/views/Landing.test.js
+++ b/test/backend/views/Landing.test.js
@@ -11,7 +11,7 @@ describe('Landing', function() {
     it('Can navigate to pages', () => {
         const wrapper = shallow(<LandingPage/>);
         const fullAppDiv = wrapper.find('#link-to-full');
-        expect(fullAppDiv.prop('href')).to.equal('/demo2')
+        expect(fullAppDiv.prop('href')).to.equal('/pilot1')
         const patinaDiv = wrapper.find('#link-to-patina');
         expect(patinaDiv.prop('href')).to.equal('/patina');
     });


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Edited landing page test because link now leads to pilot1 instead of demo2
## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
