### PR TITLE
Open source note functionality for medication changes

### DIFF
--- a/src/model/medication/FluxMedicationChange.js
+++ b/src/model/medication/FluxMedicationChange.js
@@ -1,3 +1,4 @@
+import FluxEntry from '../base/FluxEntry';
 import MedicationChange from '../shr/medication/MedicationChange';
 import FluxMedicationBeforeChange from './FluxMedicationBeforeChange';
 import FluxMedicationAfterChange from './FluxMedicationAfterChange';
@@ -8,9 +9,10 @@ import codeableConceptUtils from '../CodeableConceptUtils.jsx';
 import Lang from 'lodash';
 import moment from 'moment';
 
-class FluxMedicationChange {
+class FluxMedicationChange extends FluxEntry {
     constructor(json, patientRecord) {
-        this._medicationChange = MedicationChange.fromJSON(json);
+        super(json);
+        this._entry = this._medicationChange = MedicationChange.fromJSON(json);
         this._patientRecord = patientRecord;
         if (!this._medicationChange.entryInfo) {
             let entry = new Entry();

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -140,7 +140,7 @@ class PatientRecord {
         this.entries.push(entry);
     }
 
-    addEntryToPatient(entry, clinicalNote) {       
+    addEntryToPatient(entry, clinicalNote) {
         entry.entryInfo.shrId = this.shrId;
         entry.entryInfo.entryId = this.nextEntryId;
         this.nextEntryId = this.nextEntryId + 1;

--- a/src/summary/MedicationRangeChartVisualizer.jsx
+++ b/src/summary/MedicationRangeChartVisualizer.jsx
@@ -121,7 +121,7 @@ class MedicationRangeChartVisualizer extends Component {
         } else {
             medChangeClassName = 'medication-change';
         }
-        const medChangeTypeSigned = medChange.unsigned ? 'medication-change-type-unsigned' : 'medication-change-type';
+        const medChangeTypeSigned = medChange.isUnsigned ? 'medication-change-type-unsigned' : 'medication-change-type';
 
         if (medChange.type === 'stop') {
             return (

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -64,21 +64,18 @@ class VisualizerManager {
     }
 
     transformMedicationsToColumns = (patient, condition, subsection, getFilterValue) => {
-        let newsection = {};
-
+        const newsection = {};
         const itemList = subsection.itemsFunction(patient, condition, subsection, getFilterValue);
 
         newsection.name = "";
         newsection.headings = ["Medication", "Change", "Dosage", "Timing", "Start", "End"];
-        newsection.data_cache = itemList.map((med) => {
-            
-            
+        newsection.data_cache = itemList.map(med => {
             const dose = med.medication.amountPerDose ? `${med.medication.amountPerDose.value} ${med.medication.amountPerDose.units}` : "";
             const medicationChange = this.formatMedicationChange(med.medicationChange);
             const endDate = this.getEndDate(med);
-            const {doseInstructionsText} = med.medication;
+            const { doseInstructionsText } = med.medication;
             let timing;
-            
+
             if (med.medication.timingOfDoses) {
                 if (!Lang.isNull(med.medication.timingOfDoses.units)) {
                     timing = `${med.medication.timingOfDoses.value} ${med.medication.timingOfDoses.units}`;
@@ -88,29 +85,44 @@ class VisualizerManager {
             } else {
                 timing = "";
             }
-            
+
             // isUnsigned is false by default
             let isUnsigned = false;
-            let sourceClinicalNote;
-            
+            let source;
             if (med.medicationChange) {
-                isUnsigned = med.medicationChange.unsigned;
-                sourceClinicalNote = med.medicationChange.sourceClinicalNote;
+                isUnsigned = med.medicationChange.isUnsigned;
+                source = med.medicationChange.source;
             }
-
             const asNeeded = med.medication.asNeededIndicator ? ' as needed' : '';
 
-            return [    {   value: med.medication.medication },
-                        {   value: medicationChange, 
-                            unsigned: isUnsigned, 
-                            source: sourceClinicalNote },
-                        {   value: dose },
-                        {   value: timing || doseInstructionsText + asNeeded },
-                        {   value: med.medication.expectedPerformanceTime.timePeriodStart },
-                        {   value: endDate, 
-                            unsigned: isUnsigned, 
-                            source: sourceClinicalNote }
-                    ];
+            return [
+                { 
+                    value: med.medication.medication,
+                },
+                {
+                    value: {
+                        isUnsigned,
+                        source,
+                        value: medicationChange,
+                    }
+                },
+                { 
+                    value: dose,
+                },
+                { 
+                    value: timing || doseInstructionsText + asNeeded,
+                },
+                { 
+                    value: med.medication.expectedPerformanceTime.timePeriodStart,
+                },
+                {
+                    value: {
+                        isUnsigned,
+                        source,
+                        value: endDate,
+                    },
+                },
+            ];
         });
 
         // Format function used to 


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

-  Open source note now works for `#reduce medication` and `#stop medication`.
-  `FluxMedicationChange` now extends `FluxEntry`.
-  MedicationChanges now have dotted underline if the note is unsigned.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
-  Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
-  Recognizes any potential shortcomings/bugs in the description 
-  Cheat sheet is updated
-  Demo script is updated 
-  Documentation on Wiki has been updated 
-  Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

-  Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added Enzyme-UI tests for slim mode 
-  Added Enzyme-UI tests for full mode
-  Added backend tests for new functionality added
-  Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
