### PR TITLE
Newline structured data bug

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -603,17 +603,16 @@ class FluxNotesEditor extends React.Component {
 
     scrollToAnchorEl = () => {
         const anchorEl = Slate.findDOMNode(this.state.state.anchorBlock);
-        const anchorBottom = anchorEl.offsetTop + anchorEl.clientHeight;
-        const documentEl = Slate.findDOMNode(this.state.state.document);
-        const documentBottom = documentEl.offsetTop + documentEl.clientHeight;
+        const anchorBottom = anchorEl.getBoundingClientRect().top + anchorEl.getBoundingClientRect().height;
+        const editorEl = document.getElementsByClassName('editor-content')[0];
+        const editorBottom = editorEl.getBoundingClientRect().top + editorEl.getBoundingClientRect().height;
         let anchorElInView = true;
 
         // add a slight offset to the anchor bottom to account for padding
-        if (anchorBottom + 2 > documentBottom) anchorElInView = false;
+        if (anchorBottom + 2 > editorBottom) anchorElInView = false;
 
-        // only scroll if the element is partially out of view (i.e. the dashed line is hidden)
         if (anchorEl && anchorEl.scrollIntoView && !anchorElInView) {
-            anchorEl.scrollIntoView();
+            anchorEl.scrollIntoView({block: 'end'});
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -602,17 +602,17 @@ class FluxNotesEditor extends React.Component {
     }
 
     scrollToAnchorEl = () => {
-        const anchorEl = Slate.findDOMNode(this.state.state.anchorBlock);
-        const anchorBottom = anchorEl.getBoundingClientRect().top + anchorEl.getBoundingClientRect().height;
-        const editorEl = document.getElementsByClassName('editor-content')[0];
-        const editorBottom = editorEl.getBoundingClientRect().top + editorEl.getBoundingClientRect().height;
-        let anchorElInView = true;
+        const anchorElement = Slate.findDOMNode(this.state.state.anchorBlock);
+        const anchorBottom = anchorElement.getBoundingClientRect().top + anchorElement.getBoundingClientRect().height;
+        const editorElement = document.getElementsByClassName('editor-content')[0];
+        const editorBottom = editorElement.getBoundingClientRect().top + editorElement.getBoundingClientRect().height;
+        let anchorElementInView = true;
 
         // add a slight offset to the anchor bottom to account for padding
-        if (anchorBottom + 2 > editorBottom) anchorElInView = false;
+        if (anchorBottom + 2 > editorBottom) anchorElementInView = false;
 
-        if (anchorEl && anchorEl.scrollIntoView && !anchorElInView) {
-            anchorEl.scrollIntoView({block: 'end'});
+        if (anchorElement && anchorElement.scrollIntoView && !anchorElementInView) {
+            anchorElement.scrollIntoView({block: 'end'});
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -446,7 +446,7 @@ class FluxNotesEditor extends React.Component {
     insertStructuredFieldTransform = (transform, shortcut) => {
         if (Lang.isNull(shortcut)) return transform.focus();
         const result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
-        this.scrollToAnchorEl();
+        this.scrollToAnchorElement();
         return result[0];
     }
 
@@ -601,7 +601,7 @@ class FluxNotesEditor extends React.Component {
         }
     }
 
-    scrollToAnchorEl = () => {
+    scrollToAnchorElement = () => {
         const anchorElement = Slate.findDOMNode(this.state.state.anchorBlock);
         const anchorBottom = anchorElement.getBoundingClientRect().top + anchorElement.getBoundingClientRect().height;
         const editorElement = document.getElementsByClassName('editor-content')[0];
@@ -748,7 +748,7 @@ class FluxNotesEditor extends React.Component {
             if (nextProps.shouldRevertTemplate) {
                 this.revertTemplate();
             }
-            this.scrollToAnchorEl();
+            this.scrollToAnchorElement();
         }
 
         // The note will still scroll to structured data when the user clicks on `Open Source Note` action but note is already open

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -1369,7 +1369,9 @@ class FluxNotesEditor extends React.Component {
                 }
             });
         } else {
-            this.setState({ state });
+            this.setState({ state }, () => {
+                if (source === 'paste') this.scrollToAnchorElement();
+            });
         }
     }
 

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -446,6 +446,7 @@ class FluxNotesEditor extends React.Component {
     insertStructuredFieldTransform = (transform, shortcut) => {
         if (Lang.isNull(shortcut)) return transform.focus();
         const result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
+        this.scrollToData(this.state.state.document, shortcut.key);
 
         return result[0];
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -603,7 +603,16 @@ class FluxNotesEditor extends React.Component {
 
     scrollToAnchorEl = () => {
         const anchorEl = Slate.findDOMNode(this.state.state.anchorBlock);
-        if (anchorEl && anchorEl.scrollIntoView) {
+        const anchorBottom = anchorEl.offsetTop + anchorEl.clientHeight;
+        const documentEl = Slate.findDOMNode(this.state.state.document);
+        const documentBottom = documentEl.offsetTop + documentEl.clientHeight;
+        let anchorElInView = true;
+
+        // add a slight offset to the anchor bottom to account for padding
+        if (anchorBottom + 2 > documentBottom) anchorElInView = false;
+
+        // only scroll if the element is partially out of view (i.e. the dashed line is hidden)
+        if (anchorEl && anchorEl.scrollIntoView && !anchorElInView) {
             anchorEl.scrollIntoView();
         }
     }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -446,8 +446,7 @@ class FluxNotesEditor extends React.Component {
     insertStructuredFieldTransform = (transform, shortcut) => {
         if (Lang.isNull(shortcut)) return transform.focus();
         const result = this.structuredFieldPlugin.transforms.insertStructuredField(transform, shortcut);
-        this.scrollToData(this.state.state.document, shortcut.key);
-
+        this.scrollToAnchorEl();
         return result[0];
     }
 
@@ -602,6 +601,13 @@ class FluxNotesEditor extends React.Component {
         }
     }
 
+    scrollToAnchorEl = () => {
+        const anchorEl = Slate.findDOMNode(this.state.state.anchorBlock);
+        if (anchorEl && anchorEl.scrollIntoView) {
+            anchorEl.scrollIntoView();
+        }
+    }
+
     updateTemplateWithPickListOptions = (nextProps) => {
         if (nextProps.shouldUpdateShortcutType) {
             let transform = this.state.state.transform();
@@ -734,10 +740,7 @@ class FluxNotesEditor extends React.Component {
             if (nextProps.shouldRevertTemplate) {
                 this.revertTemplate();
             }
-            const anchorEl = Slate.findDOMNode(this.state.state.anchorBlock);
-            if (anchorEl && anchorEl.scrollIntoView) {
-                anchorEl.scrollIntoView();
-            }
+            this.scrollToAnchorEl();
         }
 
         // The note will still scroll to structured data when the user clicks on `Open Source Note` action but note is already open

--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -147,7 +147,7 @@
         border-bottom: 1.5px dashed $shr-context-line;
     }
     
-    div:last-child {
+    div {
         padding-bottom: 2px;
     }
 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -273,13 +273,13 @@ function StructuredFieldPlugin(opts) {
             // NoteParser also overrides this function since there is no slate
             const saveIsBlock1BeforeBlock2 = contextManager.getIsBlock1BeforeBlock2();
             contextManager.setIsBlock1BeforeBlock2(() => { return false; });
-            insertText(decoded, undefined, true, true, 'paste');
+            insertText(decoded, undefined, true, 'paste');
             contextManager.setIsBlock1BeforeBlock2(saveIsBlock1BeforeBlock2);
             event.preventDefault();
             return state;
         } else if (data.text) {
             event.preventDefault();
-            insertText(data.text, undefined, true, true, 'paste');
+            insertText(data.text, undefined, true, 'paste');
             return state;
         }
     }


### PR DESCRIPTION
Added a scrollIntoView that fires anytime structured data is created in the editor.  This should only adjust the scrolling if the structured data dashed line is out of view, not in the middle of the editor.  Try adding structured data in all ways at the bottom of the note as well as in the middle of the note.

Potential shortfall:  the scrollIntoView options are not supported in Safari and I believe IE (see here: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).  The affect this has is if you add structured data to a line at the bottom of the editor but it is not the last line of the note (i.e. there are more lines hidden that will show if you scroll down), then the scroll that adjusts the view to see the dotted line does not place it at the bottom of the screen like it does in chrome, but it tries to scroll it as much to the center as possible.  I think this is a pretty rare situation and there is no issue in chrome, but let me know what you all think.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [ ] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [ ] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
