### PR TITLE
added a new pathology section to summary metadata

### DIFF
--- a/src/summary/metadata/PathologySection.jsx
+++ b/src/summary/metadata/PathologySection.jsx
@@ -1,0 +1,103 @@
+import MetadataSection from "./MetadataSection";
+import FluxTumorDimensions from '../../model/oncology/FluxTumorDimensions';
+import FluxTumorMargins from '../../model/oncology/FluxTumorMargins';
+
+export default class PathologySection extends MetadataSection {
+    getMetadata(preferencesManager, patient, condition, roleType, role, specialty) {
+        return {
+            name: "Pathology",
+            shortName: "Pathology",
+            type: "NameValuePairs",
+            /*eslint no-template-curly-in-string: "off"*/
+            narrative: [
+                {
+                    defaultTemplate: "Date of pathology report is ${.Report Date}. Pathologist is ${.Pathologist}."
+                },
+                {
+                    defaultTemplate: "Primary tumor color is ${.Color}, weight is ${.Weight}, and size is ${.Size}."
+                },
+                {
+                    defaultTemplate: "Tumor margins are ${.Tumor Margins}. Histological grade is ${.Histological Grade}."
+                }
+
+            ],
+            data: [
+                {
+                    name: "",
+                    items: [
+
+                        // TODO: When return value for items that are currently null, need to also return patient.isUnsigned(currentConditionEntry)
+                        {
+                            name: "Report Date",
+                            value: (patient, currentConditionEntry) => {
+                                const list = patient.getPathologyReportsChronologicalOrder();
+                                if (list.length === 0) return null;
+                                const report = list.pop();
+                           
+                                return  {  value: report.clinicallyRelevantTime,
+                                           isUnsigned: patient.isUnsigned(report), 
+                                           source: this.determineSource(patient, report)
+                                }
+                            }
+                        },
+                        {
+                            name: "Pathologist",
+                            value: (patient, currentConditionEntry) => {
+                                const list = patient.getPathologyReportsChronologicalOrder();
+                                if (list.length === 0) return null;
+                                const report = list.pop();
+                               
+                                return  {  value: report.author,
+                                           isUnsigned: patient.isUnsigned(report), 
+                                           source: this.determineSource(patient, report)
+                                }
+                            }
+                        },
+                        {
+                            name: "Color",
+                            value: null
+                        },
+                        {
+                            name: "Weight",
+                            value: null
+                        },
+                        {
+                            name: "Size",
+                            value: (patient, currentConditionEntry) => {
+                                const list = currentConditionEntry.getObservationsOfTypeChronologicalOrder(FluxTumorDimensions);
+                                if (list.length === 0) return null;
+                                const size = list.pop(); // last is most recent
+                                return  {   value: size.quantity.value + " " + size.quantity.unit,
+                                            isUnsigned: patient.isUnsigned(size),
+                                            source: this.determineSource(patient, size)
+                                        };
+                            }
+                        },
+                        {
+                            name: "Tumor Margins",
+                            value: (patient, currentConditionEntry) => {
+                                const list = currentConditionEntry.getObservationsOfTypeChronologicalOrder(FluxTumorMargins);
+                                if (list.length === 0) return null;
+                                const margins = list.pop(); // last is most recent
+                                return  {   value: margins.value,
+                                            isUnsigned: patient.isUnsigned(margins),
+                                            source: this.determineSource(patient, margins)
+                                        };
+                            }
+                        },
+                        {
+                            name: "Histological Grade",
+                            value: (patient, currentConditionEntry) => {
+                                let histologicalGrade = currentConditionEntry.getMostRecentHistologicalGrade();
+                                return  {   value: histologicalGrade.grade,
+                                            isUnsigned: patient.isUnsigned(histologicalGrade),
+                                            source: this.determineSource(patient, histologicalGrade)
+                                        };
+                            }
+                        },
+                    ]
+                }
+            ]
+        };
+    }
+}

--- a/src/summary/metadata/SarcomaMetadata.jsx
+++ b/src/summary/metadata/SarcomaMetadata.jsx
@@ -5,6 +5,7 @@ import DiseaseStatusSection from './DiseaseStatusSection';
 import HemoglobinSubsection from './HemoglobinSubsection';
 import MedicationsSection from './MedicationsSection';
 import NeutrophilCountSubsection from './NeutrophilCountSubsection';
+import PathologySection from './PathologySection';
 import PlateletSubsection from "./PlateletSubsection";
 import ProceduresSection from './ProceduresSection';
 import ReviewOfSystemsSection from './ReviewOfSystemsSection';
@@ -19,7 +20,6 @@ import BloodPressureSubsection from './BloodPressureSubsection';
 import TemperatureSubsection from './TemperatureSubsection';
 import WeightSubsection from './WeightSubsection';
 import HeartRateSubsection from './HeartRateSubsection';
