### PR TITLE
Categorize filter criteria with corresponding mCODE element

### DIFF
--- a/src/mcode-pilot/utils/filterTreatmentData.js
+++ b/src/mcode-pilot/utils/filterTreatmentData.js
@@ -123,7 +123,7 @@ function isSimilarPatient(treatmentDataPatient, similarPatientProps) {
                 const value = _.lowerCase(options[option].value);
 
                 // demographics
-                const { demographics, diseaseStatus, tumorMarkers, treatments } = treatmentDataPatient;
+                const { demographics, diseaseStatus, tumorMarkers } = treatmentDataPatient;
                 const { race, gender, birthDate } = demographics;
                 if (mcodeElement === 'shr.core.DateOfBirth') {
                     // age
@@ -169,25 +169,6 @@ function isSimilarPatient(treatmentDataPatient, similarPatientProps) {
                     return false;
                 } else if (mcodeElement === 'onco.core.CancerHistologicGrade' && (!diseaseStatus.grade || diseaseStatus.grade !== value)) {
                     return false;
-                // treatment history
-                } else if (option === 'receivedRadTherapy') {
-                    let hadTreatmentOption = value === 'yes';
-                    let hadTreatment = treatments.includes('radiation');
-                    if ((!hadTreatmentOption && hadTreatment) || (hadTreatmentOption && !hadTreatment)) {
-                        return false;
-                    }
-                } else if (option === 'receivedChemo') {
-                    let hadTreatmentOption = value === 'yes';
-                    let hadTreatment = treatments.includes('chemo') || treatments.includes('chemotherapy');
-                    if ((!hadTreatmentOption && hadTreatment) || (hadTreatmentOption && !hadTreatment)) {
-                        return false;
-                    }
-                } else if (option === 'hadSurgery') {
-                    let hadTreatmentOption = value === 'yes';
-                    let hadTreatment = treatments.includes('surgery');
-                    if ((!hadTreatmentOption && hadTreatment) || (hadTreatmentOption && !hadTreatment)) {
-                        return false;
-                    }
                 }
             }
         }

