### PR TITLE
Fix copying and pasting into inserter shortcuts

### DIFF
--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -522,7 +522,7 @@ function StructuredFieldPlugin(opts) {
         }
 
         // Create a new shortcut with the trailing shortcut text after split
-        const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
+        let newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
 
         transform = transform.collapseToEndOf(newTextNode);
         transform = applyMarks(state.marks, transform);
@@ -530,7 +530,12 @@ function StructuredFieldPlugin(opts) {
 
         // Ignore updating the latter split shortcut if it is deleted by typing a character
         if (newShortcutNode) {
+            const doc = transform.state.document;
+
+            // Search for new node with trailing shortcut text in case the node key has changed
+            newShortcutNode = getAllStructuredFields(doc.toJSON().nodes).map(n => doc.getNode(n.key)).find(n => n.key > key && n.text === newShortcutNode.text);
             let shortcutText = newShortcutNode.text;
+
             if (shortcut.valueObject) {
                 shortcutText = `{"text": "${newShortcutNode.text}", "entryId": "${shortcut.valueObject.entryInfo.entryId}"}`;
             }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -521,12 +521,12 @@ function StructuredFieldPlugin(opts) {
             newTextNode = transform.state.document.getPreviousText(key);
         }
 
+        // Create a new shortcut with the trailing shortcut text after split
+        const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
+
         transform = transform.collapseToEndOf(newTextNode);
         transform = applyMarks(state.marks, transform);
         insertText ? insertText(text, transform) : transform = transform.insertText(text);
-
-        // Create a new shortcut with the trailing shortcut text after split
-        const newShortcutNode = transform.state.document.getNextSibling(newTextNode.key);
 
         // Ignore updating the latter split shortcut if it is deleted by typing a character
         if (newShortcutNode) {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

Addresses JIRA-1747.

- Separates out logic to split up an inserter shortcut into a separate function called `splitInserterAndInsertText` so that it can be used by both `onKeyDown` and `onPaste`.
-  `onPaste` now recognizes when text is being pasted into an inserter shortcut and calls the `splitInserterAndInsertText` function.

To test:
- Copy and paste text into an inserter shortcut.  Plain text should now be inserted in between the structured field instead of grey text.


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [x] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [x] Document any new APIs/extension points
- [x] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
