### PR TITLE
Flag for editable inserter shortcuts

### DIFF
--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -63,10 +63,10 @@ function StructuredFieldPlugin(opts) {
         // If the previous node is not an inserter,
         // delete the full node when hitting backspace right before it, as it is not editable.
         const previousNode = state.document.getPreviousSibling(state.selection.anchorKey);
-        
+
         if (e.key === 'Backspace' && previousNode) {
             if (previousNode.type === 'structured_field'
-                && !(previousNode.data.get('shortcut') instanceof InsertValue)
+                && !((previousNode.data.get('shortcut') instanceof InsertValue) && previousNode.data.get('shortcut').metadata.isEditable)
                 && state.selection.anchorOffset === 0 && state.selection.isCollapsed) {
                 let transform = state.transform();
                 transform = transform.removeNodeByKey(previousNode.key);
@@ -81,7 +81,8 @@ function StructuredFieldPlugin(opts) {
                 return newState;
             }
         } else if (e.keyCode === 39 && parentNode) {
-            if ((parentNode.type === 'structured_field') && !(shortcut instanceof InsertValue)) {
+            if ((parentNode.type === 'structured_field')
+                && !((shortcut instanceof InsertValue) && shortcut.metadata.isEditable)) {
                 let transform = state.transform();
                 transform = transform.collapseToStartOfNextText();
                 let newState = transform.apply();
@@ -108,7 +109,7 @@ function StructuredFieldPlugin(opts) {
             }
         }
 
-        if (!(shortcut instanceof InsertValue)) return;
+        if (!((shortcut instanceof InsertValue) && shortcut.metadata.isEditable)) return;
 
         // Arrow keys, shift, escape, tab, numlock, page up/down, etc
         let ignoredKeys = [8, 9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];
@@ -221,7 +222,7 @@ function StructuredFieldPlugin(opts) {
             structured_field: props => {
                 const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter' {...props.attributes}>{props.children}{safariSpacing}</span>;
+                    return <span contentEditable={shortcut.metadata.isEditable ? '' : false} className='structured-field-inserter' {...props.attributes}>{props.children}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 }
@@ -229,7 +230,7 @@ function StructuredFieldPlugin(opts) {
             bolded_structured_field: props => {
                 const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}{safariSpacing}</span>;
+                    return <span contentEditable={shortcut.metadata.isEditable ? '' : false} className='structured-field-inserter structured-field-bolded' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-bolded' {...props.attributes}>{props.children}</span>;
                 }
@@ -237,7 +238,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_selected_search_result: props => {
                 const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
+                    return <span contentEditable={shortcut.metadata.isEditable ? '' : false} className='structured-field-inserter structured-field-selected-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-selected-search-result' {...props.attributes}>{props.children}</span>;
                 }
@@ -245,7 +246,7 @@ function StructuredFieldPlugin(opts) {
             structured_field_search_result: props => {
                 const shortcut = props.node.get('data').get('shortcut');
                 if (shortcut instanceof InsertValue) {
-                    return <span className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
+                    return <span contentEditable={shortcut.metadata.isEditable ? '' : false} className='structured-field-inserter structured-field-search-result' {...props.attributes}>{props.children}{safariSpacing}</span>;
                 } else {
                     return <span contentEditable={false} className='structured-field-creator structured-field-search-result' {...props.attributes}>{props.children}</span>;
                 }

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -109,7 +109,15 @@ function StructuredFieldPlugin(opts) {
             }
         }
 
-        if (!((shortcut instanceof InsertValue) && shortcut.metadata.isEditable)) return;
+        if (shortcut) {
+            // If there is a shortcut that is not an editable inserter shortcut, return state to cause zero changes
+            // to editor when typing inside.
+            if (!((shortcut instanceof InsertValue) && shortcut.metadata.isEditable)) return state;
+            // If it is an editable inserter shortcut, continue through onKeyDown to allow splitting and editing shortcuts.
+        } else {
+            // If no shortcut, continue return to continue through slate's calls to update state.
+            return;
+        }
 
         // Arrow keys, shift, escape, tab, numlock, page up/down, etc
         let ignoredKeys = [8, 9, 12, 16, 20, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 93, 144, 145];

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -443,6 +443,7 @@
     "id": "OncologyHistoryInserter",
     "getData": {"object": "$parentValueObject", "method": "buildHpiNarrative"},
     "isContext": false,
+    "isEditable": true,
     "stringTriggers": [{"name": "@ONCOHIST", "description": "Insert patient's oncology history"}],
     "contextValueObjectEntryTypes": ["http://standardhealthrecord.org/spec/oncocore/CancerDisorderPresent"],
     "knownParentContexts": "ConditionInserter"


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

This adds a flag in `Shortcuts.json` to determine if an inserter shortcut should be editable. Right now, only @oncohist is editable. This helps to avoid some of the issues we were having relating to resetting context on edited shortcuts like @condition. I also updated the if statement that returns out of the onKeyDown function to avoid some unintended typing inside creators and non-editable inserters.

Outstanding questions:
- Are there any other inserter shortcuts that we want to have editable?
- For inserter shortcuts that are multiple lines long and not editable (@recent labs and @medications are two examples), you can now delete individual lines of that shortcut with one "delete" click, rather than deleting the full shortcut. Is that the desired behavior?

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
