### PR TITLE
Ccp table legend

### DIFF
--- a/src/mcode-pilot/components/TreatmentOptionsOutcomes/TreatmentOptionsOutcomes.jsx
+++ b/src/mcode-pilot/components/TreatmentOptionsOutcomes/TreatmentOptionsOutcomes.jsx
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { isSame, getCombinations } from '../../utils/arrayCompare';
 
 import BarChart from '../../visualizations/BarChart/BarChart';
+import TableLegend from '../../visualizations/TableLegend/TableLegend';
 import TreatmentsPopover from '../TreatmentsPopover/TreatmentsPopover';
 
 import './TreatmentOptionsOutcomes.css';
@@ -299,6 +300,7 @@ export default class TreatmentOptionsOutcomes extends Component {
                         )}
                     </div>
                 </div>
+                <TableLegend includedRow={includedRow} treatmentNames ={TREATMENT_NAMES}/>
             </div>
         );
     }

--- a/src/mcode-pilot/components/TreatmentOptionsOutcomes/TreatmentOptionsOutcomes.jsx
+++ b/src/mcode-pilot/components/TreatmentOptionsOutcomes/TreatmentOptionsOutcomes.jsx
@@ -300,7 +300,7 @@ export default class TreatmentOptionsOutcomes extends Component {
                         )}
                     </div>
                 </div>
-                <TableLegend includedRow={includedRow} treatmentNames ={TREATMENT_NAMES}/>
+                <TableLegend includedRow={includedRow} treatmentNames={TREATMENT_NAMES}/>
             </div>
         );
     }

