### PR TITLE
Medications via SMART on FHIR

### DIFF
--- a/src/dataaccess/utils/fhir-entry-processor.js
+++ b/src/dataaccess/utils/fhir-entry-processor.js
@@ -45,6 +45,7 @@ export default function(responses, patientId, resourceMapper = null) {
     });
     
     allObjects.push(...referencesOut);
-    const json = allObjects.filter(o => o).map(o => o.toJSON());
+    const uniqueObjects = Array.from(new Set(allObjects)); // there may be some duplicates between the referencesOut and allObjects
+    const json = uniqueObjects.filter(o => o).map(o => o.toJSON());
     return new PatientRecord(json);
 }

--- a/src/model/json-helper.js
+++ b/src/model/json-helper.js
@@ -66,7 +66,7 @@ export function getNamespaceAndNameFromFHIR(fhir, type) {
     }
   } else if (!fhir['resourceType'] && !type) {
     // it's not a FHIR resource, so it's likely a general purpose FHIR data type
-    return getGeneralPurposeFHIRType(fhir);
+    return FHIRHelper.getGeneralPurposeFHIRType(fhir);
   }
 
   // Get the type from the JSON if we can
@@ -89,47 +89,6 @@ export function getNamespaceAndNameFromFHIR(fhir, type) {
   const namespace = mappingStringArray.join('.');
   return { namespace, elementName };
 }
-
-// https://www.hl7.org/fhir/DSTU2/datatypes.html
-const FHIR_GENERAL_PURPOSE_TYPES = {
-  'Attachment': ['contentType', 'language', 'data', 'url', 'size', 'hash', 'title', 'creation'],
-  'Coding': ['system', 'version', 'code', 'display', 'userSelected'],
-  'CodeableConcept': ['coding', 'text'],
-  'Quantity': ['value', 'comparator', 'unit', 'system', 'code'],
-  'Range': ['low', 'high'],
-  'Ratio': ['numerator', 'denominator'],
-  'Period': ['start', 'end'],
-  'SampledData': ['origin', 'period', 'factor', 'lowerLimit', 'upperLimit', 'dimensions', 'data'],
-  'Identifier': ['use', 'type', 'system', 'value', 'period', 'assigner'],
-  'HumanName': ['use', 'text', 'family', 'given', 'prefix', 'suffix', 'period'],
-  'Address': ['use', 'type', 'text', 'line', 'city', 'district', 'state', 'postalCode', 'country', 'period'],
-  'ContactPoint': ['system', 'value', 'use', 'rank', 'period'],
-  'Timing': ['event', 'repeat', 'code'],
-  'Signature': ['type', 'when', 'whoUri', 'whoReference', 'contentType', 'blob'],
-  'Annotation': ['authorReference', 'authorString', 'time', 'text']
-};
-
-function getGeneralPurposeFHIRType(fhir) {
-  // the good news is that these do not have much overlap in their field names
-
-  for (const typeName in FHIR_GENERAL_PURPOSE_TYPES) {
-    // if all fields in the given fhir object are fields from a general purpose type, then this object is an instance of that type
-    // ignore extension and modifierExtension
-    const fieldsInDefinition = FHIR_GENERAL_PURPOSE_TYPES[typeName];
-    const fieldsInInstance = Object.keys(fhir).filter(f => f !== 'extension' && f !== 'modifierExtension');
-
-    const isMatch = fieldsInInstance.every(f => fieldsInDefinition.includes(f));
-
-    if (isMatch) {
-      // luckily all these types map to shr.core
-      return { namespace: 'shr.core', elementName: typeName };
-    }
-  }
-
-  // didn't find a match, so we have no idea what this object is
-  throw new Error(`Couldn't find type for FHIR: ${JSON.stringify(fhir)}`); 
-}
-
 
 /**
  * Given a (presumably) blank instance of an ES6 class representing an element, and JSON that adheres to the
@@ -236,6 +195,76 @@ function createInstance(key, value) {
   return value;
 }
 
+const FHIR_GENERAL_PURPOSE_TYPES = {
+  'Attachment': {
+    fields: ['contentType', 'language', 'data', 'url', 'size', 'hash', 'title', 'creation'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Media' }
+  },
+  'Coding': {
+    fields: ['system', 'version', 'code', 'display', 'userSelected'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Coding' }
+  },
+  'CodeableConcept': {
+    fields: ['coding', 'text'],
+    mapsTo: { namespace: 'shr.core', elementName: 'CodeableConcept' }
+  },
+  'Quantity': {
+    fields: ['value', 'comparator', 'unit', 'system', 'code'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Quantity' }
+  },
+  'Range': {
+    fields: ['low', 'high'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Range' }
+  },
+  'Ratio': {
+    fields: ['numerator', 'denominator'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Ratio' }
+  },
+  'Period': {
+    fields: ['start', 'end'],
+    mapsTo: { namespace: 'shr.core', elementName: 'TimePeriod' }
+  },
+  'SampledData': {
+    fields: ['origin', 'period', 'factor', 'lowerLimit', 'upperLimit', 'dimensions', 'data'],
+    mapsTo: { namespace: 'shr.core', elementName: 'SampledData' }
+  },
+  'Identifier': {
+    fields: ['use', 'type', 'system', 'value', 'period', 'assigner'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Identifier' }
+  },
+  'HumanName': {
+    fields: ['use', 'text', 'family', 'given', 'prefix', 'suffix', 'period'],
+    mapsTo: { namespace: 'shr.core', elementName: 'HumanName' }
+  },
+  'Address': {
+    fields: ['use', 'type', 'text', 'line', 'city', 'district', 'state', 'postalCode', 'country', 'period'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Address' }
+  },
+  'ContactPoint': {
+    fields: ['system', 'value', 'use', 'rank', 'period'],
+    mapsTo: { namespace: 'shr.core', elementName: 'ContactPoint' }
+  },
+  'Timing': {
+    fields: ['event', 'repeat', 'code'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Timing' }
+  },
+  'Signature': {
+    fields: ['type', 'when', 'whoUri', 'whoReference', 'contentType', 'blob'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Signature' }
+  },
+  'Annotation': {
+    fields: ['authorReference', 'authorString', 'time', 'text'],
+    mapsTo: { namespace: 'shr.core', elementName: 'Annotation' }
+  },
+
+  // references may not be the best fit here but it works
+  'Reference': {
+    fields: ['reference', 'type', 'identifier', 'display'],
+    mapsTo: { namespace: '', elementName: 'Reference' }
+   }
+};
+
+
 /**
  * Wrapper object to contain multiple functions, so that generated classes don't have to pre-determine which functions to specifically import.
  */