-import PatientRecord from '../../patient/PatientRecord';
 
 
 
@@ -59,121 +59,7 @@ export default class SarcomaMetadata extends MetadataSection {
                     ]
                 },
                 MedicationsSection,
-                {
-                    name: "Pathology",
-                    shortName: "Pathology",
-                    type: "NameValuePairs",
-                    /*eslint no-template-curly-in-string: "off"*/
-                    narrative: [
-                        {
-                            defaultTemplate: "Date of pathology report is ${.Report Date}. Pathologist is ${.Pathologist}."
-                        },
-                        {
-                            defaultTemplate: "Primary tumor color is ${.Color}, weight is ${.Weight}, and size is ${.Size}."
-                        },
-                        {
-                            defaultTemplate: "Tumor margins are ${.Tumor Margins}. Histological grade is ${.Histological Grade}."
-                        }
-
-                    ],
-                    data: [
-                        {
-                            name: "",
-                            items: [
-
-                                // TODO: When return value for items that are currently null, need to also return patient.isUnsigned(currentConditionEntry)
-                                {
-                                    name: "Report Date",
-                                    value: (patient, currentConditionEntry) => {
-                                        const list = patient.getPathologyReportsChronologicalOrder();
-                                        if (list.length === 0) return null;
-                                        const report = list.pop();
-                                   
-                                        return  {  value: report.clinicallyRelevantTime,
-                                                   isUnsigned: patient.isUnsigned(report), 
-                                                   source: this.determineSource(patient, report)
-                                        }
-                                    }
-                                },
-                                {
-                                    name: "Pathologist",
-                                    value: (patient, currentConditionEntry) => {
-                                        const list = patient.getPathologyReportsChronologicalOrder();
-                                        if (list.length === 0) return null;
-                                        const report = list.pop();
-                                       
-                                        return  {  value: report.author,
-                                                   isUnsigned: patient.isUnsigned(report), 
-                                                   source: this.determineSource(patient, report)
-                                        }
-                                    }
-                                },
-                                {
-                                    name: "Color",
-                                    value: null
-                                },
-                                {
-                                    name: "Weight",
-                                    value: null
-                                },
-                                {
-                                    name: "Size",
-                                    value: (patient, currentConditionEntry) => { 
-                                        const lists = patient.getPathologyReportsChronologicalOrder();
-                                        if (lists.length === 0) return null;
-                                        const report = lists.pop();
-                                        const observation =  report.members.filter((m) => {
-                                            return PatientRecord.isEntryBasedOnType(m, "TumorDimensions")
-                                        }).map((ref) => {
-                                            return patient.getEntryFromReference(ref);
-                                        });  
-                                        const size = observation.pop();
-                                        return  {   value: size.quantity.value + " " + size.quantity.unit, 
-                                                    isUnsigned: patient.isUnsigned(report), 
-                                                    source: this.determineSource(patient, report)
-                                                };
-                                    }
-                                },
-                                {
-                                    name: "Tumor Margins",
-                                    value: (patient, currentConditionEntry) => {                                       
-                                        const lists = patient.getPathologyReportsChronologicalOrder();
-                                        if (lists.length === 0) return null;
-                                        const report = lists.pop();
-                                        const observation =  report.members.filter((m) => {
-                                            return PatientRecord.isEntryBasedOnType(m, "TumorMargins")
-                                        }).map((ref) => {
-                                            return patient.getEntryFromReference(ref);
-                                        }) 
-                                        const margins = observation.pop(); // last is most recent
-                                        return  {   value: margins.value, 
-                                                    isUnsigned: patient.isUnsigned(report), 
-                                                    source: this.determineSource(patient, report)
-                                                };
-                                    }
-                                },
-                                {
-                                    name: "Histological Grade",
-                                    value: (patient, currentConditionEntry) => {
-                                        const lists = patient.getPathologyReportsChronologicalOrder();
-                                        if (lists.length === 0) return null;
-                                        const report = lists.pop();
-                                        const observation =  report.members.filter((m) => {
-                                            return PatientRecord.isEntryBasedOnType(m, "HistologicGrade")
-                                        }).map((ref) => {
-                                            return patient.getEntryFromReference(ref);
-                                        });  
-                                        const histologicalGrade = observation.pop();
-                                        return  {   value: histologicalGrade.grade, 
-                                                    isUnsigned: patient.isUnsigned(report), 
-                                                    source: this.determineSource(patient, report)
-                                                };
-                                    }
-                                },
-                            ]
-                        }
-                    ]
-                },
+                PathologySection,
                 {
                     name: "Genetics",
                     shortName: "Genetics",

--- a/src/summary/metadata/SarcomaNursePractitionerMetadata.jsx
+++ b/src/summary/metadata/SarcomaNursePractitionerMetadata.jsx
@@ -4,6 +4,7 @@ import AllergiesSection from './AllergiesSection';
 import HemoglobinSubsection from './HemoglobinSubsection';
 import MedicationsSection from './MedicationsSection';
 import NeutrophilCountSubsection from './NeutrophilCountSubsection';
+import PathologySection from './PathologySection';
 import PlateletSubsection from './PlateletSubsection';
 import ProceduresSection from './ProceduresSection';
 import ImagingSection from "./ImagingSection";
@@ -14,8 +15,6 @@ import VisitReasonPreEncounterSection from './VisitReasonPreEncounterSection';
 import WhiteBloodCellCountSubsection from './WhiteBloodCellCountSubsection';
 import DiseaseStatusSection from './DiseaseStatusSection';
 import TreatmentOptionsSection from './TreatmentOptionsSection';
-import FluxTumorDimensions from '../../model/oncology/FluxTumorDimensions';
-import FluxTumorMargins from '../../model/oncology/FluxTumorMargins';
 import BloodPressureSubsection from './BloodPressureSubsection';
 import TemperatureSubsection from './TemperatureSubsection';
 import WeightSubsection from './WeightSubsection';
@@ -60,72 +59,7 @@ export default class SarcomaNursePractitionerMetadata extends MetadataSection {
                         PlateletSubsection
                     ]
                 },
