### PR TITLE
Disable Sign Note Button

### DIFF
--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -275,7 +275,12 @@ export default class NotesPanel extends Component {
     }
 
     renderSignButton = () => {
-        const signNoteDisabledClass = this.props.isAppBlurred ? 'content-disabled' : '';
+        const { isAppBlurred, structuredFieldMapManager } = this.props;
+
+        // containsIncompleteShortcuts searches the list of shortcuts in the note for an incomplete shortcut
+        const containsIncompleteShortcuts = [...structuredFieldMapManager.keyToShortcutMap.values()].some(shortcut => !shortcut.isComplete);
+        const signNoteDisabledClass = containsIncompleteShortcuts || isAppBlurred ? 'content-disabled' : '';
+
         return (
             <div id="finish-sign-component">
                 <Button 

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -334,7 +334,10 @@ class ShortcutManager {
                 isSet = context.getAttributeIsSet(parentAttribute);
                 isSettable = Lang.isUndefined(voa.isSettable) ? false : (voa.isSettable === "true");
                 if (isSettable) { // if is settable and not set, then we want to include the shortcut
-                    if (context.getAttributeIsSetByLabel(parentAttribute)) return false; // If attribute was set by label then we should not include the shortcut
+                    if (typeof context.getAttributeIsSetByLabel === 'function') {
+                        if (context.getAttributeIsSetByLabel(parentAttribute)) return false; // If attribute was set by label then we should not include the shortcut
+                    }
+
                     if (Lang.isArray(value)) return value.length < this.triggersPerShortcut[shortcutId].length;
                     return (!isSet);
                 } else {


### PR DESCRIPTION
Sign note button is now disabled when incomplete shortcuts are in the note.

Also check if `getAttributeIsSetByLabel` is a function so that app doesn't break.  Will add `getAttributeIsSetByLabel` in required classes in a future task.

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [ ] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [ ] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [ ] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [ ] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