@@ -290,6 +319,28 @@ export const FHIRHelper = {
    */
   conformsToProfile: function(fhirEntry = {}, targetProfile = '') {
     return fhirEntry.resource && fhirEntry.resource.meta && fhirEntry.resource.meta.profile && fhirEntry.resource.meta.profile.some(p => p === targetProfile);
+  },
+
+  getGeneralPurposeFHIRType: function (fhir) {
+    // https://www.hl7.org/fhir/DSTU2/datatypes.html
+    // the good news is that these do not have much overlap in their field names
+
+    for (const typeName in FHIR_GENERAL_PURPOSE_TYPES) {
+      // if all fields in the given fhir object are fields from a general purpose type, then this object is an instance of that type
+      // ignore extension and modifierExtension
+      const definition = FHIR_GENERAL_PURPOSE_TYPES[typeName]
+      const fieldsInDefinition = definition['fields'];
+      const fieldsInInstance = Object.keys(fhir).filter(f => f !== 'extension' && f !== 'modifierExtension');
+
+      const isMatch = fieldsInInstance.every(f => fieldsInDefinition.includes(f));
+
+      if (isMatch) {
+        return definition['mapsTo'];
+      }
+    }
+
+    // didn't find a match, so we have no idea what this object is
+    throw new Error(`Couldn't find type for FHIR: ${JSON.stringify(fhir)}`); 
   },
 
   /**

--- a/src/model/medication/FluxMedicationRequested.js
+++ b/src/model/medication/FluxMedicationRequested.js
@@ -206,10 +206,7 @@ class FluxMedicationRequested extends FluxEntry {
             }
         }
 
-        return {
-            value: null,
-            units: null
-        };
+        return null;
     }
 
     /*

--- a/src/model/shr/base/Reason.js
+++ b/src/model/shr/base/Reason.js
@@ -73,7 +73,27 @@ class Reason {
     if (asExtension) {
     }
     if (!asExtension && fhir != null) {
-      inst.value = FHIRHelper.createInstanceFromFHIR(null, fhir, shrId, allEntries, mappedResources, referencesOut);
+
+      if (typeof fhir === 'string') {
+        inst.value = fhir;
+      } else if (typeof fhir === 'object') {
+        const { elementName } = FHIRHelper.getGeneralPurposeFHIRType(fhir);
+
+        if (elementName === 'CodeableConcept') {
+          inst.value = FHIRHelper.createInstanceFromFHIR('shr.core.CodeableConcept', fhir, shrId, allEntries, mappedResources, referencesOut);
+        }
+
+        if (elementName === 'Reference') {
+          const entryId = fhir['reference'];
+          if (!mappedResources[entryId]) {
+            const referencedEntry = allEntries.find(e => e.fullUrl === entryId);
+            if (referencedEntry) {
+              mappedResources[entryId] = FHIRHelper.createInstanceFromFHIR(null, referencedEntry['resource'], shrId, allEntries, mappedResources, referencesOut);
+            }
+          }
+          inst.value = FHIRHelper.createReference(mappedResources[entryId], referencesOut);
+        }
+      }
     }
     return inst;
   }

--- a/src/model/shr/medication/MedicationRequested.js
+++ b/src/model/shr/medication/MedicationRequested.js
@@ -262,6 +262,21 @@ class MedicationRequested extends ActionRequested {
     this.substitutionAllowed = substitutionAllowed; return this;
   }
 
+  // StatementDateTime added manually. this is present in newer versions of the spec
+  // this will become a shr.core.StatementDateTime, for now just make it a shr.core.BeginDateTime
+  // since both only contain a value of type dateTime
+  get statementDateTime() {
+    return this._statementDateTime;
+  }
+
+  set statementDateTime(statementDateTime) {
+    this._statementDateTime = statementDateTime;
+  }
+
+  withStatementDateTime(statementDateTime) {
+    this.statementDateTime = statementDateTime; return this;
+  }
+
   /**
    * Deserializes JSON data to an instance of the MedicationRequested class.
    * The JSON must be valid against the MedicationRequested JSON schema, although this is not validated by the function.
@@ -353,6 +368,9 @@ class MedicationRequested extends ActionRequested {
     }
     if (this.substitutionAllowed != null) {
       inst['SubstitutionAllowed'] = typeof this.substitutionAllowed.toJSON === 'function' ? this.substitutionAllowed.toJSON() : this.substitutionAllowed;
+    }
+    if (this.statementDateTime != null) {
+      inst['StatementDateTime'] = typeof this.statementDateTime.toJSON === 'function' ? this.statementDateTime.toJSON() : this.statementDateTime;
     }
     return inst;
   }
@@ -448,8 +466,17 @@ class MedicationRequested extends ActionRequested {
       const inst_reason = FHIRHelper.createInstanceFromFHIR('shr.base.Reason', fhir['reasonCodeableConcept'], shrId, allEntries, mappedResources, referencesOut, false);
       inst.reason.push(inst_reason);
     }
+    // reasonReference added manually since it doesn't seem to be in the spec
+    if (fhir['reasonReference'] != null) {
+      inst.reason = inst.reason || [];
+      const inst_reason = FHIRHelper.createInstanceFromFHIR('shr.base.Reason', fhir['reasonReference'], shrId, allEntries, mappedResources, referencesOut, false);
+      inst.reason.push(inst_reason);
+    }
     if (fhir['note'] != null) {
       inst.performerInstructions = FHIRHelper.createInstanceFromFHIR('shr.base.PerformerInstructions', fhir['note'], shrId, allEntries, mappedResources, referencesOut, false);
+    }
+    if (fhir['dateWritten'] != null) {
+      inst.statementDateTime = FHIRHelper.createInstanceFromFHIR('shr.core.BeginDateTime', fhir['dateWritten'], shrId, allEntries, mappedResources, referencesOut, false);
     }
     if (fhir['medicationReference'] != null) {
       const entryId = fhir['medicationReference']['reference'];
@@ -460,6 +487,10 @@ class MedicationRequested extends ActionRequested {
         }
       }
       inst.medication = mappedResources[entryId];
+    }
+    if (fhir['medicationCodeableConcept'] != null) {
+      inst.medication = FHIRHelper.createInstanceFromFHIR('shr.entity.Medication', {}, shrId, allEntries, mappedResources, referencesOut);
+      inst.medication.type = FHIRHelper.createInstanceFromFHIR('shr.core.Type', fhir['medicationCodeableConcept'], shrId, allEntries, mappedResources, referencesOut, false);
     }
     if (fhir['dosageInstruction'] != null && fhir['dosageInstruction'][0] != null) {
       if (fhir['dosageInstruction'][0]['text'] != null) {

--- a/src/patient/PatientRecord.jsx
+++ b/src/patient/PatientRecord.jsx
@@ -590,7 +590,7 @@ class PatientRecord {
         const conditionEntryId = condition.entryInfo.entryId.value || condition.entryInfo.entryId;
         medications = medications.filter((med) => {
             return med instanceof FluxMedicationRequested && med.reasons.some((r) => {
-                return r.value.entryId && r.value.entryId === conditionEntryId;
+                return r.value.entryId && this._entryIdsMatch(r.value.entryId, conditionEntryId);
             });
         });
         return medications;
@@ -686,7 +686,7 @@ class PatientRecord {
         const conditionEntryId = condition.entryInfo.entryId.value || condition.entryInfo.entryId;
         medications = medications.filter((med) => {
             return med instanceof FluxMedicationRequested && med.reasons.some((r) => {
-                return r.value.entryId && r.value.entryId === conditionEntryId;
+                return r.value.entryId && this._entryIdsMatch(r.value.entryId, conditionEntryId);
             });
         });
         return medications;
@@ -697,7 +697,7 @@ class PatientRecord {
         const conditionEntryId = condition.entryInfo.entryId.value || condition.entryInfo.entryId;
         return medications.filter((med) => {
             return med instanceof FluxMedicationRequested && med.reasons.some((r) => {
-                return r.value.entryId && r.value.entryId === conditionEntryId;
+                return r.value.entryId && this._entryIdsMatch(r.value.entryId, conditionEntryId);
             });
         });
     }
@@ -966,6 +966,16 @@ class PatientRecord {
         }
     }
 
+    _entryIdsMatch(entryId1, entryId2) {
+        if (!entryId1 || !entryId2) return false;
+
+        // entryId could either be just a string or wrapped in an object. 
+        // the spec says it should be a shr.base.EntryId but we'll be a little lax here to minimize changes
+        const lhs = entryId1.id || entryId1;
+        const rhs = entryId2.id || entryId2;
+        return lhs === rhs;
+    }
+
     _medChangesTimeSorter(a, b) {
         const a_time = a.metadata.authoredDateTime.dateTime;
         const b_time = b.metadata.authoredDateTime.dateTime;
@@ -981,8 +991,8 @@ class PatientRecord {
     }
 
     _reverseMedsTimeSorter(a, b) {
-        const a_startTime = new moment(a.expectedPerformanceTime.timePeriodStart, "D MMM YYYY");
-        const b_startTime = new moment(b.expectedPerformanceTime.timePeriodStart, "D MMM YYYY");
+        const a_startTime = new moment(a.startDate, "D MMM YYYY");
+        const b_startTime = new moment(b.startDate, "D MMM YYYY");
         if (a_startTime < b_startTime) {
             return 1;
         }

--- a/src/patientControl/MedicationsIndexer.js
+++ b/src/patientControl/MedicationsIndexer.js
@@ -11,7 +11,7 @@ class MedicationsIndexer extends BaseIndexer {
                 section,
                 subsection: "",
                 valueTitle: `Dosage`,
-                value: `${item.medication.amountPerDose.value} ${item.medication.amountPerDose.units}`,
+                value: item.medication.amountPerDose ? `${item.medication.amountPerDose.value} ${item.medication.amountPerDose.units}` : null,
                 onHighlight
             });
 
@@ -29,7 +29,7 @@ class MedicationsIndexer extends BaseIndexer {
                 section,
                 subsection: "",
                 valueTitle: `Timing`,
-                value: item.medication.timingOfDoses.value || item.medication.doseInstructionsText,
+                value: item.medication.timingOfDoses ? item.medication.timingOfDoses.value : item.medication.doseInstructionsText,
                 onHighlight
             });
 

--- a/src/summary/MedicationRangeChartVisualizer.jsx
+++ b/src/summary/MedicationRangeChartVisualizer.jsx
@@ -91,8 +91,11 @@ class MedicationRangeChartVisualizer extends Visualizer {
     }
 
     renderMedicationDosage = (lowerValue, upperValue, dosageValue, dosageUnit, timingValue, timingUnit, asNeededIndicator, doseInstructionsText) => {
-        // Determining if timingUnit has a value. Set if empty string if null.
+        // we don't want to render "null" so replace nulls here with empty string
         if (timingUnit == null) timingUnit = '';
+        if (dosageUnit == null) dosageUnit = '';
+        if (dosageValue == null) dosageValue = '';
+
         //Determining if asNeededIndicator is true. Set empty string if false, set string as needed if true.
         const asNeededString = asNeededIndicator ? 'as needed' : '';
 
@@ -122,7 +125,7 @@ class MedicationRangeChartVisualizer extends Visualizer {
                     {`${dosageValue} `}
                 </span>
                 <span className="medication-dosage-info">
-                    {`${dosageUnit} ${timingValue || doseInstructionsText} ${timingUnit} ${asNeededString}`}
+                    {`${dosageUnit} ${timingValue || doseInstructionsText || ''} ${timingUnit} ${asNeededString}`}
                 </span>
             </div>);
     }

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -78,8 +78,7 @@ export default class VisualizerManager {
             const dose = med.medication.amountPerDose ? `${med.medication.amountPerDose.value} ${med.medication.amountPerDose.units}` : "";
             const medicationChange = this.formatMedicationChange(med.medicationChange);
             const endDate = this.getEndDate(med);
-            const { doseInstructionsText } = med.medication;
-            let timing;
+            let timing = null;
 
             if (med.medication.timingOfDoses) {
                 if (!Lang.isNull(med.medication.timingOfDoses.units)) {
@@ -87,8 +86,10 @@ export default class VisualizerManager {
                 } else {
                     timing = med.medication.timingOfDoses.value;
                 }
-            } else {
-                timing = "";
+            }
+
+            if (timing && med.medication.asNeededIndicator) {
+                timing += ' as needed';
             }
 
             // isUnsigned is false by default
@@ -98,7 +99,6 @@ export default class VisualizerManager {
                 isUnsigned = med.medicationChange.isUnsigned;
                 source = med.medicationChange.source;
             }
-            const asNeeded = med.medication.asNeededIndicator ? ' as needed' : '';
 
             return [
                 {
@@ -115,10 +115,10 @@ export default class VisualizerManager {
                     value: dose,
                 },
                 {
-                    value: (timing || doseInstructionsText) + asNeeded,
+                    value: timing,
                 },
                 {
-                    value: med.medication.expectedPerformanceTime.timePeriodStart,
+                    value: med.medication.startDate,
                 },
                 {
                     value: {
@@ -138,7 +138,7 @@ export default class VisualizerManager {
 
     // Returns today's date if the medication has just been stopped
     getEndDate = (med) => {
-        let endDate = med.medication.expectedPerformanceTime.timePeriodEnd;
+        let endDate = med.medication.endDate;
         if (med.medicationChange && med.medicationChange.type === "stop") {
             endDate = med.medicationChange.date;
         }

--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -86,6 +86,8 @@ export default class VisualizerManager {
                 } else {
                     timing = med.medication.timingOfDoses.value;
                 }
+            } else if (med.medication.doseInstructionsText) {
+                timing = med.medication.doseInstructionsText;
             }
 
             if (timing && med.medication.asNeededIndicator) {

--- a/src/summary/metadata/TimelineSection.jsx
+++ b/src/summary/metadata/TimelineSection.jsx
@@ -108,10 +108,10 @@ export default class TimelineSection extends MetadataSection {
 
         const items = [];
         meds.forEach((med) => {
-            const ept = med.expectedPerformanceTime;
-            if (Lang.isNull(ept)) return;
-            const startTime = new moment(med.expectedPerformanceTime.timePeriodStart, "D MMM YYYY");
-            let endTime = new moment(med.expectedPerformanceTime.timePeriodEnd, "D MMM YYYY");
+            const startDate = med.startDate;
+            if (Lang.isNull(startDate)) return;
+            const startTime = new moment(med.startDate, "D MMM YYYY");
+            let endTime = new moment(med.endDate, "D MMM YYYY");
             if (!endTime.isValid()) {
                 endTime = new moment();
             }

--- a/src/summary/metadata/TimelineSection.jsx
+++ b/src/summary/metadata/TimelineSection.jsx
@@ -122,7 +122,8 @@ export default class TimelineSection extends MetadataSection {
             if (!med.amountPerDose) {
                 dosage = "not specified";
             } else {
-                dosage = med.amountPerDose.value + " " + med.amountPerDose.units + " " + (med.timingOfDoses.value || med.doseInstructionsText) + " " + (med.timingOfDoses.units ? med.timingOfDoses.units : "");
+                const timingOfDoses = med.timingOfDoses || {};
+                dosage = med.amountPerDose.value + " " + med.amountPerDose.units + " " + (timingOfDoses.value || med.doseInstructionsText) + " " + (timingOfDoses.units || "");
             }
 
             const source = this.determineSource(patient, med);


### PR DESCRIPTION
Addresses ASCODCP-1868.

Fixes a number of issues related to getting and displaying Medications when fetching a patient via SMART on FHIR:

1. FHIR `MedicationOrder` fields `reasonReference`, `medicationCodeableConcept`, and `dateWritten`  are manually mapped in `MedicationRequested.fromFHIR`. `reasonReference` and `medicationCodeableConcept` seem to be a spec or other toolchain issue as they are not even included in the profile that gets passed to the ES6 exporter. `MedicationRequested.StatementDateTime` (mapped from FHIR `MedicationOrder.dateWritten`) is not part of mCODE 0.5, but is used in newer versions of the spec, so I borrowed from those future versions to get that data loaded.
2. Adds a workaround in `Reason.fromFHIR` to specifically handle the types of values that class can have. This should be fixed permanently in the es6 exporter to address https://github.com/standardhealth/shr-es6-export/issues/35
3. Fixes some issues with references and IDs in the fromFHIR logic
4. The UI for Medications checks for prescription date in the field FluxMedicationRequested.expectedPerformanceTime, but the test patients don't have data that maps into this field. Synthea patients instead have a field MedicationOrder.dateWritten (which is required by the argonaut profile). Leveraged the existing FluxMedicationRequested.startDate field to check for dateWritten as a fallback, and updated places that called expectedPerformanceTime.timePeriodStart
5. Fixes for "null" displaying in the UI when certain fields such as dosage are missing


To test this:
 - Launch the Compass app via http://moonshot-dev.mitre.org:4001/?auth_error=&fhir_version_1=r2&fhir_version_2=r2&iss=&launch_ehr=1&launch_url=http%3A%2F%2Flocalhost%3A3000%2Flaunchcompass&patient=&prov_skip_auth=1&provider=&pt_skip_auth=1&public_key=&sb=&sde=&sim_ehr=0&token_lifetime=15&user_pt= -- make sure that FHIR Version is set to R2 (DSTU2) and the launch URL points to your local env /launchcompass
- Select any provider and then one of the patients with last name McOde123 (not Marvin or Matthias - they don't seem to have a cancer condition, which I'm very confused about)
 - When Compass loads, switch to the cancer condition.
 - Verify the medications load correctly.
Note that the synthea patients used here have minimal data in their medications so looking for alternative sources of data would be ideal. 

Known limitations:
 - There seems to be an issue with displaying Medications in general for non-cancer conditions. See jira ASCODCP-1893 for more info. This PR only addresses displaying Medications for cancer conditions.
 - There seem to be a lot of places where null pointer errors could theoretically occur, based on data. I took the approach of only updating things where I actually saw errors, but if people want I can revisit that.
 - Dates are formatted as FHIR dateTime strings, which look like "2018-07-24T20:01:41-04:00". Rather than address those piecemeal here I think that should be a separate task to handle all places where dates are processed and displayed to ensure consistency. See Jira ASCODCP-1857


---
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- **N/A** Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- **N/A** Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- **N/A** Document any new APIs/extension points
- **N/A** Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