--- a/src/mcode-pilot/utils/recordToProps.js
+++ b/src/mcode-pilot/utils/recordToProps.js
@@ -9,23 +9,27 @@ export default function getProps(patient, condition) {
         "demographic": {
             "age": {
                 "display": "age",
+                "mcodeElement": "shr.core.DateOfBirth", // note the implied calculation required here
                 "valueType": "range",
                 "range": 10,
                 "value": patient.getAge()
             },
             "diagnosedAge": {
                 "display": "age at diagnosis",
+                "mcodeElement": "shr.core.DateOfDiagnosis", // note the implied calculation required here as well
                 "valueType": "range",
                 "range": 10,
                 "value": patient.getAgeAsOf(new Date(condition.diagnosisDate))
             },
             "race": {
                 "display": "race",
+                "mcodeElement": "shr.core.Race",
                 "valueType": "string",
                 "value": patient.patient.race
             },
             "gender": {
                 "display": "gender",
+                "mcodeElement": "shr.core.BirthSex",
                 "valueType": "string",
                 "value": _.lowerCase(patient.patient.gender)
             }
@@ -34,6 +38,7 @@ export default function getProps(patient, condition) {
         "pathology": {
             "grade": {
                 "display": "grade",
+                "mcodeElement": "onco.core.CancerHistologicGrade", // note: not part of mCODE 0.9 IG but it is part of the defined spec
                 "valueType": "int",
                 "value": (() => {
                     const grade = condition.getMostRecentHistologicalGrade();
@@ -44,30 +49,37 @@ export default function getProps(patient, condition) {
             },
             "stage": {
                 "display": "stage",
+                "mcodeElement": "onco.core.TNMClinicalStageGroup", 
+                // NOTE: the section is titled pathology but all the fields referenced in it are clinical, not pathologic
+                // (all sample data in the fixtures is clinical staging)
                 "valueType": "string",
                 "value": _safeGet(condition.getMostRecentClinicalStaging(), "stage"),
                 "reference": condition.getMostRecentClinicalStaging()
             },
             "t_stage": {
                 "display": "primary tumor",
+                "mcodeElement": "onco.core.TNMClinicalPrimaryTumorCategory",
                 "valueType": "string",
                 "value": _safeGet(condition.getMostRecentClinicalStaging(),"t_Stage"),
                 "reference": condition.getMostRecentClinicalStaging()
             },
             "n_stage": {
                 "display": "regional lymph nodes",
+                "mcodeElement": "onco.core.TNMClinicalRegionalNodesCategory",
                 "valueType": "string",
                 "value": _safeGet(condition.getMostRecentClinicalStaging(),"n_Stage"),
                 "reference": condition.getMostRecentClinicalStaging()
             },
             "m_stage": {
                 "display": "distant metastasis",
+                "mcodeElement": "onco.core.TNMClinicalDistantMetastasesCategory",
                 "valueType": "string",
                 "value": _safeGet(condition.getMostRecentClinicalStaging(),"m_Stage"),
                 "reference": condition.getMostRecentClinicalStaging()
             },
             "size": {
                 "display": "size (mm)",
+                "mcodeElement": "onco.core.TumorDimensions", // note: not part of mCODE 0.9 IG but it is part of the defined spec
                 "valueType": "int",
                 "value": (() => {
                     const quantity = _safeGet(_safeGet(condition.getObservationsOfTypeChronologicalOrder(FluxTumorDimensions), 0),'quantity');
@@ -79,6 +91,7 @@ export default function getProps(patient, condition) {
         "medical history": {
             "ECOG": {
                 "display": "ECOG Score",
+                "mcodeElement": "shr.core.ECOGPerformanceStatus",
                 "valueType": "range",
                 "range": 1,
                 "value": _safeGet(condition.getMostRecentECOGPerformanceStatus(), "value"),
@@ -92,6 +105,7 @@ export default function getProps(patient, condition) {
             if (!e.receptorType) return;
             propDict.pathology[e.receptorType.split(' ').join('')] = {
                 "display": e.receptorType,
+                "mcodeElement": "onco.core.TumorMarkerTest", 
                 "valueType": "string",
                 "value": _.lowerCase(e.status),
                 "reference": e

--- a/src/mcode-pilot/utils/recordToProps.js
+++ b/src/mcode-pilot/utils/recordToProps.js
@@ -148,6 +148,9 @@ function _mapProp(propDict) {
                 if(option.reference) {
                     propEntry.reference = option.reference;
                 }
+                if(option.mcodeElement) {
+                    propEntry.mcodeElement = option.mcodeElement;
+                }
 
                 if (option.valueType === "range") {
                     propEntry.minValue = (option.value >= option.range) ? option.value - option.range : 0;

--- a/src/reducers/initial.json
+++ b/src/reducers/initial.json
@@ -74,27 +74,6 @@
              }
           }
        },
-       "treatmentHistory": {
-          "selected": false,
-          "displayText": "treatment history",
-          "options": {
-             "hadSurgery": {
-                "selected": false,
-                "displayText": "had surgery",
-                "value": "yes"
-             },
-             "receivedRadTherapy": {
-                "selected": false,
-                "displayText": "received radiation therapy",
-                "value": "yes"
-             },
-             "receivedChemo": {
-                "selected": false,
-                "displayText": "received chemotherapy",
-                "value": "yes"
-             }
-          }
-       },
        "genetics": {
           "selected": false,
           "displayText": "genetics",


### PR DESCRIPTION
Addresses [ASCODCP-1955](https://jira.mitre.org/browse/ASCODCP-1955).

Tags the filter criteria with the corresponding mCODE element that the filter criteria represents. In some cases there isn't a perfect mapping, but this ensures a unique and consistent identifier for each filter criteria concept even if the display or internal keys change.
For instance, "age" and "age at diagnosis" are not technically part of mCODE, but "Patient date of birth" and "Condition date of diagnosis" are. 
Important note: these reference the mCODE 0.9 data elements to ensure consistency going forward, though that does mean some cases have slightly different names than the mCODE 0.5 classes that are currently in FluxNotes.

This is primarily intended for use by future implementations of the Outcomes Service, but to demonstrate they work I updated the existing static outcomes service to reference the mCODE element names instead of the field labels. Reviewers can verify that results are the same when filtering in the Treatment Options section of the /ccp endpoint before & after.

For more info see the mCODE IG: http://standardhealthrecord.org/guides/mcode/index.html and mCODE data dictionary: http://standardhealthrecord.org/guides/mcode/mCODEDataDictionary.xlsx 

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- **N/A** Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- **N/A** Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- **N/A** Document any new APIs/extension points
- **N/A** Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- **N/A** Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