-                {
-                    name: "Pathology",
-                    shortName: "Pathology",
-                    type: "NameValuePairs",
-                    /*eslint no-template-curly-in-string: "off"*/
-                    narrative: [
-                        {
-                            defaultTemplate: "Primary tumor color is ${.Color}, weight is ${.Weight}, and size is ${.Size}."
-                        },
-                        {
-                            defaultTemplate: "Tumor margins are ${.Tumor Margins}. Histological grade is ${.Histological Grade}."
-                        }
-
-                    ],
-                    data: [
-                        {
-                            name: "",
-                            items: [
-
-                                // TODO: When return value for items that are currently null, need to also return patient.isUnsigned(currentConditionEntry)
-                                {
-                                    name: "Color",
-                                    value: null
-                                },
-                                {
-                                    name: "Weight",
-                                    value: null
-                                },
-                                {
-                                    name: "Size",
-                                    value: (patient, currentConditionEntry) => {
-                                        const list = currentConditionEntry.getObservationsOfTypeChronologicalOrder(FluxTumorDimensions);
-                                        if (list.length === 0) return null;
-                                        const size = list.pop(); // last is most recent
-                                        return  {   value: size.quantity.value + " " + size.quantity.unit,
-                                                    isUnsigned: patient.isUnsigned(size),
-                                                    source: this.determineSource(patient, size)
-                                                };
-                                    }
-                                },
-                                {
-                                    name: "Tumor Margins",
-                                    value: (patient, currentConditionEntry) => {
-                                        const list = currentConditionEntry.getObservationsOfTypeChronologicalOrder(FluxTumorMargins);
-                                        if (list.length === 0) return null;
-                                        const margins = list.pop(); // last is most recent
-                                        return  {   value: margins.value,
-                                                    isUnsigned: patient.isUnsigned(margins),
-                                                    source: this.determineSource(patient, margins)
-                                                };
-                                    }
-                                },
-                                {
-                                    name: "Histological Grade",
-                                    value: (patient, currentConditionEntry) => {
-                                        let histologicalGrade = currentConditionEntry.getMostRecentHistologicalGrade();
-                                        return  {   value: histologicalGrade.grade,
-                                                    isUnsigned: patient.isUnsigned(histologicalGrade),
-                                                    source: this.determineSource(patient, histologicalGrade)
-                                                };
-                                    }
-                                },
-                            ]
-                        }
-                    ]
-                },
+                PathologySection,
                 {
                     name: "Genetics",
                     shortName: "Genetics",


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:._

Added a new section called pathologysection in the summary metadata. Updated both the sarcoma summary and sarcoma nurse practitioner summary to use the new section.  

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome
- [x] Manually tested in IE

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Cheat sheet is updated
- [ ] Demo script is updated 
- [ ] Documentation on Wiki has been updated 
- [ ] Additional technical components and libraries are documented and added to wiki as needed

**NoteParser**

- [ ] Note parser has been updated if structured phrases change

**Code Quality**

- [x] 4-space indents - convert any tabs to spaces
- [x] Use public class field syntax for binding functions - ex. handleChange = () => { ... };
- [x] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added Enzyme-UI tests for slim mode 
- [ ] Added Enzyme-UI tests for full mode
- [ ] Added backend tests for new functionality added
- [ ] Added note parser examples to test new functionality


## Reviewer 1: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code


## Reviewer 2: Name

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
