### PR TITLE
Re-added bolded structured field for templates that was lost

### DIFF
--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -119,8 +119,8 @@
 
 // ******** StructuredFieldPlugin.jsx uses this
 .structured-field {
-    // Highlighted during template hovering
-    &-highlighted {
+    // Bolded during template hovering
+    &-bolded {
         font-weight: bold;
     }
 

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -64,6 +64,14 @@ function StructuredFieldPlugin(opts) {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
             },
+            bolded_structured_field: props => {
+                let shortcut = props.node.get('data').get('shortcut');
+                if (shortcut instanceof InsertValue) {
+                    return <span contentEditable={false} className='structured-field-inserter structured-field-bolded' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                } else {
+                    return <span contentEditable={false} className='structured-field-creator structured-field-bolded' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                }
+            },
             structured_field_selected_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {

--- a/src/panels/PickListOptionsPanel.jsx
+++ b/src/panels/PickListOptionsPanel.jsx
@@ -142,7 +142,7 @@ export default class PickListOptionsPanel extends Component {
                 shortcutName = shortcutName.charAt(0).toUpperCase() + shortcutName.slice(1);
                 return (
                     <div id={i} key={i}className="shortcut-options-container"
-                        onMouseEnter={(e) => this.changeShortcutType(shortcut.shortcut, 'highlighted_structured_field', e)}
+                        onMouseEnter={(e) => this.changeShortcutType(shortcut.shortcut, 'bolded_structured_field', e)}
                         onMouseLeave={(e) => this.changeShortcutType(shortcut.shortcut, 'structured_field', e)}>
                         {shortcutName}
                         {this.renderShortcutOptions(shortcut, i)}


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

There's a bug on fluxnotes.org right now because we lost the bolding of shortcuts that happens on hover during template insertion:

![screen shot 2018-12-06 at 10 35 33 am](https://user-images.githubusercontent.com/16297930/49593936-c7338400-f942-11e8-8597-2b7ae1fa751f.png)

"@ condition" disappears when hovering over a pick list option.

This PR re-adds a bolded structured field that we lost when implementing the different highlighted colors of search results in an open note

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
