### PR TITLE
Update context insertion to properly reflect location in editor

### DIFF
--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -2,7 +2,8 @@ import Lang from 'lodash';
 
 export default class Context {
 	constructor() {
-		this.children = [];
+        this.children = [];
+        this._initialContextPosition = -1; // Where to insert the context relative to the others on creation
 	}
 
 	initialize(contextManager, trigger = undefined, updatePatient = true) {
@@ -117,5 +118,13 @@ export default class Context {
 
     isGlobalContext() {
         return false;
+    }
+
+    get initialContextPosition() {
+        return this._initialContextPosition;
+    }
+
+    set initialContextPosition(initialContextPosition) {
+        this._initialContextPosition = initialContextPosition;
     }
 }

--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -214,15 +214,6 @@ class ContextManager {
         this.activeContexts = [];
         this.contextUpdated();
     }
-
-    // Clears all non active contexts from this.contexts
-    // Only used after picking options from template
-    // When choosing options, many unncessary contexts get added
-    clearNonActiveContexts() {
-        this.contexts = this.contexts.filter((context) => {
-            return this.activeContexts.includes(context);
-        });
-    }
 }
 
 export default ContextManager;

--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -41,6 +41,10 @@ class ContextManager {
         this.activeContexts = contextsToKeep;
     }
 
+    setGetContextsBeforeSelection(getContextsBeforeSelection) {
+        this.getContextsBeforeSelection = getContextsBeforeSelection;
+    }
+
     setIsBlock1BeforeBlock2(isBlock1BeforeBlock2) {
         this.isBlock1BeforeBlock2 = isBlock1BeforeBlock2;
     }
@@ -150,27 +154,15 @@ class ContextManager {
 
     addShortcutToContext(shortcut) {
         if (!shortcut.getKey()) return; // if the key hasn't been set for a shortcut yet then it shouldn't be added
-        //console.log("adding shortcut to context: " + shortcut.getShortcutType());
-        const numContexts = this.contexts.length;
-        let index = -1;
-        for (var i = 0; i < numContexts; i++) {
-            // check if current selection (first block key is null) is after the context. If yes, we have our
-            // insertion point
-            if (!this.isBlock1BeforeBlock2(null, 0, this.contexts[i].getKey(), 0)) {
-                index = i;
-                break;
-            }
-        }
-        if (index === -1) {
-            /*  Changed this from push to unshift to fix context ordering when loading in a note.
-             *  This seems to work since the cursor is always at the beginning when loading in a note.
-             *  Also tested copy and pasting and normal insertion of shortcuts into the note and those actions do not seem to be affected.
-             *  If unintended consequences are found in the future, this change can be reversed and we can find a new solution.
-             */  
-            this.contexts.unshift(shortcut);
+
+        let insertionIndex = this.contexts.length;
+        if (shortcut.initialContextPosition === -1) {
+            // If we have not specified the position, insert it after the last context before the cursor location
+            insertionIndex -= this.getContextsBeforeSelection().length;
         } else {
-            this.contexts.splice(index, 0, shortcut);
+            insertionIndex -= shortcut.initialContextPosition;
         }
+        this.contexts.splice(insertionIndex, 0, shortcut);
 
         //when adding a new shortcut to context, we assume cursor ends up after it so its active
         this.activeContexts.unshift(shortcut);

--- a/src/mcode-pilot/components/TreatmentOptionsOutcomes/TreatmentOptionsOutcomes.jsx
+++ b/src/mcode-pilot/components/TreatmentOptionsOutcomes/TreatmentOptionsOutcomes.jsx
@@ -290,7 +290,7 @@ export default class TreatmentOptionsOutcomes extends Component {
     }
 
     renderOutcomesIcons = () => {
-        const { includedTreatmentData, comparedTreatmentData } = this.props;
+        const { includedTreatmentData, /* comparedTreatmentData */ } = this.props;
         const { timescaleToggle } = this.state;
         if (includedTreatmentData.length === 0) return <div className="note">No included treatment chosen.</div>;
 

--- a/src/noteparser/NoteParser.js
+++ b/src/noteparser/NoteParser.js
@@ -22,6 +22,9 @@ export default class NoteParser {
             this.contextManager.setIsBlock1BeforeBlock2(() => {
                 return true;
             });
+            this.contextManager.setGetContextsBeforeSelection(() => {
+                return true;
+            });
         } else {
             this.contextManager = contextManager;
         }

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -820,7 +820,6 @@ class FluxNotesEditor extends React.Component {
         // This means user either clicked the OK or Cancel button on the pick list options panel
         if (this.props.noteAssistantMode === 'pick-list-options-panel' && nextProps.noteAssistantMode === 'context-tray') {
             this.adjustActiveContexts(this.state.state.selection, this.state.state);
-            this.props.contextManager.clearNonActiveContexts();
             this.props.setNoteViewerEditable(true);
             // If the user clicks cancel button, change editor state back to what it was before they clicked the template
             if (nextProps.shouldRevertTemplate) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -63,6 +63,7 @@ class FluxNotesEditor extends React.Component {
         this.updateErrors = this.props.updateErrors;
 
         this.contextManager.setIsBlock1BeforeBlock2(this.isBlock1BeforeBlock2.bind(this));
+        this.contextManager.setGetContextsBeforeSelection(this.getContextsBeforeSelection.bind(this));
 
         this.didFocusChange = false;
         this.editorHasFocus = false;
@@ -292,7 +293,7 @@ class FluxNotesEditor extends React.Component {
         return this.insertPlaceholder(suggestion.value, transformBeforeInsert).apply();
     }
 
-    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, source) => {
+    insertShortcut = (shortcutC, shortcutTrigger, text, transform = undefined, updatePatient = true, source, initialContextPosition = -1) => {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
@@ -303,16 +304,18 @@ class FluxNotesEditor extends React.Component {
         }
 
         let shortcut = this.props.newCurrentShortcut(shortcutC, shortcutTrigger, text, updatePatient, source);
+        shortcut.initialContextPosition = initialContextPosition;
         if (!Lang.isNull(shortcut) && shortcut.needToSelectValueFromMultipleOptions() && text.length === 0) {
             return this.openPortalToSelectValueForShortcut(shortcut, false, transform);
         }
         return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
     }
 
-    updateExistingShortcut = (shortcut, transform = undefined) => {
+    updateExistingShortcut = (shortcut, transform = undefined, initialContextPosition = -1) => {
         if (Lang.isUndefined(transform)) {
             transform = this.state.state.transform();
         }
+        shortcut.initialContextPosition = initialContextPosition;
         return this.insertStructuredFieldTransform(transform, shortcut).collapseToStartOfNextText().focus();
     }
 
@@ -335,7 +338,7 @@ class FluxNotesEditor extends React.Component {
             return this.insertPlaceholder(matches.before[0], transform).insertText(characterToAppend);
         }
 
-        return this.insertShortcut(def, matches.before[0], "", transform, true, true, 'typed').insertText(characterToAppend);
+        return this.insertShortcut(def, matches.before[0], "", transform, true, 'typed').insertText(characterToAppend);
     }
 
     getTextCursorPosition = () => {
@@ -533,6 +536,38 @@ class FluxNotesEditor extends React.Component {
         }).delete()
 
         this.insertTextWithStructuredPhrases(data.newText, nextState, true, "dictation");
+    }
+
+    getContextsBeforeSelection(state = this.state.state) {
+        return this._getShortcutsUpToKey(state, state.selection.anchorKey); // Get all contexts up to where the cursor is
+    }
+
+    _getShortcutsUpToKey(state, key) {
+        const allNodes = this._getAllNodes(state.document.toJSON().nodes);
+        const inlinesUntilSelection = [];
+
+        // Find all shortcuts up until the selection
+        allNodes.some(n => {
+            if (n.type === 'structured_field') inlinesUntilSelection.push(n);
+            return n.key === key;
+        });
+
+        // Return a list of context shortcuts
+        return inlinesUntilSelection
+            .map(i => i.data.shortcut)
+            .filter(s => s.isContext());
+    }
+
+    _getAllNodes(nodes) {
+        // Get all the nodes in the Slate document as a flattened array
+        let allNodes = [];
+        nodes.forEach(node => {
+            allNodes.push(node);
+            if (node.nodes) {
+                allNodes = allNodes.concat(this._getAllNodes(node.nodes));
+            }
+        });
+        return allNodes;
     }
 
     isBlock1BeforeBlock2(key1, offset1, key2, offset2, state) {
@@ -1395,11 +1430,14 @@ class FluxNotesEditor extends React.Component {
                     after = "";
                 }
 
+                // Update the context position based on selection
+                const shortcutsUntilSelection = this.getContextsBeforeSelection(transform.state);
                 if (arrayOfPickLists && this.noteParser.isPickList(trigger) && !trigger.selectedValue) {
-                    transform = this.updateExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform);
+                    transform = this.updateExistingShortcut(arrayOfPickLists[pickListCount].shortcut, transform, shortcutsUntilSelection.length);
                     pickListCount++;
                 } else {
-                    transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, source);
+                    transform = this.insertShortcut(trigger.definition, trigger.trigger, after, transform, updatePatient, source, shortcutsUntilSelection.length);
+                    this.adjustActiveContexts(transform.state.selection, transform.state); // Updates active contexts based on cursor position
                 }
             });
         }


### PR DESCRIPTION
See [Jira 1850](https://jira.mitre.org/browse/ASCODCP-1850) for screenshots of the original bug. When a context was added at the beginning of the note, it would still appear last in the active context breadcrumb. This was due to the implementation of `addShortcutToContext` incorrectly detecting where to splice the context.

I changed the implementation to allow for two possible options for knowing where to insert the context:

1) There is now a property on `Context` objects called `initialContextPosition` that specifies where to splice it relative to other contexts
2) Make a call to `FluxNotesEditor` to get all the context shortcuts before the cursor position, and splice in the new context after those

These are the following ways to add context to a note (I think I got them all):

* Typing the shortcut
    * Hitting enter or clicking on portal suggestion
    * Typing out the full shortcut without clicking/enter
* Inserting a context from the TDP into a note
* Pasting a context into a note
* Loading a close in-progress note
* Inserting a template that has context shortcute
* Inserting a context from the context tray
* Flux commands for inserting structured phrases

All of these cases should result in the context being inserted in the correct position, which will be seen in the active context breadcrumb.

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
