### PR TITLE
Added shortcutData to fix insertion of structured data from TDP.

### DIFF
--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -325,9 +325,9 @@ export class FullApp extends Component {
                 }
             } else if (item.shortcutData) {
                 if (item.shortcutData.entryId) {
-                    newStateValues = { summaryItemToInsert: `${item.shortcutData.shortcut}[[{"text":"${item.value}", "entryId":${item.shortcutData.entryId}}]]` };
+                    newStateValues = { summaryItemToInsert: `${item.shortcutData.shortcut}[[{"text":"${item.value}", "entryId":"${item.shortcutData.entryId}"}]]` };
                 } else {
-                    newStateValues = newStateValues = { summaryItemToInsert: `${item.shortcutData.shortcut}[[${item.value}]]` };
+                    newStateValues = { summaryItemToInsert: `${item.shortcutData.shortcut}[[${item.value}]]` };
                 }
             } else if (item.value) {
                 newStateValues = { summaryItemToInsert: item.value };

--- a/src/containers/FullApp.jsx
+++ b/src/containers/FullApp.jsx
@@ -323,8 +323,12 @@ export class FullApp extends Component {
                 } else {
                     newStateValues = { summaryItemToInsert: item[arrayIndex] };
                 }
-            } else if (item.shortcut) {
-                newStateValues = { summaryItemToInsert: `${item.shortcut}[[${item.value}]]` };
+            } else if (item.shortcutData) {
+                if (item.shortcutData.entryId) {
+                    newStateValues = { summaryItemToInsert: `${item.shortcutData.shortcut}[[{"text":"${item.value}", "entryId":${item.shortcutData.entryId}}]]` };
+                } else {
+                    newStateValues = newStateValues = { summaryItemToInsert: `${item.shortcutData.shortcut}[[${item.value}]]` };
+                }
             } else if (item.value) {
                 newStateValues = { summaryItemToInsert: item.value };
             } else {

--- a/src/summary/NarrativeNameValuePairsVisualizer.jsx
+++ b/src/summary/NarrativeNameValuePairsVisualizer.jsx
@@ -209,11 +209,11 @@ class NarrativeNameValuePairsVisualizer extends Component {
 
         // convert snippet to format action is expecting
         const transformedSnippet = {
-            shortcut: snippet.shortcut,
             value: [
                 snippet.value,
                 snippet.unsigned,
-                snippet.source
+                snippet.source,
+                snippet.shortcutData
             ],
         };
 

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -388,7 +388,7 @@ export default class TargetedDataSection extends Component {
                         } else {
                             let val = item.value(patient, condition, loginUser);
                             if (val) {
-                                return {name: item.name, value: val.value, shortcut: item.shortcut, unsigned: val.isUnsigned, source: val.source, when: val.when};
+                                return {name: item.name, value: val.value, shortcutData: val.shortcutData, unsigned: val.isUnsigned, source: val.source, when: val.when};
                             } else {
                                 return {name: item.name, value: null};
                             }

--- a/src/summary/VisualizerMenu.jsx
+++ b/src/summary/VisualizerMenu.jsx
@@ -25,7 +25,7 @@ export default class VisualizerMenu extends Component {
             return {    value: a.value[0],
                         isUnsigned: a.value[1],
                         source: a.value[2],
-                        shortcut: a.shortcut };
+                        shortcutData: a.value[3] };
         } else if(Lang.isObject(a.value)) {
             return a.value;
         } else {

--- a/src/summary/metadata/ActiveConditionsSection.jsx
+++ b/src/summary/metadata/ActiveConditionsSection.jsx
@@ -12,7 +12,6 @@ export default class ActiveConditionsSection extends MetadataSection {
                     name: "",
                     headings: ["Condition", "Diagnosed", "Body Site"],
                     itemsFunction: this.getItemListForConditions,
-                    shortcut: "@condition"
                 }
             ]
         };
@@ -25,7 +24,10 @@ export default class ActiveConditionsSection extends MetadataSection {
                 {    value: c.type, 
                      isUnsigned: patient.isUnsigned(c),
                      source: this.determineSource(patient, c),
-                     shortcut: subsection.shortcut
+                     shortcutData: {
+                        shortcut: '@condition',
+                        entryId: c.entryInfo.entryId,
+                    }
                 }, 
                 {   value: c.diagnosisDate
                 },

--- a/src/summary/metadata/BreastCancerMetadata.jsx
+++ b/src/summary/metadata/BreastCancerMetadata.jsx
@@ -111,7 +111,10 @@ export default class BreastCancerMetadata extends MetadataSection {
                                         return {    value: currentConditionEntry.type, 
                                                     isUnsigned: patient.isUnsigned(currentConditionEntry), 
                                                     source: this.determineSource(patient, currentConditionEntry),
-                                                    shortcut: "@condition"
+                                                    shortcutData: {
+                                                        shortcut: '@condition',
+                                                        entryId: currentConditionEntry.entryInfo.entryId,
+                                                    }
                                         };
                                     },
                                 },

--- a/src/summary/metadata/DefaultCoreCancerPilotMetadata.jsx
+++ b/src/summary/metadata/DefaultCoreCancerPilotMetadata.jsx
@@ -23,10 +23,13 @@ export default class DefaultCoreCancerPilotMetadata extends MetadataSection {
                                     value: (patient, currentConditionEntry) => {
                                         return  {   value: currentConditionEntry.type, 
                                                     isUnsigned: patient.isUnsigned(currentConditionEntry), 
-                                                    source: this.determineSource(patient, currentConditionEntry)
+                                                    source: this.determineSource(patient, currentConditionEntry),
+                                                    shortcutData: {
+                                                        shortcut: '@condition',
+                                                        entryId: currentConditionEntry.entryInfo.entryId,
+                                                    }
                                                 };
                                     },
-                                    shortcut: "@condition"
                                 },
                                 {
                                     name: "Diagnosis Date",

--- a/src/summary/metadata/DefaultMetadata.jsx
+++ b/src/summary/metadata/DefaultMetadata.jsx
@@ -29,10 +29,13 @@ export default class DefaultMetadata extends MetadataSection {
                                     value: (patient, currentConditionEntry) => {
                                         return  {   value: currentConditionEntry.type, 
                                                     isUnsigned: patient.isUnsigned(currentConditionEntry), 
-                                                    source: this.determineSource(patient, currentConditionEntry)
+                                                    source: this.determineSource(patient, currentConditionEntry),
+                                                    shortcutData: {
+                                                        shortcut: '@condition',
+                                                        entryId: currentConditionEntry.entryInfo.entryId,
+                                                    }
                                                 };
                                     },
-                                    shortcut: "@condition"
                                 },
                                 {
                                     name: "Diagnosis Date",

--- a/src/summary/metadata/ProceduresSection.jsx
+++ b/src/summary/metadata/ProceduresSection.jsx
@@ -25,7 +25,10 @@ export default class ProceduresSection extends MetadataSection {
                 {   value: p.name, 
                     isUnsigned: patient.isUnsigned(p),
                     source:  this.determineSource(patient, p),
-                    shortcut: "@procedure"
+                    shortcutData: {
+                        shortcut: '@procedure',
+                        entryId: p.entryInfo.entryId,
+                    }
                 }];
             if (typeof p.occurrenceTime !== 'string') {
                 result.push(

--- a/src/summary/metadata/SarcomaSummarySection.jsx
+++ b/src/summary/metadata/SarcomaSummarySection.jsx
@@ -126,7 +126,10 @@ export default class SarcomaSummarySection extends MetadataSection {
                                 return  {   value: currentConditionEntry.type, 
                                             isUnsigned: patient.isUnsigned(currentConditionEntry), 
                                             source: this.determineSource(patient, currentConditionEntry),
-                                            shortcut: "@condition"
+                                            shortcutData: {
+                                                shortcut: '@condition',
+                                                entryId: currentConditionEntry.entryInfo.entryId,
+                                            }
                                         };
                             },
                         },

--- a/src/summary/metadata/VisitReasonPreEncounterSection.jsx
+++ b/src/summary/metadata/VisitReasonPreEncounterSection.jsx
@@ -26,14 +26,24 @@ export default class VisitReasonPreEncounterSection extends MetadataSection {
                             name: "Reason",
                             value: (patient, currentConditionEntry) => {
                                 const nextEncounter = patient.getNextEncounter();
-                                if (Lang.isUndefined(nextEncounter)) return { value: "No upcoming appointments", isUnsigned: false };
+                                if (Lang.isUndefined(nextEncounter)) {
+                                    return {
+                                        value: "No upcoming appointments",
+                                        isUnsigned: false,
+                                        shortcutData: {
+                                            shortcut: '@reason for next visit',
+                                        }
+                                    };
+                                }
                                 return {
                                         value: patient.getNextEncounterReasonAsText(), 
                                         isUnsigned: patient.isUnsigned(nextEncounter), 
-                                        source: this.determineSource(patient, nextEncounter)
+                                        source: this.determineSource(patient, nextEncounter),
+                                        shortcutData: {
+                                            shortcut: '@reason for next visit',
+                                        }
                                 };
                             },
-                            shortcut: "@reason for next visit"
                         }
                     ]
                 }


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Since we added additional metadata to insertion shortcuts to get the value object from the patient record, insertion of structured data from Targeted Data Panel no longer works.  The entryId is now included with the shortcut data so that we can retrieve the value object when the shortcut is created.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
