### PR TITLE
change height of all line graph visualizers (labs, vitals, disease st…

### DIFF
--- a/src/summary/BandedLineChartVisualizer.jsx
+++ b/src/summary/BandedLineChartVisualizer.jsx
@@ -19,7 +19,7 @@ class BandedLineChartVisualizer extends Component {
         // This var will be used 
         this.state = {
             chartWidth: 600,
-            chartHeight: 400,
+            chartHeight: 250,
         }
     }
 

--- a/src/summary/ProgressionLineChartVisualizer.jsx
+++ b/src/summary/ProgressionLineChartVisualizer.jsx
@@ -23,7 +23,7 @@ class ProgressionLineChartVisualizer extends Component {
         super(props);
 
         // This var will be used
-        this.chartHeight = 400;
+        this.chartHeight = 250;
         this.xVarField = "start_time";
         this.xVarNumberField = `${this.xVarField}_number`;
         this.yVarField = "disease_status_code";


### PR DESCRIPTION
Changed the height of all line graphs from 400px to 250px.  This currently allows the user to view all four vitals graphs or all four lab graphs without scrolling.  Also changed the disease status graph height to match the labs and vitals, although if this seems too small we can find a happy medium height for that graph.


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [ ] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [ ] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [ ] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
