### PR TITLE
User type within inserter text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yarn-error.log*
 /src/forms/SingleChoiceButton.css
 /src/forms/MultiChoiceButton.css
 /src/mcode-pilot/**/*.css
+/src/forms/TemplateForm.css
 /src/notes/FluxNotesEditor.css
 /src/notes/NoteAssistant.css
 /src/notes/fillFieldComponents/MenuItemSetFillForPlaceholder.css

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "flux_notes_treatment_options_rest_client": "^1.1.2",
     "font-awesome": "4.7.0",
     "fuse.js": "^3.3.0",
-    "guid": "0.0.12",
     "highcharts": "^6.2.0",
     "history": "^4.7.2",
     "immutable": "3.8.1",
@@ -55,7 +54,8 @@
     "shr_rest_client": "^0.0.6",
     "slate": "0.20.2",
     "slate-auto-replace": "0.5.0",
-    "sync-request": "^4.1.0"
+    "sync-request": "^4.1.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/forms/TemplateForm.css
+++ b/src/forms/TemplateForm.css
@@ -1,5 +1,5 @@
 .template {
-  margin: 5px 0 5px 26px;
+  margin: 5px 0 5px 0px;
   font-size: 0.9em;
   color: #888;
   cursor: pointer;

--- a/src/forms/TemplateForm.scss
+++ b/src/forms/TemplateForm.scss
@@ -3,9 +3,9 @@
   font-size: 0.9em;
   color: #888;
   cursor: pointer;
-}
-
-.template:hover {
-  color: #555;
-  font-weight: bold;
+  
+  &:hover {
+    color: #555;
+    font-weight: bold;
+  }
 }

--- a/src/lib/slate/index.js
+++ b/src/lib/slate/index.js
@@ -43,6 +43,7 @@ import Transforms from './transforms'
 
 import findDOMNode from './utils/find-dom-node'
 import { resetKeyGenerator, setKeyGenerator } from './utils/generate-key'
