### PR TITLE
Update jane dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,20 @@ If a directory is specified, every file in that directory will be treated as a n
 
 ## Patient Date Update
 
-This patient date updater is designed to change all of the dates in each of the entries in a patient JSON.  One of the parameters passed to the app is the entryid of an encounter.  The tool will calculate the difference of the current date and the date of the encounter and will add that difference to all of the dates.
+This patient date updater is designed to change all of the dates in each of the entries in a patient JSON.  One of the parameters passed to the app is the entryid of an encounter.  The tool will calculate the difference of the current date and the date of the encounter and will add that difference to all of the dates.  The tool can also output a list of all the dates in the record.
 
 The patient date updater can be executed (local command line) by running the following command:
 
 ```bash
-yarn patient-date-update <path-to-patient-json> <encounter-entryid>
+yarn patient-date-update <path-to-patient-json> [encounter-entryid] [options]
 ```
 
+Where the the available options are:
+
+`-o` -- Output a list of all the dates in the record
+`-O` -- Output a list of all the dates in the record in chronological order
+
+* If no `encounter-entryid` is provided, the program can still run and output dates, but will not update any of the dates in the record.
 * The program expects the JSON file provided to be an array of SHR entries.
 * The program will overwrite the file that was passed in and will create a backup using the same path but adding `'.backup'` to the end.
   * For example, the backup file that will be created for `HardCodedPatientMidYearDemo18.json` will named `HardCodedPatientMidYearDemo18.json.backup`.
@@ -70,10 +76,22 @@ yarn patient-date-update <path-to-patient-json> <encounter-entryid>
 For example:
 
 ```bash
-yarn patient-date-update ./src/dataaccess/HardCodedPatientMidYearDemo18.json 100
+yarn patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json 33 -o
 ```
 
-will search the patient entries for an `EncounterRequested` with an `entryid` of 100.  It will then use the `ActionContext.ExpectedPerformanceTime.Value` to calculate the difference to add to the dates.
+will search the patient entries for an `EncounterRequested` with an `entryid` of 33.  It will then use the `ActionContext.ExpectedPerformanceTime.Value` to calculate the difference to add to the dates.  It will also output a list of every date found in the record.
+
+```bash
+yarn patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json -o
+```
+
+This command will only output a list of dates found in the record, it will not update the patient record.
+
+When using `npm`, passing in flags like `-o` requires the usage of `--` to separate them from the commands, like so:
+
+```bash
+npm patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json 33 -- -o
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -76,22 +76,18 @@ Where the the available options are:
 For example:
 
 ```bash
-yarn patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json 33 -o
+yarn patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json 33
 ```
 
-will search the patient entries for an `EncounterRequested` with an `entryid` of 33.  It will then use the `ActionContext.ExpectedPerformanceTime.Value` to calculate the difference to add to the dates.  It will also output a list of every date found in the record.
+will search the patient entries for an `EncounterRequested` with an `entryid` of 33.  It will then use the `ActionContext.ExpectedPerformanceTime.Value` to calculate the difference to add to the dates.
+
+The dates in the file can be easily listed out using the `patient-date-list` script.  To run the script:
 
 ```bash