--- a/src/mcode-pilot/visualizations/BarChart/BarChart.jsx
+++ b/src/mcode-pilot/visualizations/BarChart/BarChart.jsx
@@ -10,7 +10,18 @@ export default class BarChart extends Component {
         if (percentChange < 0) {
             // style for when survival decreases (red)
             mainStyle = {"width": `${survivedPercent}%`, "backgroundColor": "#9e9e9e" };
-            changeStyle = {"width": `${Math.abs(percentChange)}%`, "backgroundColor": "#e13949" };
+            changeStyle = {"width": `${Math.abs(roundedPercent)}%`, "background": `repeating-linear-gradient(
+                45deg,
+                transparent,
+                transparent 2px,
+                #EC9696 2px,
+                #EC9696 4px
+              ),
+              linear-gradient(
+                to bottom,
+                #9e9e9e,
+                #9e9e9e
+              )`  };
             textStyle = { "color": "#d9534f" };
         } else {
             // styles for when survival increases (green)

--- a/src/mcode-pilot/visualizations/BarChart/BarChart.jsx
+++ b/src/mcode-pilot/visualizations/BarChart/BarChart.jsx
@@ -5,7 +5,7 @@ import FontAwesome from 'react-fontawesome';
 import './BarChart.css';
 
 export default class BarChart extends Component {
-    getStyles = (survivedPercent, compareToPercent, percentChange) => {
+    getStyles = (survivedPercent, compareToPercent, percentChange, roundedPercent) => {
         let mainStyle, changeStyle, textStyle;
         if (percentChange < 0) {
             // style for when survival decreases (red)
@@ -44,7 +44,7 @@ export default class BarChart extends Component {
             compareToPercent = compareToNumerator / compareToDenominator * 100;
             roundedPercent = Math.floor(survivedPercent - compareToPercent);
             percentChange = survivedPercent - compareToPercent;
-            const styles = this.getStyles(survivedPercent, compareToPercent, percentChange);
+            const styles = this.getStyles(survivedPercent, compareToPercent, percentChange, roundedPercent);
             mainStyle = styles.mainStyle;
             changeStyle = styles.changeStyle;
             textStyle = styles.textStyle;
@@ -66,6 +66,7 @@ export default class BarChart extends Component {
                     <div className="progress-bar">
                         <div className="prog-fill" style={mainStyle}></div>
                         {hasCompare && <div className="prog-fill" style={changeStyle}></div>}
+                        <div className="prog-fill-empty"></div>
                     </div>
                 </div>
             </div>

--- a/src/mcode-pilot/visualizations/BarChart/BarChart.scss
+++ b/src/mcode-pilot/visualizations/BarChart/BarChart.scss
@@ -26,6 +26,7 @@ $color-background: #9e9e9e;
     }
 
     .prog-fill {
+        background-size:6px !important;
         display: inline-block;
         padding: 0;
         height: 12px;

--- a/src/mcode-pilot/visualizations/BarChart/BarChart.scss
+++ b/src/mcode-pilot/visualizations/BarChart/BarChart.scss
@@ -20,20 +20,26 @@ $color-background: #9e9e9e;
 
     .progress-bar {
         display: flex;
-        height: 12px;
+        height: 100%;
         position: relative;
-        border: 1px solid $color-border;
         background-color: $color-white;
     }
 
     .prog-fill {
         display: inline-block;
         padding: 0;
-        height: 100%;
+        height: 12px;
         width: 0;
         background-color: $color-background;
     }
 
+    .prog-fill-empty {
+        border-style: solid;
+        border-color: $color-border;
+        border-width:1px 1px 1px 0;
+        flex-grow:100;
+
+    }
     .tiny-arrow {
         opacity: 0.75;
         padding-right: 2px;

--- a/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
+++ b/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
@@ -19,7 +19,7 @@ export default class TableLegend extends Component {
         }
         const mainStyle = {"width": `45px`};
         const treatmentStyle = {"width":"10px", "backgroundColor":"#91bd7b"};
-        const redTreatmentStyle = {"width": "13px", "background": `repeating-linear-gradient(
+        const redTreatmentStyle = {"width": "14px", "background": `repeating-linear-gradient(
             45deg,
             transparent,
             transparent 2px,
@@ -30,7 +30,7 @@ export default class TableLegend extends Component {
             to bottom,
             #FFFFFF,
             #FFFFFF
-          )`  };
+          )`};
         const cancerStyle = {"width":"20px"};
         return (
             <div className="table-legend">

--- a/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
+++ b/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import FontAwesome from 'react-fontawesome';
 
 import './TableLegend.css';
 

--- a/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
+++ b/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
@@ -46,7 +46,7 @@ export default class TableLegend extends Component {
                         <div className="prog-fill-container">
                             <div className="prog-fill" style={treatmentStyle}/>
                         </div>
-                        <span className="legend-text">additional survivors due to treatment</span>
+                        <span className="legend-text">increase in survival due to treatment</span>
                     </div>
 
                     <div className="legend-entry">

--- a/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
+++ b/src/mcode-pilot/visualizations/TableLegend/TableLegend.jsx
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+
+import './TableLegend.css';
+
+export default class TableLegend extends Component {
+
+    render() {
+        let message;
+        if(this.props.includedRow instanceof Array) {
+            // the row is empty
+            message = "survived with treatment"
+        }else{
+            const name = this.props.includedRow.name;
+            const noTreatment = this.props.treatmentNames.noTreatment===name;
+            const hasAnd = name.indexOf('&') > -1
+            message = "survived with " + (noTreatment?'no treatment':name) + (hasAnd||noTreatment?"":" alone")
+        }
+        const mainStyle = {"width": `45px`};
+        const treatmentStyle = {"width":"10px", "backgroundColor":"#91bd7b"};
+        const redTreatmentStyle = {"width": "13px", "background": `repeating-linear-gradient(
+            45deg,
+            transparent,
+            transparent 2px,
+            #EC9696 2px,
+            #EC9696 4px
+          ),
+          linear-gradient(
+            to bottom,
+            #FFFFFF,
+            #FFFFFF
+          )`  };
+        const cancerStyle = {"width":"20px"};
+        return (
+            <div className="table-legend">
+            <div className="wrapper">
+                <div className="legend-entry">
+                        <div className="prog-fill-container">
+                            <div className="prog-fill" style={mainStyle}/>
+                        </div>
+                        <span className="legend-text">{message}</span>
+                    </div>
+
+                    <div className="legend-entry">
+                        <div className="prog-fill-container">
+                            <div className="prog-fill" style={treatmentStyle}/>
+                        </div>
+                        <span className="legend-text">additional survivors due to treatment</span>
+                    </div>
+
+                    <div className="legend-entry">
+                        <div className="prog-fill-container">
+                            <div className="prog-fill" style={redTreatmentStyle}/>
+                        </div>
+                        <span className="legend-text">decrease in survival due to treatment</span>
+                    </div>
+
+                    <div className="legend-entry">
+                        <div className="prog-fill-container">
+                            <div className="progress-bar" style={cancerStyle}/>
+                        </div>
+                        <span className="legend-text">cancer related deaths</span>
+                    </div>
+                
+            </div>
+
+            </div>
+        );
+    }
+}
+
+TableLegend.propTypes = {
+    includedRow: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
+    ]),
+    treatmentNames: PropTypes.object
+};

--- a/src/mcode-pilot/visualizations/TableLegend/TableLegend.scss
+++ b/src/mcode-pilot/visualizations/TableLegend/TableLegend.scss
@@ -8,6 +8,7 @@ $color-background: #9e9e9e;
         display:inline-block;
     }
     .prog-fill {
+        background-size:6px !important;
         display: inline-block;
         padding: 0;
         height: 10px;

--- a/src/mcode-pilot/visualizations/TableLegend/TableLegend.scss
+++ b/src/mcode-pilot/visualizations/TableLegend/TableLegend.scss
@@ -1,0 +1,44 @@
+$color-white: #fff;
+$color-border: #d1d1d1;
+$color-background: #9e9e9e;
+
+.table-legend {
+    text-align: center;
+    .wrapper {
+        display:inline-block;
+    }
+    .prog-fill {
+        display: inline-block;
+        padding: 0;
+        height: 10px;
+        width: 40px;
+        background-color: $color-background;
+    }
+
+    .legend-entry {
+        display:block;
+        text-align: left;
+    }
+
+    .prog-fill-container {
+
+        display:inline-block;
+        width: 50px;
+    }
+
+    .legend-text {
+
+        font-size: 10px;
+        padding-left:10px;
+        line-height:10px;
+
+    }
+
+    .progress-bar {
+        display: flex;
+        height: 8px;
+        // position: relative;
+        border: 1px solid $color-border;
+        background-color: $color-white;
+    }
+}


### PR DESCRIPTION
These changes add a legend to the ccp outcomes table.  The legend describes the little bar components that show the % of survivors for each treatment.  The topmost legend entry will change depending on which treatment is in context (being compared to).  

This also changes the way the bar graphs show negative change in survival.  Instead of a solid block of red that represents a decrease in survival, there is now a mask that is overlaid on top of the gray bar to show that it is a decrease in survival due to _comparison_.  This was causing issues with the legend, since the meaning of the gray part of the bar changed depending on whether there was an increase or decrease in survival.  If it increased, the gray bit represents the survival due to the treatment we are comparing to, and the green bit represents the increase due to the treatment we want to compare.  If it decreased, the gray bit would now represent survival due to the treatment we want to compare.  

In any case, the new red mask solves this problem.  There was a small bug in Chrome due to this change where the gradient used to make the mask would hang off the side of its background.  Simply put, the gradient was constructed using red "stripes" in the foreground and a background that matched the preceding gray bit to make it look like one cohesive segment.  

However, due to the way Chrome renders borders, the foreground was sometimes being pushed a pixel off the background and looking odd.  This was fixed by removing the border on the bar and adding a border to only the white bit of the bar. 

I'm a bit unsure what to name the red block on the legend though.  Right now it is "decrease in survival due to treatment" which isn't really true, since it makes it sound like the treatment is killing people.  I'm considering changing it to "comparative decrease in survival" but that's also not really a good description, especially considering how the other legend entries are phrased.  

There also appears to be a few merge conflicts due to this branch being made off of Noranda's branch and pulling along some of its commits from a while ago.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