+import { IS_CHROME, IS_FIREFOX, IS_IE, IS_SAFARI } from './constants/environment';
 
 /**
  * Export.
@@ -71,7 +72,11 @@ export {
   Transforms,
   findDOMNode,
   resetKeyGenerator,
-  setKeyGenerator
+  setKeyGenerator,
+  IS_CHROME,
+  IS_SAFARI,
+  IS_IE,
+  IS_FIREFOX
 }
 
 export default {
@@ -95,5 +100,9 @@ export default {
   Transforms,
   findDOMNode,
   resetKeyGenerator,
-  setKeyGenerator
+  setKeyGenerator,
+  IS_CHROME,
+  IS_SAFARI,
+  IS_IE,
+  IS_FIREFOX
 }

--- a/src/lib/slate/plugins/core.js
+++ b/src/lib/slate/plugins/core.js
@@ -484,11 +484,6 @@ function Plugin(options = {}) {
     if (data.isWord) boundary = 'Word'
     if (data.isLine) boundary = 'Line'
 
-    // Override line deletion if deleting structured field text at the beginning of a line
-    if (e.isPropagationStopped()) {
-      return state;
-    }
-
     return state
       .transform()
       [`delete${boundary}Backward`]()

--- a/src/lib/slate/plugins/core.js
+++ b/src/lib/slate/plugins/core.js
@@ -448,6 +448,8 @@ function Plugin(options = {}) {
   function onKeyDownEnter(e, data, state) {
     const { document, startKey } = state
     const hasVoidParent = document.hasVoidParent(startKey)
+
+    // Override block splitting if enter is pressed inside a structured field
     if (e.isPropagationStopped()) {
       return state;
     }

--- a/src/lib/slate/plugins/core.js
+++ b/src/lib/slate/plugins/core.js
@@ -484,6 +484,11 @@ function Plugin(options = {}) {
     if (data.isWord) boundary = 'Word'
     if (data.isLine) boundary = 'Line'
 
+    // Override line deletion if deleting structured field text at the beginning of a line
+    if (e.isPropagationStopped()) {
+      return state;
+    }
+
     return state
       .transform()
       [`delete${boundary}Backward`]()

--- a/src/lib/slate/plugins/core.js
+++ b/src/lib/slate/plugins/core.js
@@ -448,7 +448,9 @@ function Plugin(options = {}) {
   function onKeyDownEnter(e, data, state) {
     const { document, startKey } = state
     const hasVoidParent = document.hasVoidParent(startKey)
-
+    if (e.isPropagationStopped()) {
+      return state;
+    }
     // For void nodes, we don't want to split. Instead we just move to the start
     // of the next text node if one exists.
     if (hasVoidParent) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1032,8 +1032,7 @@ class FluxNotesEditor extends React.Component {
         } else if (node.characters) {
             length += node.characters.length;
         } else if (node.type === 'structured_field') {
-            let shortcut = node.data.shortcut;
-            length += shortcut.getText().length;
+            length += node.data.shortcut.getText().length;
         }
         return length;
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -585,9 +585,15 @@ class FluxNotesEditor extends React.Component {
             }
         });
 
+        // Save anchor block to reset selection after updating shortcut text
+        const {anchorBlock} = transform.state;
+
         // Update text on the node
         const shortcutNode = transform.state.document.getNode(shortcut.getKey());
         transform = transform.moveToRangeOf(shortcutNode).insertText(shortcut.getText()).collapseToStartOfNextText().focus();
+
+        // Move to previous anchor block to not lose the valid selection
+        transform = transform.moveToRangeOf(anchorBlock).collapseToEnd().focus();
 
         return transform;
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -868,7 +868,7 @@ class FluxNotesEditor extends React.Component {
     
     unhighlightAllStructuredFields = (transform) => {
         this.getSearchResultInlines(transform.state.document).forEach(inline => {
-            transform = this.unhighlightStructuredField(transform, inline.get('data').get('shortcut'));
+            transform = this.unhighlightStructuredField(transform, inline);
         });
         return transform;
     }
@@ -918,12 +918,13 @@ class FluxNotesEditor extends React.Component {
             // an identifier -- the order its in; that is 'n' where this is the nth phrase we've 
             // seen that matches the current search text
             indexOfCurrentMatch = 0
-            this.state.state.document.getInlinesByTypeAsArray('structured_field').forEach(sf => {
+            this.getSearchResultInlines(this.state.state.document).forEach(inline => {
+                const shortcut = inline.get('data').get('shortcut');
                 // TODO: handle highlighting of placeholder text -- should happen in the highlight fn
-                if (sf.getText().toLowerCase().includes(newHighlightedSearchSuggestion.inputValue.toLowerCase()) && newHighlightedSearchSuggestion.indexOfMatch === indexOfCurrentMatch) {
-                    transform = this.selectedHighlightStructuredField(transform, sf);
+                if (shortcut.getText().toLowerCase().includes(newHighlightedSearchSuggestion.inputValue.toLowerCase()) && newHighlightedSearchSuggestion.indexOfMatch === indexOfCurrentMatch) {
+                    transform = this.selectedHighlightStructuredField(transform, inline);
                     indexOfCurrentMatch += 1;
-                } else if (sf.getText().toLowerCase().includes(newHighlightedSearchSuggestion.inputValue.toLowerCase())) { 
+                } else if (shortcut.getText().toLowerCase().includes(newHighlightedSearchSuggestion.inputValue.toLowerCase())) {
                     indexOfCurrentMatch += 1;
                 }
             });
@@ -960,9 +961,10 @@ class FluxNotesEditor extends React.Component {
                 }
             });
             // regular highlighting of structured fields
-            this.state.state.document.getInlinesByTypeAsArray('structured_field').forEach(sf => {
-                if (sf.getText().toLowerCase().includes(prevHighlightedSuggestion.inputValue.toLowerCase())) {
-                    transform = this.regularHighlightStructuredField(transform, sf);
+            this.getSearchResultInlines(this.state.state.document).forEach(inline => {
+                const shortcut = inline.get('data').get('shortcut');
+                if (shortcut.getText().toLowerCase().includes(prevHighlightedSuggestion.inputValue.toLowerCase())) {
+                    transform = this.regularHighlightStructuredField(transform, inline);
                 } 
             });
         }
@@ -988,12 +990,13 @@ class FluxNotesEditor extends React.Component {
         suggestions.forEach(suggestion => {
 
             // Highlight matching shortcuts; reset highlights of unmatched shortcuts
-            this.state.state.document.getInlinesByTypeAsArray('structured_field').forEach(sf => {
+            this.state.state.document.getInlinesByTypeAsArray('structured_field').forEach(inline => {
+                const shortcut = inline.get('data').get('shortcut');
                 // Handle highlighting of placeholder text should happen in the highlight fn
-                if (sf.getText().toLowerCase().includes(suggestion.inputValue.toLowerCase())) {
-                    transform = this.regularHighlightStructuredField(transform, sf);
+                if (shortcut.getText().toLowerCase().includes(suggestion.inputValue.toLowerCase())) {
+                    transform = this.regularHighlightStructuredField(transform, inline);
                 } else {
-                    transform = this.unhighlightStructuredField(transform, sf);
+                    transform = this.unhighlightStructuredField(transform, inline);
                 }
             });
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -584,6 +584,11 @@ class FluxNotesEditor extends React.Component {
                 shortcut
             }
         });
+
+        // Update text on the node
+        const shortcutNode = transform.state.document.getNode(shortcut.getKey());
+        transform = transform.moveToRangeOf(shortcutNode).insertText(shortcut.getText()).collapseToStartOfNextText().focus();
+
         return transform;
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -86,7 +86,8 @@ class FluxNotesEditor extends React.Component {
             contextManager: this.contextManager,
             structuredFieldMapManager: this.structuredFieldMapManager,
             updateErrors: this.updateErrors,
-            insertText: this.insertTextWithStructuredPhrases
+            insertText: this.insertTextWithStructuredPhrases,
+            createShortcut: this.props.newCurrentShortcut
         };
         structuredFieldTypes.forEach((type) => {
             const typeName = type.name;

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -591,7 +591,7 @@ class FluxNotesEditor extends React.Component {
 
         // Update text on the node
         const shortcutNode = transform.state.document.getNode(shortcut.getKey());
-        transform = transform.moveToRangeOf(shortcutNode).insertText(shortcut.getText()).collapseToStartOfNextText().focus();
+        transform = transform.moveToRangeOf(shortcutNode).insertText(shortcut.getText());
 
         // Move to previous anchor block to not lose the valid selection
         transform = transform.moveToRangeOf(anchorBlock).collapseToEnd().focus();

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -528,6 +528,9 @@ class FluxNotesEditor extends React.Component {
         if (key1 === key2) {
             return offset1 < offset2;
         } else {
+            const parentNode = state.document.getParent(state.selection.anchorKey);
+            const shortcut = this.props.structuredFieldMapManager.keyToShortcutMap.get(parentNode.key);
+            if (shortcut && shortcut.getKey() === key1) return false;
             return state.document.areDescendantsSorted(key1, key2);
         }
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -581,6 +581,17 @@ class FluxNotesEditor extends React.Component {
         this.contextManager.contextUpdated();
     }
 
+    updateStructuredFieldResetSelection = (shortcut, transform) => {
+        // Save anchor block to reset selection after updating shortcut text
+        const { anchorBlock } = transform.state;
+
+        transform = this.structuredFieldPlugin.transforms.updateStructuredField(transform, shortcut);
+
+        // Move to previous anchor block to not lose the valid selection
+        transform = transform.moveToRangeOf(anchorBlock).collapseToEnd().focus();
+        return transform;
+    }
+
     resetShortcutData = (shortcut, transform) => {
         const key = shortcut.getKey();
         transform = transform.setNodeByKey(key, {
@@ -658,10 +669,10 @@ class FluxNotesEditor extends React.Component {
                                 // Set the text, then change the data of the shortcut to trigger a re-render.
                                 const text = childShortcut.determineText(this.contextManager);
                                 childShortcut.setText(text);
-                                transform = this.resetShortcutData(childShortcut, transform);
+                                transform = this.updateStructuredFieldResetSelection(childShortcut, transform);
                             } else {
                                 childShortcut.setText(null);
-                                transform = this.resetShortcutData(childShortcut, transform);
+                                transform = this.updateStructuredFieldResetSelection(childShortcut, transform);
                             }
                         });
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1331,10 +1331,10 @@ class FluxNotesEditor extends React.Component {
                 }
                 remainder = remainder.substring(start + trigger.trigger.length);
 
-                // FIXME: Temporary work around that adds spaces when needed to @-phrases inserted via mic
-                if (start !== 0 && trigger.trigger.startsWith('@') && !before.endsWith(' ')) {
-                    transform = this.insertPlainText(transform, ' ');
-                }
+                // // FIXME: Temporary work around that adds spaces when needed to @-phrases inserted via mic
+                // if (start !== 0 && trigger.trigger.startsWith('@') && !before.endsWith(' ')) {
+                //     transform = this.insertPlainText(transform, ' ');
+                // }
 
                 // Deals with @condition phrases inserted via data summary panel buttons. 
                 if (remainder.startsWith("[[")) {

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -107,7 +107,7 @@
             // Inserter values are grayed out
             &-inserter {
                 color: $state;
-                display: inline-block;
+                display: inline;
             }
         
             &-creator {

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -97,6 +97,30 @@
             display: inline;
         }
 
+        // ******** StructuredFieldPlugin.jsx uses this
+        .structured-field {
+            // Bolded during template hovering
+            &-bolded {
+                font-weight: bold;
+            }
+        
+            // Inserter values are grayed out
+            &-inserter {
+                color: $state;
+                display: inline-block;
+            }
+        
+            &-creator {
+                border-bottom: 1px solid $shr-context-line;
+            }
+        
+            &-search-result {
+                background-color: $highlight-yellow;
+            }
+            &-selected-search-result {
+                background-color: $highlight-selected-yellow;
+            }
+        }
         // ******** Special editor marks use this
         .search-result-regular-highlight { 
             background-color: $highlight-yellow;
@@ -105,54 +129,39 @@
             background-color: $highlight-selected-yellow;
         }
     }
-}
-
-.editor-content {
-    /* 96px is the height of the Patient Control Panel, 20px is the height of the top margin of post encounter view
-    content and a little extra for potential scroll bars, 130px accounts for the editor header and editor toolbar 
-    plus margins, 76px is the height of the sign button, 20px is the margin on the sign button */
-    height: calc(100vh - 96px - 20px - 130px - 76px - 20px) !important;
-    overflow-y: auto;
-    overflow-x: hidden;
-    text-align: left;
-}
-
-// ******** StructuredFieldPlugin.jsx uses this
-.structured-field {
-    // Bolded during template hovering
-    &-bolded {
-        font-weight: bold;
-    }
-
-    // Inserter values are grayed out
-    &-inserter {
-        color: $state;
-    }
-
-    &-creator {
-        border-bottom: 1px solid $shr-context-line;
-    }
-
-    &-search-result {
-        background-color: $highlight-yellow;
-    }
-    &-selected-search-result {
-        background-color: $highlight-selected-yellow;
-    }
-}
-
-.in-progress-note { 
-    .structured-field-creator {
-        background-color: rgba(0, 0, 0, 0);
-        border-bottom: 1.5px dashed $shr-context-line;
+    
+    .editor-content {
+        /* 96px is the height of the Patient Control Panel, 20px is the height of the top margin of post encounter view
+        content and a little extra for potential scroll bars, 130px accounts for the editor header and editor toolbar 
+        plus margins, 76px is the height of the sign button, 20px is the margin on the sign button */
+        height: calc(100vh - 96px - 20px - 130px - 76px - 20px) !important;
+        overflow-y: auto;
+        overflow-x: hidden;
+        text-align: left;
     }
     
-    div {
-        padding-bottom: 2px;
+    .in-progress-note { 
+        .structured-field-creator {
+            background-color: rgba(0, 0, 0, 0);
+            border-bottom: 1.5px dashed $shr-context-line;
+        }
+        
+        div:last-child {
+            padding-bottom: 2px;
+        }
     }
-}
-.placeholder {
-    background-color: #dddddd;
+    .placeholder {
+        background-color: #dddddd;
+    }
+    
+    @media only screen and (max-width: 1024px) { 
+        .editor-content {
+            /* 117px is the height of the Patient Control Panel, 20px is the height of the top margin of post encounter view
+            content and a little extra for potential scroll bars, 130px accounts for the editor header and editor toolbar 
+            plus margins, 76px is the height of the sign button, 20px is the margin on the sign button */
+            height: calc(100vh - 117px - 20px - 130px - 76px - 20px) !important;
+        }
+    }
 }
 
 .placeholder-data {
@@ -177,6 +186,8 @@
     line-height: 140%;
 }
 
+// TODO: Move this code into the suggestion portal code 
+//
 // ******** suggestion-portal.js uses this
 .suggestion-portal { 
     position: absolute;
@@ -212,14 +223,5 @@
     li.selected {
         background-color: #297DA2;
         color: #fff;
-    }
-}
-
-@media only screen and (max-width: 1200px) { 
-    .editor-content {
-        /* 117px is the height of the Patient Control Panel, 20px is the height of the top margin of post encounter view
-        content and a little extra for potential scroll bars, 130px accounts for the editor header and editor toolbar 
-        plus margins, 76px is the height of the sign button, 20px is the margin on the sign button */
-        height: calc(100vh - 117px - 20px - 130px - 76px - 20px) !important;
     }
 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -50,6 +50,10 @@ function StructuredFieldPlugin(opts) {
             newShortcut.setKey(newShortcutNode.key);
             newShortcut.setOriginalText(shortcut.getLabel());
             newShortcut.setText(newShortcutNode.text);
+            if (shortcut.wasRemovedFromContext) {
+                contextManager.removeShortcutFromContext(newShortcut);
+                newShortcut.setWasRemovedFromContext(true);
+            }
             transform = transform.setNodeByKey(newShortcutNode.key, {
                 data: { shortcut: newShortcut }
             });
@@ -91,6 +95,10 @@ function StructuredFieldPlugin(opts) {
             newShortcut.setKey(newShortcutNode.key);
             newShortcut.setOriginalText(shortcut.getLabel());
             newShortcut.setText(newShortcutNode.text);
+            if (shortcut.wasRemovedFromContext) {
+                contextManager.removeShortcutFromContext(newShortcut);
+                newShortcut.setWasRemovedFromContext(true);
+            }
             transform = transform.setNodeByKey(newShortcutNode.key, {
                 data: { shortcut: newShortcut }
             });

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -20,19 +20,6 @@ function StructuredFieldPlugin(opts) {
     let insertText = opts.insertText;
     const clearStructuredFieldMap = opts.structuredFieldMapManager.clearStructuredFieldMap;
 
-    function onBeforeInput(e, _, state, editor) {
-        const anchorParent = state.document.getParent(state.selection.anchorKey);
-        const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
-        if (shortcut) {
-            const typedLetter = e.nativeEvent.data || ' ';
-            const indexOfTyping = state.anchorOffset;
-            let arr = shortcut.getArrayOfText();
-            if (arr.length === 0) arr = shortcut.getText().split('').map(c => [c, true]);
-            arr.splice(indexOfTyping, 0, [typedLetter, false]);
-            shortcut.setText(arr)
-        }
-    }
-
     function onKeyDown(e, key, state, editor) {
         const anchorParent = state.document.getParent(state.selection.anchorKey);
         const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
@@ -53,7 +40,13 @@ function StructuredFieldPlugin(opts) {
             transform = transform.splitInline();
             const key = transform.state.document.getNode(anchorParent.key).key;
             const newTextNode = transform.state.document.getNextSibling(key);
-            transform = transform.moveToRangeOf(newTextNode).insertText(e.key).apply();
+            transform = transform.moveToRangeOf(newTextNode).insertText(e.key);
+
+            const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
+
+            transform = transform.apply();
+
+            opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, shortcut);
 
             // transform = transform.setNodeByKey(anchorParent.key, {
             //     data: { shortcut }
@@ -382,7 +375,6 @@ function StructuredFieldPlugin(opts) {
 		a cursor. see style top value of -18px  */
 	return {
         clearStructuredFieldMap,
-        onBeforeInput,
         onKeyDown,
         onChange,
         onCut,

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -19,6 +19,7 @@ function StructuredFieldPlugin(opts) {
     let updateErrors = opts.updateErrors;
     let insertText = opts.insertText;
     const clearStructuredFieldMap = opts.structuredFieldMapManager.clearStructuredFieldMap;
+    const createShortcut = opts.createShortcut;
 
     function onKeyDown(e, key, state, editor) {
         const anchorParent = state.document.getParent(state.selection.anchorKey);
@@ -43,7 +44,8 @@ function StructuredFieldPlugin(opts) {
             transform = transform.moveToRangeOf(newTextNode).insertText(e.key);
 
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
-            const newShortcut = Lang.cloneDeep(shortcut);
+            const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`, true, shortcut.getSource());
+            newShortcut.setKey(newShortcutNode.key);
             newShortcut.setText(newShortcutNode.text);
             transform = transform.setNodeByKey(newShortcutNode.key, {
                 data: { shortcut: newShortcut }
@@ -51,6 +53,8 @@ function StructuredFieldPlugin(opts) {
 
             const oldShortcutNode = transform.state.document.getPreviousSibling(newTextNode.key);
             shortcut.setText(oldShortcutNode.text);
+            contextManager.removeShortcutFromContext(shortcut);
+            shortcut.setWasRemovedFromContext(true);
             transform = transform.setNodeByKey(anchorParent.key, {
                 data: { shortcut }
             });
@@ -58,6 +62,7 @@ function StructuredFieldPlugin(opts) {
             transform = transform.apply();
 
             opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, newShortcut);
+            contextManager.contextUpdated();
 
             // transform = transform.setNodeByKey(anchorParent.key, {
             //     data: { shortcut }
@@ -76,7 +81,8 @@ function StructuredFieldPlugin(opts) {
             transform = transform.moveToRangeOf(newTextNode);
 
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
-            const newShortcut = Lang.cloneDeep(shortcut);
+            const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`, true, shortcut.getSource());
+            newShortcut.setKey(newShortcutNode.key);
             newShortcut.setText(newShortcutNode.text);
             transform = transform.setNodeByKey(newShortcutNode.key, {
                 data: { shortcut: newShortcut }
@@ -84,6 +90,8 @@ function StructuredFieldPlugin(opts) {
 
             const oldShortcutNode = parentBlock.getChild(anchorParent.key);
             shortcut.setText(oldShortcutNode.text);
+            contextManager.removeShortcutFromContext(shortcut);
+            shortcut.setWasRemovedFromContext(true);
             transform = transform.setNodeByKey(anchorParent.key, {
                 data: { shortcut }
             });
@@ -91,6 +99,7 @@ function StructuredFieldPlugin(opts) {
             transform = transform.apply();
 
             opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, newShortcut);
+            contextManager.contextUpdated();
 
             editor.onChange(transform);
         }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -12,6 +12,12 @@ function createOpts(opts) {
 	return opts;
 }
 
+function stopEventPropagation(e) {
+    // Prevent native event handling in Slate
+    // Used for inserting text inside an inserter shortcut
+    e.preventDefault();
+    e.stopPropagation();
+}
 
 function StructuredFieldPlugin(opts) {
     opts = createOpts(opts);
@@ -32,9 +38,8 @@ function StructuredFieldPlugin(opts) {
         const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isWord;
 
         // Override native typing when typing inside a structured field
-        if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier && e.key !== 'Enter' && e.key !== 'Backspace') {
-            e.preventDefault();
-            e.stopPropagation();
+        if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier && e.key !== 'Enter') {
+            stopEventPropagation(e);
 
             // Split the inline and insert typed text into new text node
             let transform = state.transform();
@@ -78,8 +83,7 @@ function StructuredFieldPlugin(opts) {
 
             editor.onChange(transform);
         } else if (shortcut && e.key === 'Enter') {
-            e.preventDefault();
-            e.stopPropagation();
+            stopEventPropagation(e);
 
             // Split block and move focus into the new text node
             let transform = state.transform().splitBlock();

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -19,6 +19,21 @@ function stopEventPropagation(e) {
     e.stopPropagation();
 }
 
+function updateShortcut(shortcut, transform, key, label, text) {
+    shortcut.setOriginalText(label);
+    shortcut.setText(text);
+    transform = transform.setNodeByKey(key, {
+        data: { shortcut }
+    });
+    return transform;
+}
+
+function updateMaps(shortcut, opts) {
+    opts.structuredFieldMapManager.keyToShortcutMap.set(shortcut.getKey(), shortcut);
+    opts.structuredFieldMapManager.idToShortcutMap.set(shortcut.uniqueId, shortcut);
+    opts.structuredFieldMapManager.idToKeysMap.set(shortcut.uniqueId, [shortcut.getKey()]);
+}
+
 function StructuredFieldPlugin(opts) {
     opts = createOpts(opts);
     let contextManager = opts.contextManager;
@@ -61,29 +76,21 @@ function StructuredFieldPlugin(opts) {
             }
             const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, shortcutText, true, shortcut.getSource());
             newShortcut.setKey(newShortcutNode.key);
-            newShortcut.setOriginalText(shortcut.getLabel());
-            newShortcut.setText(newShortcutNode.text);
+            transform = updateShortcut(newShortcut, transform, newShortcutNode.key, shortcut.getLabel(), newShortcutNode.text);
             if (shortcut.wasRemovedFromContext) {
                 contextManager.removeShortcutFromContext(newShortcut);
                 newShortcut.setWasRemovedFromContext(true);
             }
-            transform = transform.setNodeByKey(newShortcutNode.key, {
-                data: { shortcut: newShortcut }
-            });
 
             // Update the existing shortcut to reflect the leading text after split
             const oldShortcutNode = transform.state.document.getPreviousSibling(newTextNode.key);
-            newShortcut.setOriginalText(shortcut.getLabel());
-            shortcut.setText(oldShortcutNode.text);
+            transform = updateShortcut(shortcut, transform, oldShortcutNode.key, shortcut.getLabel(), oldShortcutNode.text);
             contextManager.removeShortcutFromContext(shortcut);
             shortcut.setWasRemovedFromContext(true);
-            transform = transform.setNodeByKey(anchorParent.key, {
-                data: { shortcut }
-            });
 
             transform = transform.apply();
 
-            opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, newShortcut);
+            updateMaps(newShortcut, opts);
             contextManager.contextUpdated();
 
             editor.onChange(transform);
@@ -105,29 +112,21 @@ function StructuredFieldPlugin(opts) {
             }
             const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, shortcutText, true, shortcut.getSource());
             newShortcut.setKey(newShortcutNode.key);
-            newShortcut.setOriginalText(shortcut.getLabel());
-            newShortcut.setText(newShortcutNode.text);
+            transform = updateShortcut(newShortcut, transform, newShortcutNode.key, shortcut.getLabel(), newShortcutNode.text);
             if (shortcut.wasRemovedFromContext) {
                 contextManager.removeShortcutFromContext(newShortcut);
                 newShortcut.setWasRemovedFromContext(true);
             }
-            transform = transform.setNodeByKey(newShortcutNode.key, {
-                data: { shortcut: newShortcut }
-            });
 
             // Update the existing shortcut to reflect the leading text after split
             const oldShortcutNode = parentBlock.getChild(anchorParent.key);
-            newShortcut.setOriginalText(shortcut.getLabel());
-            shortcut.setText(oldShortcutNode.text);
+            transform = updateShortcut(shortcut, transform, anchorParent.key, shortcut.getLabel(), oldShortcutNode.text);
             contextManager.removeShortcutFromContext(shortcut);
             shortcut.setWasRemovedFromContext(true);
-            transform = transform.setNodeByKey(anchorParent.key, {
-                data: { shortcut }
-            });
 
             transform = transform.apply();
 
-            opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, newShortcut);
+            updateMaps(newShortcut, opts);
             contextManager.contextUpdated();
 
             editor.onChange(transform);

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -31,18 +31,14 @@ function StructuredFieldPlugin(opts) {
             e.preventDefault();
             e.stopPropagation();
 
-            // const indexOfTyping = state.anchorOffset;
-            // let arr = shortcut.getArrayOfText();
-            // if (arr.length === 0) arr = shortcut.getText().split('').map(c => [c, true]);
-            // arr.splice(indexOfTyping, 0, [e.key, false]);
-            // shortcut.setText(arr)
-
+            // Split the inline and insert typed text into new text node
             let transform = state.transform();
             transform = transform.splitInline();
             const key = transform.state.document.getNode(anchorParent.key).key;
             const newTextNode = transform.state.document.getNextSibling(key);
             transform = transform.moveToRangeOf(newTextNode).insertText(e.key);
 
+            // Create a new shortcut with the trailing shortcut text after split
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
             let shortcutText = newShortcutNode.text;
             if (shortcut.valueObject) {
@@ -56,6 +52,7 @@ function StructuredFieldPlugin(opts) {
                 data: { shortcut: newShortcut }
             });
 
+            // Update the existing shortcut to reflect the leading text after split
             const oldShortcutNode = transform.state.document.getPreviousSibling(newTextNode.key);
             newShortcut.setOriginalText(shortcut.getLabel());
             shortcut.setText(oldShortcutNode.text);
@@ -70,10 +67,6 @@ function StructuredFieldPlugin(opts) {
             opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, newShortcut);
             contextManager.contextUpdated();
 
-            // transform = transform.setNodeByKey(anchorParent.key, {
-            //     data: { shortcut }
-            // }).insertText(e.key).focus().apply();
-
             editor.onChange(transform);
         } else if (shortcut && e.key === 'Enter') {
             e.preventDefault();
@@ -86,6 +79,7 @@ function StructuredFieldPlugin(opts) {
             const newTextNode = newBlock.getFirstText();
             transform = transform.moveToRangeOf(newTextNode);
 
+            // Create a new shortcut with the trailing shortcut text after split
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
             let shortcutText = newShortcutNode.text;
             if (shortcut.valueObject) {
@@ -99,6 +93,7 @@ function StructuredFieldPlugin(opts) {
                 data: { shortcut: newShortcut }
             });
 
+            // Update the existing shortcut to reflect the leading text after split
             const oldShortcutNode = parentBlock.getChild(anchorParent.key);
             newShortcut.setOriginalText(shortcut.getLabel());
             shortcut.setText(oldShortcutNode.text);
@@ -156,30 +151,7 @@ function StructuredFieldPlugin(opts) {
             structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    // const arr = shortcut.getArrayOfText();
-                    // let text = [];
-                    // if (arr.length > 0) {
-                    //     let word = '';
-                    //     let prev = true;
-                    //     arr.forEach(char => {
-                    //         if (char[1] === prev) {
-                    //             word += char[0];
-                    //         } else  {
-                    //             text.push(word);
-                    //             word = char[0];
-                    //         }
-                    //         prev = char[1];
-                    //     });
-                    //     text.push(word);
-                    //     let spans = [];
-                    //     text.forEach((snippet, i) => {
-                    //         if (i % 2 === 0) spans.push(<span key={i} className='structured-field-inserter'>{snippet}</span>);
-                    //         else spans.push(<span key={i}>{snippet}</span>);
-                    //     });
-                    //     return <span {...props.attributes}>{spans.map(s => s)}</span>
-                    // } else {
-                        return <span className='structured-field-inserter' {...props.attributes}>{props.children}</span>;
-                    // }
+                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -161,6 +161,8 @@ function StructuredFieldPlugin(opts) {
             structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
+                    // Added a zero-width-space at the end of the structured field so Safari doesn't think we are still typing in a
+                    // structured field once one has been inserted
                     return <span className='structured-field-inserter' {...props.attributes}>{props.children}&#8203;</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -27,6 +27,8 @@ function StructuredFieldPlugin(opts) {
         const ignoredKeys = [16, 20, 37, 38, 39, 40];
         const { isAlt, isCmd, isCtrl, isLine, isMeta, isMod, isModAlt, isWord } = key;
         const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isWord;
+
+        // Override native typing when typing inside a structured field
         if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier && e.key !== 'Enter') {
             e.preventDefault();
             e.stopPropagation();
@@ -271,7 +273,6 @@ function StructuredFieldPlugin(opts) {
     }
 
     function convertToText(fragment) {
-
         return `${convertSlateNodesToText(fragment.toJSON().nodes)}`;
     }
 
@@ -480,6 +481,7 @@ function createStructuredField(opts, shortcut) {
     const isInserter = shortcut instanceof InsertValue;
     const isVoid = !isInserter;
     if (isInserter) {
+        // Make inserter shortcuts editable by initialized nodes for each character in shortcut
         nodes = [Slate.Text.create({
             characters: Slate.Character.createList(String(shortcut.getText())
                 .split('')

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -21,6 +21,7 @@ function StructuredFieldPlugin(opts) {
     const clearStructuredFieldMap = opts.structuredFieldMapManager.clearStructuredFieldMap;
 
     function onChange(state, editor) {
+        // console.log(state.document.getParent(state.selection.anchorKey))// Gets the structured field
         var deletedKeys = [];
         const keyToShortcutMap = opts.structuredFieldMapManager.keyToShortcutMap;
         const idToShortcutMap = opts.structuredFieldMapManager.idToShortcutMap;

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -24,7 +24,10 @@ function StructuredFieldPlugin(opts) {
     function onKeyDown(e, key, state, editor) {
         const anchorParent = state.document.getParent(state.selection.anchorKey);
         const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
-        const ignoredKeys = [16, 20, 37, 38, 39, 40];
+        // Arrow keys, shift, escape, tab, numlock, page up/down, etc
+        let ignoredKeys = [9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];
+        const fKeys = [112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124];
+        ignoredKeys = ignoredKeys.concat(fKeys);
         const { isAlt, isCmd, isCtrl, isLine, isMeta, isMod, isModAlt, isWord } = key;
         const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isWord;
 

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -166,7 +166,7 @@ function StructuredFieldPlugin(opts) {
             bolded_structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span contentEditable={false} className='structured-field-inserter structured-field-bolded' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-bolded' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -174,7 +174,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_selected_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-highlighted structured-field-selected-search-result' {...props.attributes}>{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-selected-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -44,7 +44,11 @@ function StructuredFieldPlugin(opts) {
             transform = transform.moveToRangeOf(newTextNode).insertText(e.key);
 
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
-            const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`, true, shortcut.getSource());
+            let shortcutText = newShortcutNode.text;
+            if (shortcut.valueObject) {
+                shortcutText = `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`;
+            }
+            const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, shortcutText, true, shortcut.getSource());
             newShortcut.setKey(newShortcutNode.key);
             newShortcut.setOriginalText(shortcut.getLabel());
             newShortcut.setText(newShortcutNode.text);
@@ -83,7 +87,11 @@ function StructuredFieldPlugin(opts) {
             transform = transform.moveToRangeOf(newTextNode);
 
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
-            const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`, true, shortcut.getSource());
+            let shortcutText = newShortcutNode.text;
+            if (shortcut.valueObject) {
+                shortcutText = `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`;
+            }
+            const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, shortcutText, true, shortcut.getSource());
             newShortcut.setKey(newShortcutNode.key);
             newShortcut.setOriginalText(shortcut.getLabel());
             newShortcut.setText(newShortcutNode.text);

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -32,7 +32,7 @@ function StructuredFieldPlugin(opts) {
         const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isWord;
 
         // Override native typing when typing inside a structured field
-        if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier && e.key !== 'Enter') {
+        if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier && e.key !== 'Enter' && e.key !== 'Backspace') {
             e.preventDefault();
             e.stopPropagation();
 
@@ -122,6 +122,14 @@ function StructuredFieldPlugin(opts) {
             contextManager.contextUpdated();
 
             editor.onChange(transform);
+        } else if (shortcut && e.key === 'Backspace' && state.anchorOffset === 0) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            let transform = state.transform();
+            const prevTextNode = transform.state.document.getPreviousSibling(anchorParent.key);
+            transform = transform.collapseToStartOf(prevTextNode).deleteBackward(1);
+            editor.onChange(transform.apply());
         }
     }
 

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -24,9 +24,9 @@ function StructuredFieldPlugin(opts) {
     function onKeyDown(e, key, state, editor) {
         const anchorParent = state.document.getParent(state.selection.anchorKey);
         const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
-        const ignoredKeys = [20, 37, 38, 39, 40];
-        const { isAlt, isCmd, isCtrl, isLine, isMeta, isMod, isModAlt, isShift, isWord } = key;
-        const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isShift || isWord;
+        const ignoredKeys = [16, 20, 37, 38, 39, 40];
+        const { isAlt, isCmd, isCtrl, isLine, isMeta, isMod, isModAlt, isWord } = key;
+        const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isWord;
         if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier && e.key !== 'Enter') {
             e.preventDefault();
             e.stopPropagation();

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -43,10 +43,21 @@ function StructuredFieldPlugin(opts) {
             transform = transform.moveToRangeOf(newTextNode).insertText(e.key);
 
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
+            const newShortcut = Lang.cloneDeep(shortcut);
+            newShortcut.setText(newShortcutNode.text);
+            transform = transform.setNodeByKey(newShortcutNode.key, {
+                data: { shortcut: newShortcut }
+            });
+
+            const oldShortcutNode = transform.state.document.getPreviousSibling(newTextNode.key);
+            shortcut.setText(oldShortcutNode.text);
+            transform = transform.setNodeByKey(anchorParent.key, {
+                data: { shortcut }
+            });
 
             transform = transform.apply();
 
-            opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, shortcut);
+            opts.structuredFieldMapManager.keyToShortcutMap.set(newShortcutNode.key, newShortcut);
 
             // transform = transform.setNodeByKey(anchorParent.key, {
             //     data: { shortcut }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -32,6 +32,9 @@ function StructuredFieldPlugin(opts) {
         // NOTE: This uses the new suggested approach. keyToShortcutMap approach works until keys change after enter and map is incorrect.
         // const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
         const shortcut = anchorParent.data.get('shortcut');
+
+        if (!(shortcut instanceof InsertValue)) return;
+
         // Arrow keys, shift, escape, tab, numlock, page up/down, etc
         let ignoredKeys = [9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];
         const fKeys = [112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124];
@@ -302,7 +305,12 @@ function StructuredFieldPlugin(opts) {
                 }
             } else if (node.type === 'structured_field') {
                 const shortcut = node.data.shortcut;
-                result += shortcut.getResultText(node.data.displayText);
+                if (shortcut instanceof InsertValue) {
+                    // Inserters have characters as their children. Use characters to get current text in the node.
+                    result += shortcut.getResultText(node.nodes[0].characters.map(c => c.text).join(''));
+                } else {
+                    result += shortcut.getResultText();
+                }
             } else if (node.type === 'placeholder') {
                 result += node.data.placeholder.getResultText();
             } else if (node.type === 'bulleted-list') {
@@ -549,7 +557,6 @@ function createStructuredField(opts, shortcut) {
                 nodes: textNodes,
                 isVoid,
                 data: {
-                    displayText: line,
                     shortcut: shortcut
                 }
             };

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -342,6 +342,10 @@ function StructuredFieldPlugin(opts) {
         attach.setAttribute('flux-string', encoded);
         if (contents.childNodes.length > 1) {
             contents.childNodes[1].setAttribute('flux-string', encoded);
+            if (state.selection.focusOffset === 0) {
+                // Reset contenteditable prop to make copy work for editable structured fields
+                contents.childNodes[1].setAttribute('contenteditable', false);
+            }
         }
 
         // Add the phony content to the DOM, and select it, so it will be copied.

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -33,6 +33,36 @@ function StructuredFieldPlugin(opts) {
         }
     }
 
+    function onKeyDown(e, key, state, editor) {
+        const anchorParent = state.document.getParent(state.selection.anchorKey);
+        const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
+        const ignoredKeys = [20, 37, 38, 39, 40];
+        const { isAlt, isCmd, isCtrl, isLine, isMeta, isMod, isModAlt, isShift, isWord } = key;
+        const isModifier = isAlt || isCmd || isCtrl || isLine || isMeta || isMod || isModAlt || isShift || isWord;
+        if (shortcut && !Lang.includes(ignoredKeys, e.keyCode) && !isModifier) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            // const indexOfTyping = state.anchorOffset;
+            // let arr = shortcut.getArrayOfText();
+            // if (arr.length === 0) arr = shortcut.getText().split('').map(c => [c, true]);
+            // arr.splice(indexOfTyping, 0, [e.key, false]);
+            // shortcut.setText(arr)
+
+            let transform = state.transform();
+            transform = transform.splitInline();
+            const key = transform.state.document.getNode(anchorParent.key).key;
+            const newTextNode = transform.state.document.getNextSibling(key);
+            transform = transform.moveToRangeOf(newTextNode).insertText(e.key).apply();
+
+            // transform = transform.setNodeByKey(anchorParent.key, {
+            //     data: { shortcut }
+            // }).insertText(e.key).focus().apply();
+
+            editor.onChange(transform);
+        }
+    }
+
     function onChange(state, editor) {
         var deletedKeys = [];
         const keyToShortcutMap = opts.structuredFieldMapManager.keyToShortcutMap;
@@ -353,6 +383,7 @@ function StructuredFieldPlugin(opts) {
 	return {
         clearStructuredFieldMap,
         onBeforeInput,
+        onKeyDown,
         onChange,
         onCut,
         onCopy,

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -64,9 +64,9 @@ function StructuredFieldPlugin(opts) {
             // Split the inline and insert typed text into new text node
             let transform = state.transform();
             transform = transform.splitInline();
-            const key = transform.state.document.getNode(anchorParent.key).key;
-            const newTextNode = transform.state.document.getNextSibling(key);
-            transform = transform.moveToRangeOf(newTextNode).insertText(e.key);
+            const key = transform.state.selection.anchorKey;
+            const newTextNode = transform.state.document.getPreviousText(key);
+            transform = transform.collapseToEndOf(newTextNode).insertText(e.key);
 
             // Create a new shortcut with the trailing shortcut text after split
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
@@ -97,12 +97,14 @@ function StructuredFieldPlugin(opts) {
         } else if (shortcut && e.key === 'Enter') {
             stopEventPropagation(e);
 
+            // Get the current shortcut node before splitting the block
+            const oldShortcutNode = state.document.getParent(state.selection.anchorKey);
+
             // Split block and move focus into the new text node
             let transform = state.transform().splitBlock();
-            const parentBlock = transform.state.document.getParent(anchorParent.key);
-            const newBlock = transform.state.document.getNextSibling(parentBlock.key);
-            const newTextNode = newBlock.getFirstText();
-            transform = transform.moveToRangeOf(newTextNode);
+            const key = transform.state.selection.anchorKey;
+            const newTextNode = transform.state.document.getPreviousText(key);
+            transform = transform.collapseToEndOf(newTextNode);
 
             // Create a new shortcut with the trailing shortcut text after split
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
@@ -119,7 +121,6 @@ function StructuredFieldPlugin(opts) {
             }
 
             // Update the existing shortcut to reflect the leading text after split
-            const oldShortcutNode = parentBlock.getChild(anchorParent.key);
             transform = updateShortcut(shortcut, transform, anchorParent.key, shortcut.getLabel(), oldShortcutNode.text);
             contextManager.removeShortcutFromContext(shortcut);
             shortcut.setWasRemovedFromContext(true);

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -133,12 +133,26 @@ function StructuredFieldPlugin(opts) {
         }
     }
 
+    function getAllStructuredFields(nodes) {
+        let allStructuredFields = [];
+        nodes.forEach(node => {
+            if (node.type === 'structured_field') {
+                allStructuredFields.push(node);
+            }
+            if (node.nodes) {
+                allStructuredFields = allStructuredFields.concat(getAllStructuredFields(node.nodes));
+            }
+        });
+        return allStructuredFields;
+    }
+
     function onChange(state, editor) {
         var deletedKeys = [];
         const keyToShortcutMap = opts.structuredFieldMapManager.keyToShortcutMap;
         const idToShortcutMap = opts.structuredFieldMapManager.idToShortcutMap;
-        const nodes = state.document.getInlines();
-        if (nodes.size !== keyToShortcutMap.size) {
+        const nodes = getAllStructuredFields(state.document.toJSON().nodes);
+
+        if (nodes.length !== keyToShortcutMap.size) {
             var currentNodesMap = new Map(nodes.map((i) => [i.key, i]));
             keyToShortcutMap.forEach((value, key) => {
                 if (!currentNodesMap.has(key)) {

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -161,7 +161,7 @@ function StructuredFieldPlugin(opts) {
             structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}</span>;
+                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}&#8203;</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -169,7 +169,7 @@ function StructuredFieldPlugin(opts) {
             bolded_structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}&#8203;</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-bolded' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -177,7 +177,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_selected_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}&#8203;</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-selected-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -185,7 +185,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}&#8203;</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -488,7 +488,7 @@ function createStructuredField(opts, shortcut) {
     const isVoid = !isInserter;
     if (isInserter) {
         nodes = [Slate.Text.create({
-            characters: Slate.Character.createList(shortcut.getText()
+            characters: Slate.Character.createList(String(shortcut.getText())
                 .split('')
                 .map((char) => {
                     return Slate.Character.create({

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -46,12 +46,14 @@ function StructuredFieldPlugin(opts) {
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
             const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`, true, shortcut.getSource());
             newShortcut.setKey(newShortcutNode.key);
+            newShortcut.setOriginalText(shortcut.getLabel());
             newShortcut.setText(newShortcutNode.text);
             transform = transform.setNodeByKey(newShortcutNode.key, {
                 data: { shortcut: newShortcut }
             });
 
             const oldShortcutNode = transform.state.document.getPreviousSibling(newTextNode.key);
+            newShortcut.setOriginalText(shortcut.getLabel());
             shortcut.setText(oldShortcutNode.text);
             contextManager.removeShortcutFromContext(shortcut);
             shortcut.setWasRemovedFromContext(true);
@@ -83,12 +85,14 @@ function StructuredFieldPlugin(opts) {
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
             const newShortcut = createShortcut(shortcut.metadata, shortcut.initiatingTrigger, `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`, true, shortcut.getSource());
             newShortcut.setKey(newShortcutNode.key);
+            newShortcut.setOriginalText(shortcut.getLabel());
             newShortcut.setText(newShortcutNode.text);
             transform = transform.setNodeByKey(newShortcutNode.key, {
                 data: { shortcut: newShortcut }
             });
 
             const oldShortcutNode = parentBlock.getChild(anchorParent.key);
+            newShortcut.setOriginalText(shortcut.getLabel());
             shortcut.setText(oldShortcutNode.text);
             contextManager.removeShortcutFromContext(shortcut);
             shortcut.setWasRemovedFromContext(true);

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -59,7 +59,8 @@ function StructuredFieldPlugin(opts) {
             structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span contentEditable={false} className='structured-field-inserter' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+//                    return <span contentEditable={false} className='structured-field-inserter' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -75,7 +76,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_selected_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span contentEditable={false} className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-highlighted structured-field-selected-search-result' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-selected-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -83,7 +84,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span contentEditable={false} className='structured-field-inserter structured-field-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
+                    return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -383,11 +384,19 @@ function insertStructuredFieldAtRange(opts, transform, shortcut, range) {
  * @return {State.Block}
  */
 function createStructuredField(opts, shortcut) {
-	let nodes = [];
+	let nodes = [ Slate.Text.create({characters: Slate.Character.createList(shortcut.getText()
+                                                                                .split('')
+                                                                                .map((char) => {
+                                                                                    return Slate.Character.create({
+                                                                                        text: char
+                                                                                    })
+                                                                                })
+                                                                            )})];
+	//let nodes = [ Slate.Text.create({})];
     const properties = {
         type:  opts.typeStructuredField,
         nodes: nodes,
-        isVoid: true,
+        //isVoid: true,
         data: {
             shortcut: shortcut
         }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -159,14 +159,16 @@ function StructuredFieldPlugin(opts) {
         return result;
     }
 
+    // Added a zero-width-space at the end of the structured field so Safari doesn't think we are still typing in a
+    // structured field once one has been inserted
+    const safariSpacing = Slate.IS_SAFARI ? '\u200B' : '';
+
     const schema = {
         nodes: {
             structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    // Added a zero-width-space at the end of the structured field so Safari doesn't think we are still typing in a
-                    // structured field once one has been inserted
-                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}&#8203;</span>;
+                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -174,7 +176,7 @@ function StructuredFieldPlugin(opts) {
             bolded_structured_field: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}&#8203;</span>;
+                    return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-bolded' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -182,7 +184,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_selected_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}&#8203;</span>;
+                    return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-selected-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }
@@ -190,7 +192,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_search_result: props => {
                 let shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}&#8203;</span>;
+                    return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-search-result' {...props.attributes}>{shortcut.getText()}{props.children}</span>;
                 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -680,7 +680,8 @@ function createPlaceholderStructuredField(opts, placeholder) {
     };
     const sf = Slate.Inline.create(properties);
     opts.structuredFieldMapManager.keyToShortcutMap.set(sf.key, placeholder);
-    opts.structuredFieldMapManager.idToShortcutMap.set(placeholder.metadata.id, placeholder);
+    opts.structuredFieldMapManager.idToShortcutMap.set(placeholder.uniqueId, placeholder);
+    opts.structuredFieldMapManager.idToKeysMap.set(placeholder.uniqueId, [sf.key]);
     opts.structuredFieldMapManager.addPlaceholder(placeholder);
     return sf;
 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -84,9 +84,14 @@ function StructuredFieldPlugin(opts) {
 
             // Update the existing shortcut to reflect the leading text after split
             const oldShortcutNode = transform.state.document.getPreviousSibling(newTextNode.key);
-            transform = updateShortcut(shortcut, transform, oldShortcutNode.key, shortcut.getLabel(), oldShortcutNode.text);
-            contextManager.removeShortcutFromContext(shortcut);
-            shortcut.setWasRemovedFromContext(true);
+
+            // In the case where there is no prior shortcut node in this block
+            // nothing needs to be updated
+            if (oldShortcutNode) {
+                transform = updateShortcut(shortcut, transform, oldShortcutNode.key, shortcut.getLabel(), oldShortcutNode.text);
+                contextManager.removeShortcutFromContext(shortcut);
+                shortcut.setWasRemovedFromContext(true);
+            }
 
             transform = transform.apply();
 

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -51,7 +51,7 @@ function StructuredFieldPlugin(opts) {
         if (!(shortcut instanceof InsertValue)) return;
 
         // Arrow keys, shift, escape, tab, numlock, page up/down, etc
-        let ignoredKeys = [9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];
+        let ignoredKeys = [8, 9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];
         const fKeys = [112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124];
         ignoredKeys = ignoredKeys.concat(fKeys);
         const { isAlt, isCmd, isCtrl, isLine, isMeta, isMod, isModAlt, isWord } = key;
@@ -130,14 +130,6 @@ function StructuredFieldPlugin(opts) {
             contextManager.contextUpdated();
 
             editor.onChange(transform);
-        } else if (shortcut && e.key === 'Backspace' && state.anchorOffset === 0) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            let transform = state.transform();
-            const prevTextNode = transform.state.document.getPreviousSibling(anchorParent.key);
-            transform = transform.collapseToStartOf(prevTextNode).deleteBackward(1);
-            editor.onChange(transform.apply());
         }
     }
 
@@ -181,7 +173,8 @@ function StructuredFieldPlugin(opts) {
                 }
                 keyToShortcutMap.delete(key);
                 idToShortcutMap.delete(shortcut.uniqueId);
-                idToKeysMap.delete(shortcut.uniqueId);
+                const updatedShortcutKeys = idToKeysMap.get(shortcut.uniqueId).filter(k => k !== key);
+                idToKeysMap.set(shortcut.uniqueId, updatedShortcutKeys);
                 contextManager.contextUpdated();
             } else {
                 result = editor.getState(); // don't allow state change

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -29,7 +29,9 @@ function StructuredFieldPlugin(opts) {
 
     function onKeyDown(e, key, state, editor) {
         const anchorParent = state.document.getParent(state.selection.anchorKey);
-        const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
+        // NOTE: This uses the new suggested approach. keyToShortcutMap approach works until keys change after enter and map is incorrect.
+        // const shortcut = opts.structuredFieldMapManager.keyToShortcutMap.get(anchorParent.key);
+        const shortcut = anchorParent.data.get('shortcut');
         // Arrow keys, shift, escape, tab, numlock, page up/down, etc
         let ignoredKeys = [9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];
         const fKeys = [112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124];
@@ -194,7 +196,7 @@ function StructuredFieldPlugin(opts) {
     const schema = {
         nodes: {
             structured_field: props => {
-                let shortcut = props.node.get('data').get('shortcut');
+                const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
                     return <span className='structured-field-inserter' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
@@ -202,7 +204,7 @@ function StructuredFieldPlugin(opts) {
                 }
             },
             bolded_structured_field: props => {
-                let shortcut = props.node.get('data').get('shortcut');
+                const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
                     return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
@@ -210,7 +212,7 @@ function StructuredFieldPlugin(opts) {
                 }
             },
             structured_field_selected_search_result: props => {
-                let shortcut = props.node.get('data').get('shortcut');
+                const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
                     return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
@@ -218,7 +220,7 @@ function StructuredFieldPlugin(opts) {
                 }
             },
             structured_field_search_result: props => {
-                let shortcut = props.node.get('data').get('shortcut');
+                const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
                     return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
@@ -299,8 +301,8 @@ function StructuredFieldPlugin(opts) {
                     });
                 }
             } else if (node.type === 'structured_field') {
-                let shortcut = node.data.shortcut;
-                result += shortcut.getResultText();
+                const shortcut = node.data.shortcut;
+                result += shortcut.getResultText(node.data.displayText);
             } else if (node.type === 'placeholder') {
                 result += node.data.placeholder.getResultText();
             } else if (node.type === 'bulleted-list') {
@@ -547,6 +549,7 @@ function createStructuredField(opts, shortcut) {
                 nodes: textNodes,
                 isVoid,
                 data: {
+                    displayText: line,
                     shortcut: shortcut
                 }
             };

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -28,7 +28,7 @@ import Reference from '../model/Reference';
 import mapper from '../lib/FHIRMapper';
 import Lang from 'lodash';
 import moment from 'moment';
-import Guid from 'guid';
+import { v4 } from 'uuid';
 import _ from 'lodash';
 
 class PatientRecord {
@@ -49,7 +49,7 @@ class PatientRecord {
             this.entries = [];
             this.patient = null;
             this.person = null;
-            this.shrId = Guid.raw();
+            this.shrId = v4();
             this.nextEntryId = 1;
             //this.patientReference = null;
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -10,7 +10,7 @@ export default class InsertValue extends Shortcut {
         this.text = null;
         this.originalText = null;
         this.patient = patient;
-        this._wasRemovedFromContext = false;
+        this.wasRemovedFromContext = false;
         this._shouldRemoveFromContext = false;
     }
 
@@ -206,7 +206,7 @@ export default class InsertValue extends Shortcut {
             const shortcutDataObj = {
                 text,
                 entryId: this.valueObject.entryInfo.entryId,
-                wasRemovedFromContext: this._wasRemovedFromContext,
+                wasRemovedFromContext: this.wasRemovedFromContext,
                 originalText: this.originalText,
             };
             return `${this.initiatingTrigger}[[${JSON.stringify(shortcutDataObj)}]]`;
@@ -223,7 +223,7 @@ export default class InsertValue extends Shortcut {
     }
 
     setWasRemovedFromContext(value) {
-        this._wasRemovedFromContext = value;
+        this.wasRemovedFromContext = value;
     }
 
     setText(text) {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -188,11 +188,7 @@ export default class InsertValue extends Shortcut {
     }
 
     getText() {
-        // if (Lang.isArray(this.text)) {
-        //     return this.text ? this.text.map(c => c[0]).join('') : this.initiatingTrigger
-        // } else {
-            return this.text ? this.text : this.initiatingTrigger;
-        // }
+        return this.text ? this.text : this.initiatingTrigger;
     }
 
     getArrayOfText() {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -197,8 +197,8 @@ export default class InsertValue extends Shortcut {
         return Lang.isArray(this.text) ? this.text : [];
     }
 
-    getResultText() {
-        let text = this.text;
+    getResultText(displayText = null) {
+        let text = displayText || this.text; // Use provided text to override shortcut text
         if (typeof text === "string" && text.startsWith(this.getPrefixCharacter())) {
             text = text.substring(1);
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -197,8 +197,6 @@ export default class InsertValue extends Shortcut {
         let text = this.text;
         if (typeof text === "string" && text.startsWith(this.getPrefixCharacter())) {
             text = text.substring(1);
-        } else if (Lang.isArray(text)) {
-            text = text.map(c => c[0]).join('');
         }
         // If this.valueObject exists, put the entryId of the valueObject in the result text
         if (this.valueObject) {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -182,11 +182,11 @@ export default class InsertValue extends Shortcut {
     }
 
     getText() {
-        if (Lang.isArray(this.text)) {
-            return this.text ? this.text.map(c => c[0]).join('') : this.initiatingTrigger
-        } else {
+        // if (Lang.isArray(this.text)) {
+        //     return this.text ? this.text.map(c => c[0]).join('') : this.initiatingTrigger
+        // } else {
             return this.text ? this.text : this.initiatingTrigger;
-        }
+        // }
     }
 
     getArrayOfText() {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -9,6 +9,8 @@ export default class InsertValue extends Shortcut {
         this.metadata = metadata;
         this.text = null;
         this.patient = patient;
+        this._wasRemovedFromContext = false;
+        this._shouldRemoveFromContext = false;
     }
 
     initialize(contextManager, trigger = undefined, updatePatient = true, shortcutData = "") {
@@ -33,6 +35,9 @@ export default class InsertValue extends Shortcut {
             this.text = shortcutDataObj.text;
             const valueObject = this.patient.getEntryById(shortcutDataObj.entryId);
             this.setValueObject(valueObject);
+            if (shortcutDataObj.wasRemovedFromContext) {
+                this._shouldRemoveFromContext = true;
+            }
         }
     }
 
@@ -170,7 +175,7 @@ export default class InsertValue extends Shortcut {
     }
 
     isContext() {
-        return this.metadata.isContext;
+        return this.metadata.isContext && !this._shouldRemoveFromContext;
     }
 
     getLabel() {
@@ -203,6 +208,7 @@ export default class InsertValue extends Shortcut {
             const shortcutDataObj = {
                 text,
                 entryId: this.valueObject.entryInfo.entryId,
+                wasRemovedFromContext: this._wasRemovedFromContext,
             };
             return `${this.initiatingTrigger}[[${JSON.stringify(shortcutDataObj)}]]`;
         }
@@ -215,6 +221,10 @@ export default class InsertValue extends Shortcut {
         const object = this._resolveCallSpec(callSpec, contextManager, selectedValue);
 
         return object;
+    }
+
+    setWasRemovedFromContext(value) {
+        this._wasRemovedFromContext = value;
     }
 
     setText(text) {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -8,6 +8,7 @@ export default class InsertValue extends Shortcut {
         super();
         this.metadata = metadata;
         this.text = null;
+        this.originalText = null;
         this.patient = patient;
         this._wasRemovedFromContext = false;
         this._shouldRemoveFromContext = false;
@@ -179,7 +180,7 @@ export default class InsertValue extends Shortcut {
     }
 
     getLabel() {
-        return this.getText();
+        return this.getOriginalText() ? this.getOriginalText() : this.getText();
     }
 
     getId() {
@@ -229,6 +230,14 @@ export default class InsertValue extends Shortcut {
 
     setText(text) {
         this.text = text;
+    }
+
+    setOriginalText(text) {
+        this.originalText = text;
+    }
+
+    getOriginalText() {
+        return this.originalText;
     }
 
     setValueObject(valueObject) {

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -37,6 +37,7 @@ export default class InsertValue extends Shortcut {
             if (shortcutDataObj.originalText) this.setOriginalText(shortcutDataObj.originalText);
             const valueObject = this.patient.getEntryById(shortcutDataObj.entryId);
             this.setValueObject(valueObject);
+            this.setWasRemovedFromContext(shortcutDataObj.wasRemovedFromContext);
             if (shortcutDataObj.wasRemovedFromContext) {
                 this._shouldRemoveFromContext = true;
             }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -34,6 +34,7 @@ export default class InsertValue extends Shortcut {
             // Parse shortcutData and find value object by entryId
             const shortcutDataObj = JSON.parse(shortcutData);
             this.text = shortcutDataObj.text;
+            if (shortcutDataObj.originalText) this.setOriginalText(shortcutDataObj.originalText);
             const valueObject = this.patient.getEntryById(shortcutDataObj.entryId);
             this.setValueObject(valueObject);
             if (shortcutDataObj.wasRemovedFromContext) {
@@ -206,6 +207,7 @@ export default class InsertValue extends Shortcut {
                 text,
                 entryId: this.valueObject.entryInfo.entryId,
                 wasRemovedFromContext: this._wasRemovedFromContext,
+                originalText: this.originalText,
             };
             return `${this.initiatingTrigger}[[${JSON.stringify(shortcutDataObj)}]]`;
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -182,13 +182,23 @@ export default class InsertValue extends Shortcut {
     }
 
     getText() {
-        return this.text ? this.text : this.initiatingTrigger;
+        if (Lang.isArray(this.text)) {
+            return this.text ? this.text.map(c => c[0]).join('') : this.initiatingTrigger
+        } else {
+            return this.text ? this.text : this.initiatingTrigger;
+        }
+    }
+
+    getArrayOfText() {
+        return Lang.isArray(this.text) ? this.text : [];
     }
 
     getResultText() {
         let text = this.text;
         if (typeof text === "string" && text.startsWith(this.getPrefixCharacter())) {
             text = text.substring(1);
+        } else if (Lang.isArray(text)) {
+            text = text.map(c => c[0]).join('');
         }
         // If this.valueObject exists, put the entryId of the valueObject in the result text
         if (this.valueObject) {

--- a/src/shortcuts/Placeholder.jsx
+++ b/src/shortcuts/Placeholder.jsx
@@ -1,4 +1,4 @@
-import Lang from 'lodash';
+import { v4 } from 'uuid';
 class Placeholder {
     constructor(placeholderText, shortcutName, data, metadata, shortcutManager, contextManager, patient, clinicalNote, setForceRefresh) {
         this._placeholderText = placeholderText;
@@ -9,7 +9,7 @@ class Placeholder {
         this._patient = patient;
         this._clinicalNote = clinicalNote;
         this._setForceRefresh = setForceRefresh;
-        this.uniqueId = Lang.uniqueId('placeholder-');
+        this.uniqueId = v4();
         let shortcuts = [];
         if (data) {
             let parsedData = JSON.parse(data);

--- a/src/shortcuts/Placeholder.jsx
+++ b/src/shortcuts/Placeholder.jsx
@@ -1,3 +1,4 @@
+import Lang from 'lodash';
 class Placeholder {
     constructor(placeholderText, shortcutName, data, metadata, shortcutManager, contextManager, patient, clinicalNote, setForceRefresh) {
         this._placeholderText = placeholderText;
@@ -8,6 +9,7 @@ class Placeholder {
         this._patient = patient;
         this._clinicalNote = clinicalNote;
         this._setForceRefresh = setForceRefresh;
+        this.uniqueId = Lang.uniqueId('placeholder-');
         let shortcuts = [];
         if (data) {
             let parsedData = JSON.parse(data);

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -2,6 +2,7 @@ import Context from '../context/Context';
 //import React from 'react';
 import Lang from 'lodash';
 import moment from 'moment';
+import { v4 } from 'uuid';
 
 class Shortcut extends Context {
     constructor() {
@@ -11,7 +12,7 @@ class Shortcut extends Context {
         }
         this.optionsToSelectFrom = null;
         this.valueChangeHandlers = {};
-        this.uniqueId = Lang.uniqueId('shortcut-');
+        this.uniqueId = v4();
     }
     
     initialize(contextManager, trigger = undefined, updatePatient = true) {

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -11,6 +11,7 @@ class Shortcut extends Context {
         }
         this.optionsToSelectFrom = null;
         this.valueChangeHandlers = {};
+        this.uniqueId = Lang.uniqueId('shortcut-');
     }
     
     initialize(contextManager, trigger = undefined, updatePatient = true) {

--- a/src/shortcuts/StructuredFieldMapManager.js
+++ b/src/shortcuts/StructuredFieldMapManager.js
@@ -1,7 +1,8 @@
 class StructuredFieldMapManager { 
     constructor () { 
         this._keyToShortcutMap = new Map();
-        this._idToShortcutMap = new Map()
+        this._idToShortcutMap = new Map();
+        this._idToKeysMap = new Map();
         this._placeholders = [];
     }
 
@@ -33,6 +34,14 @@ class StructuredFieldMapManager {
 
     set idToShortcutMap(idToShortcutMap) { 
         this._idToShortcutMap = idToShortcutMap;
+    }
+
+    get idToKeysMap() {
+        return this._idToKeysMap;
+    }
+
+    set idToKeysMap(idToKeysMap) {
+        this._idToKeysMap = idToKeysMap;
     }
 
     addPlaceholder(placeholder) {

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -420,11 +420,11 @@ describe('6 FluxNotesEditor', function() {
 
         // Check structured phrases
         const structuredField = wrapper.find('.structured-field-inserter');
-        expect(structuredField.at(0).text()).to.equal(`Test Name `);
-        expect(structuredField.at(1).text()).to.equal(`49 `);
-        expect(structuredField.at(2).text()).to.equal(`Female `);
+        expect(structuredField.at(0).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(`Test Name`);
+        expect(structuredField.at(1).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(`49`);
+        expect(structuredField.at(2).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(`Female`);
         // Check full text
-        expect(wrapper.find('.editor-content').text()).to.contains('Test Name  is a  49  year old  Female  coming in for follow up.')
+        expect(wrapper.find('.editor-content').text().replace(/[^\x20-\x7E]+/g, "")).to.equals('Test Name is a 49 year old Female coming in for follow up.');
     });
 
     // it.only('In pre-encounter mode, clicking the "New Note" button clears the editor content', () => {
@@ -762,8 +762,8 @@ describe('6 FluxNotesEditor', function() {
 
         // let noteContent = ' #staging t2 n2 m1';
         const arrayOfStructuredDataToEnter = ["@condition[[{\"text\":\"Invasive ductal carcinoma of breast\",\"entryId\":\"8\"}]] ", "#staging ", "t2 ", "n2 ", "m1 "];
-        const arrayOfExpectedStructuredDataInserters = ["Invasive ductal carcinoma of breast "];
-        const arrayOfExpectedStructuredDataCreators = ["staging ", "t2 ", "n2 ", "m1 "];
+        const arrayOfExpectedStructuredDataInserters = ["Invasive ductal carcinoma of breast"];
+        const arrayOfExpectedStructuredDataCreators = ["staging", "t2", "n2", "m1"];
         const entryId = patient.addClinicalNote('', '', '', '', '', arrayOfStructuredDataToEnter.join(' '), false);
         const updatedEditorNote = patient.getEntryById(entryId);
         // Set updatedEditorNote props because this triggers that a change is coming in to the editor and inserts text with structured phrases.
@@ -773,7 +773,7 @@ describe('6 FluxNotesEditor', function() {
         const structuredFieldInserter = wrapper.find('.structured-field-inserter');
         expect(structuredFieldInserter).to.have.lengthOf(arrayOfExpectedStructuredDataInserters.length)
         for (let index = 0; index < arrayOfExpectedStructuredDataInserters.length; index++) {
-            expect(structuredFieldInserter.at(index).text()).to.contain(arrayOfExpectedStructuredDataInserters[index]);
+            expect(structuredFieldInserter.at(index).text().replace(/[^\x20-\x7E]+/g, "")).to.equals(arrayOfExpectedStructuredDataInserters[index]);
         }
         // Check structured phrases creators
         const structuredFieldCreator = wrapper.find('.structured-field-creator');
@@ -784,7 +784,7 @@ describe('6 FluxNotesEditor', function() {
         // Check full text
         const editorContent = wrapper.find('.editor-content');
         for (let index = 0; index < arrayOfExpectedStructuredDataInserters.length; index++) {
-            expect(editorContent.text()).to.contain(arrayOfExpectedStructuredDataInserters[index]);
+            expect(editorContent.text().replace(/[^\x20-\x7E]+/g, "")).to.contain(arrayOfExpectedStructuredDataInserters[index]);
         }
         for (let index = 0; index < arrayOfExpectedStructuredDataCreators.length; index++) {
             expect(editorContent.text()).to.contain(arrayOfExpectedStructuredDataCreators[index]);
@@ -980,7 +980,7 @@ describe('6 FluxNotesEditor', function() {
         expect(notesPanelWrapper.find(NoteAssistant)).to.have.lengthOf(1);
 
         const arrayOfStructuredDataToEnter = ["@condition[[{\"text\":\"Invasive ductal carcinoma of breast\",\"entryId\":\"8\"}]] ", "#PR ", "#Positive "];
-        const arrayOfExpectedStructuredDataInserter = ["Invasive ductal carcinoma of breast "]
+        const arrayOfExpectedStructuredDataInserter = ["Invasive ductal carcinoma of breast"]
         const arrayOfExpectedStructuredDataCreator = ["PR ", "Positive "]
         const entryId = patient.addClinicalNote('', '', '', '', '', arrayOfStructuredDataToEnter.join(' '), false);
         const updatedEditorNote = patient.getEntryById(entryId);
@@ -993,7 +993,7 @@ describe('6 FluxNotesEditor', function() {
         const structuredFieldInserter = notesPanelWrapper.find('.structured-field-inserter');
         expect(structuredFieldInserter).to.have.lengthOf(arrayOfExpectedStructuredDataInserter.length)
         for (let index = 0; index < arrayOfExpectedStructuredDataInserter.length; index++) {
-            expect(structuredFieldInserter.at(index).text()).to.contain(arrayOfExpectedStructuredDataInserter[index]);
+            expect(structuredFieldInserter.at(index).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(arrayOfExpectedStructuredDataInserter[index]);
         }
         const structuredFieldCreator = notesPanelWrapper.find('.structured-field-creator');
         expect(structuredFieldCreator).to.have.lengthOf(arrayOfExpectedStructuredDataCreator.length)
@@ -1003,7 +1003,7 @@ describe('6 FluxNotesEditor', function() {
         // Check full text
         const editorContentInserter = notesPanelWrapper.find('.editor-content');
         for (let index = 0; index < arrayOfExpectedStructuredDataInserter.length; index++) {
-            expect(editorContentInserter.text()).to.contain(arrayOfExpectedStructuredDataInserter[index]);
+            expect(editorContentInserter.text().replace(/[^\x20-\x7E]+/g, "")).to.contain(arrayOfExpectedStructuredDataInserter[index]);
         }
         const editorContentCreator = notesPanelWrapper.find('.editor-content');
         for (let index = 0; index < arrayOfExpectedStructuredDataCreator.length; index++) {
@@ -1200,7 +1200,7 @@ describe('6 FluxNotesEditor', function() {
 
         // let noteContent = ' #staging t2 n2 m1';
         const arrayOfShortcutText = ["@condition[[{\"text\":\"Invasive ductal carcinoma of breast\",\"entryId\":\"8\"}]] ", "#toxicity ", "#nausea ", "#disease status ", "#imaging "];
-        const arrayOfParsedShortcutTextInserter = ["Invasive ductal carcinoma of breast "]
+        const arrayOfParsedShortcutTextInserter = ["Invasive ductal carcinoma of breast"]
         const arrayOfParsedShortcutTextCreator = ["toxicity ", "nausea ", "disease status ", "imaging "]
         const entryId = patient.addClinicalNote('', '', '', '', '', arrayOfShortcutText.join(' '), false);
         const updatedEditorNote = patient.getEntryById(entryId);
@@ -1211,7 +1211,7 @@ describe('6 FluxNotesEditor', function() {
         const structuredFieldInserter = wrapper.find('.structured-field-inserter');
         expect(structuredFieldInserter).to.have.lengthOf(arrayOfParsedShortcutTextInserter.length)
         for (let index = 0; index < arrayOfParsedShortcutTextInserter.length; index++) {
-            expect(structuredFieldInserter.at(index).text()).to.contain(arrayOfParsedShortcutTextInserter[index]);
+            expect(structuredFieldInserter.at(index).text().replace(/[^\x20-\x7E]+/g, "")).to.equals(arrayOfParsedShortcutTextInserter[index]);
         }
         const structuredFieldCreator = wrapper.find('.structured-field-creator');
         expect(structuredFieldCreator).to.have.lengthOf(arrayOfParsedShortcutTextCreator.length)

--- a/test/backend/views/FullApp.test.js
+++ b/test/backend/views/FullApp.test.js
@@ -361,6 +361,12 @@ describe('6 FluxNotesEditor', function() {
             }
         };
     })
+
+    // Replace a zero-width-space with nothing to strip out the non-printable character during testing
+    function replaceZeroWidthSpace(text) {
+        return text.replace(/\u200B/g, "");
+    }
+
     it('6.1 inserts supplied text for inserter shortcuts', () => {
         // Set up Managers that are needed by FluxNotesEditor
         let patient = new PatientRecord(hardCodedPatient);
@@ -420,11 +426,11 @@ describe('6 FluxNotesEditor', function() {
 
         // Check structured phrases
         const structuredField = wrapper.find('.structured-field-inserter');
-        expect(structuredField.at(0).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(`Test Name`);
-        expect(structuredField.at(1).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(`49`);
-        expect(structuredField.at(2).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(`Female`);
+        expect(replaceZeroWidthSpace(structuredField.at(0).text())).to.equal(`Test Name`);
+        expect(replaceZeroWidthSpace(structuredField.at(1).text())).to.equal(`49`);
+        expect(replaceZeroWidthSpace(structuredField.at(2).text())).to.equal(`Female`);
         // Check full text
-        expect(wrapper.find('.editor-content').text().replace(/[^\x20-\x7E]+/g, "")).to.equals('Test Name is a 49 year old Female coming in for follow up.');
+        expect(replaceZeroWidthSpace(wrapper.find('.editor-content').text())).to.contain('Test Name is a 49 year old Female coming in for follow up.');
     });
 
     // it.only('In pre-encounter mode, clicking the "New Note" button clears the editor content', () => {
@@ -773,7 +779,7 @@ describe('6 FluxNotesEditor', function() {
         const structuredFieldInserter = wrapper.find('.structured-field-inserter');
         expect(structuredFieldInserter).to.have.lengthOf(arrayOfExpectedStructuredDataInserters.length)
         for (let index = 0; index < arrayOfExpectedStructuredDataInserters.length; index++) {
-            expect(structuredFieldInserter.at(index).text().replace(/[^\x20-\x7E]+/g, "")).to.equals(arrayOfExpectedStructuredDataInserters[index]);
+            expect(replaceZeroWidthSpace(structuredFieldInserter.at(index).text())).to.equal(arrayOfExpectedStructuredDataInserters[index]);
         }
         // Check structured phrases creators
         const structuredFieldCreator = wrapper.find('.structured-field-creator');
@@ -784,7 +790,7 @@ describe('6 FluxNotesEditor', function() {
         // Check full text
         const editorContent = wrapper.find('.editor-content');
         for (let index = 0; index < arrayOfExpectedStructuredDataInserters.length; index++) {
-            expect(editorContent.text().replace(/[^\x20-\x7E]+/g, "")).to.contain(arrayOfExpectedStructuredDataInserters[index]);
+            expect(replaceZeroWidthSpace(editorContent.text())).to.contain(arrayOfExpectedStructuredDataInserters[index]);
         }
         for (let index = 0; index < arrayOfExpectedStructuredDataCreators.length; index++) {
             expect(editorContent.text()).to.contain(arrayOfExpectedStructuredDataCreators[index]);
@@ -993,7 +999,7 @@ describe('6 FluxNotesEditor', function() {
         const structuredFieldInserter = notesPanelWrapper.find('.structured-field-inserter');
         expect(structuredFieldInserter).to.have.lengthOf(arrayOfExpectedStructuredDataInserter.length)
         for (let index = 0; index < arrayOfExpectedStructuredDataInserter.length; index++) {
-            expect(structuredFieldInserter.at(index).text().replace(/[^\x20-\x7E]+/g, "")).to.equal(arrayOfExpectedStructuredDataInserter[index]);
+            expect(replaceZeroWidthSpace(structuredFieldInserter.at(index).text())).to.equal(arrayOfExpectedStructuredDataInserter[index]);
         }
         const structuredFieldCreator = notesPanelWrapper.find('.structured-field-creator');
         expect(structuredFieldCreator).to.have.lengthOf(arrayOfExpectedStructuredDataCreator.length)
@@ -1003,7 +1009,7 @@ describe('6 FluxNotesEditor', function() {
         // Check full text
         const editorContentInserter = notesPanelWrapper.find('.editor-content');
         for (let index = 0; index < arrayOfExpectedStructuredDataInserter.length; index++) {
-            expect(editorContentInserter.text().replace(/[^\x20-\x7E]+/g, "")).to.contain(arrayOfExpectedStructuredDataInserter[index]);
+            expect(replaceZeroWidthSpace(editorContentInserter.text())).to.contain(arrayOfExpectedStructuredDataInserter[index]);
         }
         const editorContentCreator = notesPanelWrapper.find('.editor-content');
         for (let index = 0; index < arrayOfExpectedStructuredDataCreator.length; index++) {
@@ -1211,7 +1217,7 @@ describe('6 FluxNotesEditor', function() {
         const structuredFieldInserter = wrapper.find('.structured-field-inserter');
         expect(structuredFieldInserter).to.have.lengthOf(arrayOfParsedShortcutTextInserter.length)
         for (let index = 0; index < arrayOfParsedShortcutTextInserter.length; index++) {
-            expect(structuredFieldInserter.at(index).text().replace(/[^\x20-\x7E]+/g, "")).to.equals(arrayOfParsedShortcutTextInserter[index]);
+            expect(replaceZeroWidthSpace(structuredFieldInserter.at(index).text())).to.equal(arrayOfParsedShortcutTextInserter[index]);
         }
         const structuredFieldCreator = wrapper.find('.structured-field-creator');
         expect(structuredFieldCreator).to.have.lengthOf(arrayOfParsedShortcutTextCreator.length)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,10 +3494,6 @@ growly@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
-guid@0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/guid/-/guid-0.0.12.tgz#9137c52b185f7de12490b9bebcc1660b9025fe0c"
-
 gzip-size@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

I worked with @mgramigna on this.

This pull requests addresses Jira 1555 and supports editing inserter structured phrases. You can now add click or arrow key inside an inserter structured phrase and add new text inside of it. This text will show up black instead of grey since it is not part of the record. Context is only set for the last chuck of original shortcut text. Contexts are displayed correctly in the context tray and breadcrumbs when typing. The new text and contexts remain correct when reopening the note.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
