### PR TITLE
Marks in inserters

### DIFF
--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -35,8 +35,8 @@ const schema = {
         heading: props => <h1 {...props.attributes}>{props.children}</h1>,
         'bulleted-list-item': props => <li {...props.attributes}>{props.children}</li>,
         'numbered-list-item': props => <li {...props.attributes}>{props.children}</li>,
-        'bulleted-list': props => <ul {...props.attributes}>{props.children}</ul>,
-        'numbered-list': props => <ol {...props.attributes}>{props.children}</ol>,
+        'bulleted-list': props => <ul style={{ position: 'relative' }} {...props.attributes}>{props.children}</ul>,
+        'numbered-list': props => <ol style={{ position: 'relative' }}{...props.attributes}>{props.children}</ol>,
     },
     marks: {
         "bold": (props) => <strong>{props.children}</strong>,

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -19,6 +19,13 @@ function stopEventPropagation(e) {
     e.stopPropagation();
 }
 
+function applyMarks(marks, transform) {
+    marks.forEach(mark => {
+        transform = transform.toggleMark(mark.type);
+    });
+    return transform;
+}
+
 function updateShortcut(shortcut, transform, key, label, text) {
     shortcut.setOriginalText(label);
     shortcut.setText(text);
@@ -78,7 +85,9 @@ function StructuredFieldPlugin(opts) {
                 newTextNode = transform.state.document.getPreviousText(key);
             }
 
-            transform = transform.collapseToEndOf(newTextNode).insertText(e.key);
+            transform = transform.collapseToEndOf(newTextNode);
+            transform = applyMarks(state.marks, transform);
+            transform = transform.insertText(e.key);
 
             // Create a new shortcut with the trailing shortcut text after split
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
@@ -127,6 +136,7 @@ function StructuredFieldPlugin(opts) {
             const key = transform.state.selection.anchorKey;
             const newTextNode = transform.state.document.getPreviousText(key);
             transform = transform.collapseToEndOf(newTextNode);
+            transform = applyMarks(state.marks, transform);
 
             // Create a new shortcut with the trailing shortcut text after split
             const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

This addresses Jira 1734. When you are inside of an inserter structured field and enable one of the bold/italics/underline buttons, beginning to type at the same cursor location will apply those styles to the text. It will also apply the styles to text if you immediately hit enter and start typing. I also added a css attribute to our rendering of lists so that it would match what slate has for regular <div> blocks.

While looking into the styling, I noticed two bugs that are on fluxnotes.org, and I'm pretty confident they've been there for a while, so I made Jiras for both. One is if you create a list with two structured phrases in two bullet points and close and reopen the note, you get into an infinite loop. The other is if you create a list with one structured phrase in a bullet and close and reopen the note, the list has an extra bullet point.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