-yarn patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json -o
+yarn patient-date-list ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
 ```
 
-This command will only output a list of dates found in the record, it will not update the patient record.
-
-When using `npm`, passing in flags like `-o` requires the usage of `--` to separate them from the commands, like so:
-
-```bash
-npm patient-date-update ./src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json 33 -- -o
-```
+This command will only output a list of dates found in the record, it will not update the patient record.  It will list the dates in chronological order.  
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "eject": "react-scripts eject",
     "parse": "babel-node --presets es2015,react --plugins transform-class-properties,transform-es2015-destructuring,transform-object-rest-spread ./src/noteparser/app.js",
     "patient-date-update": "node ./src/patient-date-updater/app.js",
+    "patient-date-list": "node ./src/patient-date-updater/app.js -O",
     "test-ci": "react-scripts test --env=jsdom --coverage",
     "test": "run-script-os",
     "test:win32": "yarn test-backend:win32",

--- a/src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
+++ b/src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
@@ -1230,7 +1230,7 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/AuthoredDateTime"
                 },
-                "Value": "12 April 2010"
+                "Value": "12 Apr 2010"
             }
         },
         "FindingTopicCode": {
@@ -1371,7 +1371,7 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Onset"
             },
-            "Value": "12 April 2010"
+            "Value": "12 Apr 2010"
         }
     },
     {

--- a/src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
+++ b/src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
@@ -2385,7 +2385,7 @@
             "Value": "http://standardhealthrecord.org/spec/shr/encounter/ConsultRequested"
         },
         "ShrId": "788dcbc3-ed18-470c-89ef-35ff91854c7g",
-        "EntryId": "33",
+        "EntryId": "50",
         "Metadata": {
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/Metadata"
@@ -2500,13 +2500,13 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
                 },
-                "Value": "21 May 2018"
+                "Value": "25 Dec 2018"
             },
             "AuthoredDateTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/AuthoredDateTime"
                 },
-                "Value": "21 May 2018"
+                "Value": "25 Dec 2018"
             }
         },
         "Encounter": {
@@ -2521,7 +2521,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/BeginDateTime"
                     },
-                    "Value": "19 Jul 2018 18:00 -0400"
+                    "Value": "31 Dec 2018 18:00 -0400"
                 }
             },
             "Status": {

--- a/src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
+++ b/src/dataaccess/BreastMainTreatmentDiabetesHypertensionJaneV05.json
@@ -457,13 +457,13 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
                 },
-                "Value": "18 Dec 2017"
+                "Value": "18 Dec 2018"
             },
             "AuthoredDateTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/AuthoredDateTime"
                 },
-                "Value": "18 Dec 2017"
+                "Value": "18 Dec 2018"
             }
         },
         "FindingTopicCode": {
@@ -2309,7 +2309,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/BeginDateTime"
                     },
-                    "Value": "31 Jul 2018 16:00 -0400"
+                    "Value": "25 Dec 2018 16:00 -0400"
                 }
             },
             "Status": {
@@ -2415,7 +2415,7 @@
                     "EntryType": {
                         "Value": "http://standardhealthrecord.org/spec/shr/core/BeginDateTime"
                     },
-                    "Value": "3 Jul 2018 16:00 -0400"
+                    "Value": "21 Dec 2018 16:00 -0400"
                 }
             },
             "Status": {
@@ -5447,13 +5447,13 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
                 },
-                "Value": "18 Dec 2017"
+                "Value": "18 Dec 2018"
             },
             "AuthoredDateTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/AuthoredDateTime"
                 },
-                "Value": "18 Dec 2017"
+                "Value": "18 Dec 2018"
             }
         },
         "FindingResult": {
@@ -5540,7 +5540,7 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/RelevantTime"
             },
-            "Value": "18 Dec 2017"
+            "Value": "18 Dec 2018"
         }
     },
     {
@@ -5557,13 +5557,13 @@
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
                 },
-                "Value": "18 Dec 2017"
+                "Value": "18 Dec 2018"
             },
             "AuthoredDateTime": {
                 "EntryType": {
                     "Value": "http://standardhealthrecord.org/spec/shr/base/AuthoredDateTime"
                 },
-                "Value": "18 Dec 2017"
+                "Value": "18 Dec 2018"
             }
         },
         "FindingResult": {
@@ -5682,7 +5682,7 @@
             "EntryType": {
                 "Value": "http://standardhealthrecord.org/spec/shr/base/RelevantTime"
             },
-            "Value": "18 Dec 2017"
+            "Value": "18 Dec 2018"
         }
     },
     {

--- a/src/patient-date-updater/app.js
+++ b/src/patient-date-updater/app.js
@@ -35,19 +35,19 @@ if (entryid) {
     }
 }
 
-// Save backup
-fs.writeFileSync(`${input}.backup`, JSON.stringify(patientEntries, null, 4), 'utf8');
-console.log(`Saved backup JSON file to ${input}.backup`);
 
 let today, deltaDuration;
 if (encounter) {
+    // Save backup
+    fs.writeFileSync(`${input}.backup`, JSON.stringify(patientEntries, null, 4), 'utf8');
+    console.log(`Saved backup JSON file to ${input}.backup`);
+
     // encounterDateValue grabs the correct date value based on whether the patient JSON is in mCODE v0.1 or v0.5
     const encounterDateValue = encounter.Encounter.TimePeriod.TimePeriodStart ? encounter.Encounter.TimePeriod.TimePeriodStart.Value : encounter.Encounter.TimePeriod.BeginDateTime.Value;
     const encounterDate = moment(encounterDateValue, 'D MMM YYYY HH:mm ZZ').startOf('day');
     today = moment().startOf('day');
     deltaDuration = moment.duration(today.diff(encounterDate));
 }
-
 
 const entries = {};
 patientEntries.forEach((entry, i) => {
@@ -102,10 +102,10 @@ patientEntries.forEach((entry, i) => {
         if (orderedOutput && isDate) {
             entry.key = key;
             entry.value = value;
-            if(entries[entry.entryId]){
+            if (entries[entry.entryId]) {
                 entries[entry.entryId].push(entry);
-            }else{
-                entries[entry.entryId]=[entry];
+            } else {
+                entries[entry.entryId] = [entry];
             }
         } else if (output && isDate) {
             log(key, value);
@@ -140,23 +140,23 @@ function log(key, value) {
 
 function flattenOrderedOutput(entries) {
     let returnEntries = [];
-    Object.keys(entries).forEach((entryListIndex)=>{
+    Object.keys(entries).forEach((entryListIndex) => {
         let total = [];
         let metadata = [];
-        entries[entryListIndex].forEach((entry)=>{
-            if(entry.key.toLowerCase().split(".").indexOf("metadata")>-1){
+        entries[entryListIndex].forEach((entry) => {
+            if (entry.key.toLowerCase().split(".").indexOf("metadata") > -1) {
                 metadata.push(entry);
-            }else{
+            } else {
                 // pretty much everything has "Value" tacked to the end, so we lop it off
                 const valueCheck = entry.key.split(".");
-                valueCheck.splice(valueCheck.indexOf("Value"),1);
+                valueCheck.splice(valueCheck.indexOf("Value"), 1);
                 entry.key = valueCheck.join('.');
                 total.push(entry);
             }
         })
-        if(total.length>0) {
+        if (total.length > 0) {
             returnEntries = returnEntries.concat(total);
-        }else if(metadata.length>0 && showMeta){
+        } else if (metadata.length > 0 && showMeta) {
             returnEntries.push(metadata[0])
         }
     })

--- a/src/patient-date-updater/app.js
+++ b/src/patient-date-updater/app.js
@@ -50,68 +50,50 @@ patientEntries.forEach((entry, i) => {
     // flatten each entry to have only one level of properties to make it easier to traverse
     const flattenedEntry = flatten(entry);
     let change = false;
+    let isDate;
     if(output) {
-        console.log("\u001b[1;37m "+flattenedEntry.EntryId +'\t' + flattenedEntry["EntryType.Value"].split('/').slice(-1)[0]);
+        console.log("\u001b[37m " + flattenedEntry.EntryId +'\t' + flattenedEntry["EntryType.Value"].split('/').slice(-1)[0]);
     }
 
     for (const key in flattenedEntry) {
         const value = flattenedEntry[key];
-
+        isDate = false;
         /*
          *  Check for three different formats that dates in patient entries can have
          *  If a date is found, a delta is added and date on the entry is changed to the new date
          */
         if (moment(value, 'DD MMM YYYY', true).isValid()) {
             const date = moment(value, 'DD MMM YYYY');
-
-
+            isDate=true;
             if(encounter) {
                 date.add(deltaDuration);
                 flattenedEntry[key] = date.format('DD MMM YYYY');
-
-                if(date > today && output) {
-                    console.log(`\u001b[1;31m \t${key}: ${value}`);
-                }else if(output){
-                    console.log(`\u001b[1;37m \t${key}: ${value}`);
-                }
                 change = true;
-            }else if(output){
-                console.log(`\u001b[1;37m \t${key}: ${value}`);
             }
 
         } else if (moment(value, 'D MMM YYYY', true).isValid()) {
             const date = moment(value, 'D MMM YYYY');
-            flattenedEntry[key] = date.format('DD MMM YYYY');
-
+            isDate=true;
             if(encounter) {
                 date.add(deltaDuration);
-                if(date > today && output) {
-                    console.log(`\u001b[1;31m \t${key}: ${value}`);
-                }else if(output){
-                    console.log(`\u001b[1;37m \t${key}: ${value}`);
-                }
+                flattenedEntry[key] = date.format('DD MMM YYYY');
                 change = true;
-            }else if(output){
-                console.log(`\u001b[1;37m \t${key}: ${value}`);
             }
 
         } else if (moment(value, 'D MMM YYYY HH:mm ZZ', true).isValid()) {
             const date = moment(value, 'D MMM YYYY HH:mm ZZ');
-
+            isDate=true;
             if(encounter) {
                 // Keep encounter time
                 date.add(deltaDuration.asDays(), 'd');
                 flattenedEntry[key] = date.format('D MMM YYYY HH:mm ZZ');
-
-                if(date > today && output) {
-                    console.log(`\u001b[1;31m \t${key}: ${value}`);
-                }else if(output){
-                    console.log(`\u001b[1;37m \t${key}: ${value}`);
-                }
                 change = true;
-            }else if(output) {
-                console.log(`\u001b[1;37m \t${key}: ${value}`);
             }
+            
+
+        }
+        if(output && isDate) {
+            log(key,value);
         }
     }
 
@@ -126,3 +108,7 @@ fs.writeFile(input, resultJSON, 'utf8', (err) => {
     if (err) throw err;
     console.log('DONE');
 });
+
+function log(key,value) {
+    console.log(`\u001b[37m \t\t${key}: \u001b[34m ${value}`);
+}

--- a/src/patient-date-updater/app.js
+++ b/src/patient-date-updater/app.js
@@ -34,7 +34,9 @@ if (encounter === undefined) {
 fs.writeFileSync(`${input}.backup`, JSON.stringify(patientEntries, null, 4), 'utf8');
 console.log(`Saved backup JSON file to ${input}.backup`);
 
-const encounterDate = moment(encounter.Encounter.TimePeriod.TimePeriodStart.Value, 'D MMM YYYY HH:mm ZZ').startOf('day');
+// encounterDateValue grabs the correct date value based on whether the patient JSON is in mCODE v0.1 or v0.5
+const encounterDateValue = encounter.Encounter.TimePeriod.TimePeriodStart ? encounter.Encounter.TimePeriod.TimePeriodStart.Value : encounter.Encounter.TimePeriod.BeginDateTime.Value;
+const encounterDate = moment(encounterDateValue, 'D MMM YYYY HH:mm ZZ').startOf('day');
 const today = moment().startOf('day');
 const deltaDuration = moment.duration(today.diff(encounterDate));
 

--- a/src/patient-date-updater/app.js
+++ b/src/patient-date-updater/app.js
@@ -3,11 +3,11 @@ const program = require('commander');
 const flatten = require('flat');
 const moment = require('moment');
 
-let input;
-let entryid;
+let input, entryid;
 program
-    .usage('<path-to-patient-json> <encounter-entryid>')
-    .arguments('<path-to-patient-json> <encounter-entryid>')
+    .usage('<path-to-patient-json> [encounter-entryid]')
+    .arguments('<path-to-patient-json> [encounter-entryid]')
+    .option('-o, --output', 'Output all dates in the record')
     .action((pathToPatientJson, encounterEntryid) => {
         input = pathToPatientJson;
         entryid = encounterEntryid;
@@ -20,30 +20,39 @@ if (typeof input === 'undefined') {
     console.error('\x1b[31m', 'Missing path to patient JSON', '\x1b[0m');
     program.help();
 }
-
+const output = program.output;
 const patientEntries = JSON.parse(fs.readFileSync(input, 'utf8'));
-const encounter = patientEntries.find(entry => entry.EntryType.Value === 'http://standardhealthrecord.org/spec/shr/encounter/ConsultRequested' && entry.EntryId === entryid);
-
-// Encounter not found in patient entries so exit the program
-if (encounter === undefined) {
-    console.error(`Encounter with entryid ${entryid} not found.`);
-    process.exit(1);
+let encounter;
+if(entryid) {
+    encounter = patientEntries.find(entry => entry.EntryType.Value === 'http://standardhealthrecord.org/spec/shr/encounter/ConsultRequested' && entry.EntryId === entryid);
+    // Encounter not found in patient entries so exit the program
+    if (encounter === undefined) {
+        console.error(`Encounter with entryid ${entryid} not found.`);
+        process.exit(1);
+    }
 }
 
 // Save backup
 fs.writeFileSync(`${input}.backup`, JSON.stringify(patientEntries, null, 4), 'utf8');
 console.log(`Saved backup JSON file to ${input}.backup`);
 
-// encounterDateValue grabs the correct date value based on whether the patient JSON is in mCODE v0.1 or v0.5
-const encounterDateValue = encounter.Encounter.TimePeriod.TimePeriodStart ? encounter.Encounter.TimePeriod.TimePeriodStart.Value : encounter.Encounter.TimePeriod.BeginDateTime.Value;
-const encounterDate = moment(encounterDateValue, 'D MMM YYYY HH:mm ZZ').startOf('day');
-const today = moment().startOf('day');
-const deltaDuration = moment.duration(today.diff(encounterDate));
+let today, deltaDuration;
+if(encounter) {
+    // encounterDateValue grabs the correct date value based on whether the patient JSON is in mCODE v0.1 or v0.5
+    const encounterDateValue = encounter.Encounter.TimePeriod.TimePeriodStart ? encounter.Encounter.TimePeriod.TimePeriodStart.Value : encounter.Encounter.TimePeriod.BeginDateTime.Value;
+    const encounterDate = moment(encounterDateValue, 'D MMM YYYY HH:mm ZZ').startOf('day');
+    today = moment().startOf('day');
+    deltaDuration = moment.duration(today.diff(encounterDate));
+}
+
 
 patientEntries.forEach((entry, i) => {
     // flatten each entry to have only one level of properties to make it easier to traverse
     const flattenedEntry = flatten(entry);
     let change = false;
+    if(output) {
+        console.log("\u001b[1;37m "+flattenedEntry.EntryId +'\t' + flattenedEntry["EntryType.Value"].split('/').slice(-1)[0]);
+    }
 
     for (const key in flattenedEntry) {
         const value = flattenedEntry[key];
@@ -55,22 +64,54 @@ patientEntries.forEach((entry, i) => {
         if (moment(value, 'DD MMM YYYY', true).isValid()) {
             const date = moment(value, 'DD MMM YYYY');
 
-            date.add(deltaDuration);
-            flattenedEntry[key] = date.format('DD MMM YYYY');
-            change = true;
+
+            if(encounter) {
+                date.add(deltaDuration);
+                flattenedEntry[key] = date.format('DD MMM YYYY');
+
+                if(date > today && output) {
+                    console.log(`\u001b[1;31m \t${key}: ${value}`);
+                }else if(output){
+                    console.log(`\u001b[1;37m \t${key}: ${value}`);
+                }
+                change = true;
+            }else if(output){
+                console.log(`\u001b[1;37m \t${key}: ${value}`);
+            }
+
         } else if (moment(value, 'D MMM YYYY', true).isValid()) {
             const date = moment(value, 'D MMM YYYY');
-
-            date.add(deltaDuration);
             flattenedEntry[key] = date.format('DD MMM YYYY');
-            change = true;
+
+            if(encounter) {
+                date.add(deltaDuration);
+                if(date > today && output) {
+                    console.log(`\u001b[1;31m \t${key}: ${value}`);
+                }else if(output){
+                    console.log(`\u001b[1;37m \t${key}: ${value}`);
+                }
+                change = true;
+            }else if(output){
+                console.log(`\u001b[1;37m \t${key}: ${value}`);
+            }
+
         } else if (moment(value, 'D MMM YYYY HH:mm ZZ', true).isValid()) {
             const date = moment(value, 'D MMM YYYY HH:mm ZZ');
 
-            // Keep encounter time
-            date.add(deltaDuration.asDays(), 'd');
-            flattenedEntry[key] = date.format('D MMM YYYY HH:mm ZZ');
-            change = true;
+            if(encounter) {
+                // Keep encounter time
+                date.add(deltaDuration.asDays(), 'd');
+                flattenedEntry[key] = date.format('D MMM YYYY HH:mm ZZ');
+
+                if(date > today && output) {
+                    console.log(`\u001b[1;31m \t${key}: ${value}`);
+                }else if(output){
+                    console.log(`\u001b[1;37m \t${key}: ${value}`);
+                }
+                change = true;
+            }else if(output) {
+                console.log(`\u001b[1;37m \t${key}: ${value}`);
+            }
         }
     }
 

--- a/src/patient-date-updater/app.js
+++ b/src/patient-date-updater/app.js
@@ -25,7 +25,7 @@ const output = program.output;
 const orderedOutput = program.orderedOutput;
 const patientEntries = JSON.parse(fs.readFileSync(input, 'utf8'));
 let encounter;
-if(entryid) {
+if (entryid) {
     encounter = patientEntries.find(entry => entry.EntryType.Value === 'http://standardhealthrecord.org/spec/shr/encounter/ConsultRequested' && entry.EntryId === entryid);
     // Encounter not found in patient entries so exit the program
     if (encounter === undefined) {
@@ -39,7 +39,7 @@ fs.writeFileSync(`${input}.backup`, JSON.stringify(patientEntries, null, 4), 'ut
 console.log(`Saved backup JSON file to ${input}.backup`);
 
 let today, deltaDuration;
-if(encounter) {
+if (encounter) {
     // encounterDateValue grabs the correct date value based on whether the patient JSON is in mCODE v0.1 or v0.5
     const encounterDateValue = encounter.Encounter.TimePeriod.TimePeriodStart ? encounter.Encounter.TimePeriod.TimePeriodStart.Value : encounter.Encounter.TimePeriod.BeginDateTime.Value;
     const encounterDate = moment(encounterDateValue, 'D MMM YYYY HH:mm ZZ').startOf('day');
@@ -56,12 +56,12 @@ patientEntries.forEach((entry, i) => {
     let isDate;
     const entryId = flattenedEntry.EntryId
     const entryType = flattenedEntry["EntryType.Value"].split('/').slice(-1)[0];
-    if(output && !orderedOutput) {
-        console.log("\u001b[37m " + entryId +'\t' + entryType);
+    if (output && !orderedOutput) {
+        console.log("\u001b[37m " + entryId + '\t' + entryType);
     }
 
     for (const key in flattenedEntry) {
-        const entry = {entryId:entryId,entryType:entryType}
+        const entry = { entryId: entryId, entryType: entryType }
         const value = flattenedEntry[key];
         isDate = false;
         /*
@@ -70,8 +70,8 @@ patientEntries.forEach((entry, i) => {
          */
         if (moment(value, 'DD MMM YYYY', true).isValid()) {
             const date = moment(value, 'DD MMM YYYY');
-            isDate=true;
-            if(encounter) {
+            isDate = true;
+            if (encounter) {
                 date.add(deltaDuration);
                 flattenedEntry[key] = date.format('DD MMM YYYY');
                 change = true;
@@ -79,8 +79,8 @@ patientEntries.forEach((entry, i) => {
             entry.date = date;
         } else if (moment(value, 'D MMM YYYY', true).isValid()) {
             const date = moment(value, 'D MMM YYYY');
-            isDate=true;
-            if(encounter) {
+            isDate = true;
+            if (encounter) {
                 date.add(deltaDuration);
                 flattenedEntry[key] = date.format('DD MMM YYYY');
                 change = true;
@@ -89,8 +89,8 @@ patientEntries.forEach((entry, i) => {
 
         } else if (moment(value, 'D MMM YYYY HH:mm ZZ', true).isValid()) {
             const date = moment(value, 'D MMM YYYY HH:mm ZZ');
-            isDate=true;
-            if(encounter) {
+            isDate = true;
+            if (encounter) {
                 // Keep encounter time
                 date.add(deltaDuration.asDays(), 'd');
                 flattenedEntry[key] = date.format('D MMM YYYY HH:mm ZZ');
@@ -98,12 +98,12 @@ patientEntries.forEach((entry, i) => {
             }
             entry.date = date;
         }
-        if(orderedOutput && isDate) {
+        if (orderedOutput && isDate) {
             entry.key = key;
             entry.value = value;
             entries.push(entry);
-        }else if(output && isDate) {
-            log(key,value);
+        } else if (output && isDate) {
+            log(key, value);
         }
     }
 
@@ -112,10 +112,10 @@ patientEntries.forEach((entry, i) => {
         patientEntries[i] = flatten.unflatten(flattenedEntry);
     }
 });
-if(orderedOutput) {
+if (orderedOutput) {
     entries.sort(sortByDate);
-    entries.forEach((e)=>{
-        logInOrder(e.entryId, e.entryType, e.key,e.value);
+    entries.forEach((e) => {
+        logInOrder(e.entryId, e.entryType, e.key, e.value);
     })
 }
 
@@ -125,19 +125,19 @@ fs.writeFile(input, resultJSON, 'utf8', (err) => {
     console.log('DONE');
 });
 
-function log(key,value) {
+function log(key, value) {
     console.log(`\u001b[37m \t\t${key}: \u001b[34m ${value}`);
 }
 
 function logInOrder(id, type, key, value) {
     key = type + '.' + key;
-    key = key.padStart(key.length+10-id.length);
+    key = key.padStart(key.length + 10 - id.length);
     value = value.padStart(80 - key.length - id.length);
     console.log(`\u001b[37m [${id}] ${key}: \u001b[34m ${value}`);
 }
 
-function sortByDate(a,b) {
-    if(a.date < b.date) return -1;
-    if(a.date > b.date) return 1;
+function sortByDate(a, b) {
+    if (a.date < b.date) return -1;
+    if (a.date > b.date) return 1;
     return 0;
 }

--- a/src/patient-date-updater/app.js
+++ b/src/patient-date-updater/app.js
@@ -22,6 +22,7 @@ if (typeof input === 'undefined') {
     program.help();
 }
 const output = program.output;
+const showMeta = false;
 const orderedOutput = program.orderedOutput;
 const patientEntries = JSON.parse(fs.readFileSync(input, 'utf8'));
 let encounter;
@@ -124,11 +125,14 @@ if (orderedOutput) {
     })
 }
 
-const resultJSON = JSON.stringify(patientEntries, null, 4);
-fs.writeFile(input, resultJSON, 'utf8', (err) => {
-    if (err) throw err;
-    console.log('DONE');
-});
+if (encounter) {
+    const resultJSON = JSON.stringify(patientEntries, null, 4);
+    fs.writeFile(input, resultJSON, 'utf8', (err) => {
+        if (err) throw err;
+        console.log('DONE');
+    });
+}
+
 
 function log(key, value) {
     console.log(`\t\t${key}: ${value}`);
@@ -143,13 +147,16 @@ function flattenOrderedOutput(entries) {
             if(entry.key.toLowerCase().split(".").indexOf("metadata")>-1){
                 metadata.push(entry);
             }else{
-                console.log(entry);
+                // pretty much everything has "Value" tacked to the end, so we lop it off
+                const valueCheck = entry.key.split(".");
+                valueCheck.splice(valueCheck.indexOf("Value"),1);
+                entry.key = valueCheck.join('.');
                 total.push(entry);
             }
         })
         if(total.length>0) {
             returnEntries = returnEntries.concat(total);
-        }else if(metadata.length>0){
+        }else if(metadata.length>0 && showMeta){
             returnEntries.push(metadata[0])
         }
     })
@@ -158,8 +165,8 @@ function flattenOrderedOutput(entries) {
 
 function logInOrder(id, type, key, value) {
     key = type + '.' + key;
-    key = key.padStart(key.length + 10 - id.length);
-    value = value.padStart(80 - key.length - id.length);
+    key = key.padStart(key.length + 5 - id.length);
+    value = value.padStart(80 - key.length - id.length + value.length);
     console.log(`[${id}] ${key}: ${value}`);
 }
 


### PR DESCRIPTION
This makes some minor changes to Jane Bradshaw's record which puts the consult request for the breast cancer condition ahead of the diagnosis chronologically, so that the patient updater doesn't put the diagnosis date into the future.  Her procedure requests also now fall before the current encounter, which is id `33`.  A duplicate entry with id `33` was renamed to have id `50`, which was the next in incremental order. 

There's some potential changes that I was unsure about.  I avoided making any of these changes, but it seems to me that some resources referencing the breast cancer condition should occur after the diagnosis.  For example, many of the observations have a `RelevantTime` before the diagnosis, but reference the breast cancer condition as a `SpecificFocusOfFinding`.   The actual chronology is of course beyond my knowledge, but I am unsure whether certain events are supposed to be before or after the diagnosis.  It seems a bit strange to be getting information on tumor size and stage on dates well before the diagnosis of cancer.  

This PR also gives the patient date updater two new flags for outputting the date values.  Using `-o` or `--output` will output all found dates and the entry type they belong to, as well as their immediate context.  Using `-O` or `--ordered-output` will output the dates ordered chronologically.

You don't have to put in an encounter `id` if you just want to output the list of dates.  Also, an important note, if you run the patient updater through the script using `npm`, you have to pass flags in using a `--` to separate them, as discussed [here](https://github.com/npm/npm/pull/5518).  So to run the patient updater and output the dates only, you'd run `npm run patient-date-update patient.json -- -o`


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [ ] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [x] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [x] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [x] Document any new APIs/extension points
- [x] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
