### PR TITLE
SMART on FHIR - reduce console errors and add resourceType configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "downshift": "^1.31.16",
     "elasticlunr": "https://github.com/mgramigna/elasticlunr.js",
     "es6-shim": "0.35.3",
-    "fhir-mapper": "^1.0.4",
+    "fhir-mapper": "^1.0.6",
     "fhirclient": "^0.1.12",
     "flat": "^4.1.0",
     "flux_notes_treatment_options_rest_client": "^1.1.2",

--- a/public/config.js
+++ b/public/config.js
@@ -31,6 +31,9 @@
         app: "CompassApp",
         isExact: true,
         dataSource: 'McodeV05SmartOnFhirDataSource',
+        dataSourceProps: {
+            resourceTypes: ['Patient', 'Condition', 'Encounter', 'MedicationOrder', 'Observation', 'Organization', 'Practitioner', 'Procedure']
+        },
         logoObject: {
             path: './compass-logo.png',
             altText: 'Compass logo',

--- a/src/__test__/backend/dataaccess/McodeV05SmartOnFhirDataSource.test.js
+++ b/src/__test__/backend/dataaccess/McodeV05SmartOnFhirDataSource.test.js
@@ -31,6 +31,12 @@ const samplePatientSearchData = {
     entry: hardCodedFHIRPatient.entry.filter(e => e['resource']['resourceType'] === 'Patient')
 };
 
+const sampleObservationSearchData = {
+    resourceType: 'Bundle',
+    type: 'searchset',
+    entry: hardCodedFHIRPatient.entry.filter(e => e['resource']['resourceType'] === 'Observation')
+};
+
 
 describe('SMART on FHIR data source', function() {
     const originalWindowFHIR = window.FHIR;
@@ -60,6 +66,27 @@ describe('SMART on FHIR data source', function() {
           .reply(200, samplePatientSearchData);
 
         const dataSource = new McodeV05SmartOnFhirDataSource();
+
+        dataSource.getPatient('1078857', (record, error) => {
+            if (record) {
+                scope.done(); // assert that all specified calls on the scope were performed
+                done();
+            }
+            if (error) {
+                 fail(JSON.stringify(error));
+            }
+        });
+    });
+
+    it('should fetch resource types defined in data source props', function (done) {
+        const scope = nock('http://localhost/')
+          .get('/fhir/Patient?_id=1078857')
+          .reply(200, samplePatientSearchData)
+          .get('/fhir/Observation?patient=1078857')
+          .reply(200, sampleObservationSearchData);
+          // in this case it doesn't need to fetch the metadata since the resourceTypes are manually specified
+
+        const dataSource = new McodeV05SmartOnFhirDataSource({ resourceTypes: ['Patient', 'Observation'] });
 
         dataSource.getPatient('1078857', (record, error) => {
             if (record) {

--- a/src/containers/CompassApp.jsx
+++ b/src/containers/CompassApp.jsx
@@ -60,7 +60,7 @@ export class CompassApp extends Component {
         if (Lang.isUndefined(this.props.dataSource)) {
             this.dataAccess = new DataAccess("HardCodedReadOnlyDataSource");
         } else {
-            this.dataAccess = new DataAccess(this.props.dataSource);
+            this.dataAccess = new DataAccess(this.props.dataSource, this.props.dataSourceProps);
         }
 
         //        this.summaryMetadata = new SummaryMetadata(this.setForceRefresh);

--- a/src/dataaccess/DataAccess.jsx
+++ b/src/dataaccess/DataAccess.jsx
@@ -23,7 +23,7 @@ export default class DataAccess {
         } else if (dataSourceName === 'HardCodedMcodeV05DataSource') {
             this.dataSource = new HardCodedMcodeV05DataSource();
         } else if (dataSourceName === 'McodeV05SmartOnFhirDataSource') {
-            this.dataSource = new McodeV05SmartOnFhirDataSource();
+            this.dataSource = new McodeV05SmartOnFhirDataSource(dataSourceProps);
         } else if (dataSourceName === 'GenericSmartOnFhirDstu2DataSource') {
             this.dataSource = new GenericSmartOnFhirDstu2DataSource(dataSourceProps);
         } else if (dataSourceName === 'HardcodedTabletMcodeV01DataSource') {

--- a/src/dataaccess/GenericSmartOnFhirDstu2DataSource.jsx
+++ b/src/dataaccess/GenericSmartOnFhirDstu2DataSource.jsx
@@ -4,7 +4,7 @@ import mappers from 'fhir-mapper';
 
 class GenericSmartOnFhirDstu2DataSource extends McodeV05SmartOnFhirDataSource {
     constructor(props) {
-        super();
+        super(props);
         this.mapper = props && props.mapper ? mappers[props.mapper] : null;
     }
 

--- a/src/dataaccess/utils/fhir-entry-processor.js
+++ b/src/dataaccess/utils/fhir-entry-processor.js
@@ -26,11 +26,16 @@ export default function(responses, patientId, resourceMapper = null) {
     const mappedResources = {};
     const referencesOut = [];
     const allObjects = entries.map(entry => {
+        const resource = entry.resource;
+        // if there's no profile on this resource we can't determine what class to convert it into
+        // so rather than error out just ignore it
+        if (!resource || !resource.meta || !resource.meta.profile || !resource.meta.profile[0]) return null;
+
         try {
-            const result = ObjectFactory.createInstanceFromFHIR(null, entry.resource, entry.resource.resourceType, patientId, entries, mappedResources, referencesOut);
+            const result = ObjectFactory.createInstanceFromFHIR(null, resource, resource.resourceType, patientId, entries, mappedResources, referencesOut);
 
             // shortId here is the standard "resourceType/resourceID" ID format
-            const shortId = `${entry.resource.resourceType}/${entry.resource.id}`;
+            const shortId = `${resource.resourceType}/${resource.id}`;
 
             // this format and the entry fullURL are 2 formats that are used for references
             // so add this object to the map with both keys, so either one could be used for lookups

--- a/src/model/fluxExtensions/FindingResultFix.js
+++ b/src/model/fluxExtensions/FindingResultFix.js
@@ -1,0 +1,50 @@
+import FindingResult from '../shr/base/FindingResult';
+import { FHIRHelper, uuid } from '../json-helper'; 
+
+/**
+ * This fix class replaces the shr.base.FindingResult.fromFHIR function with a version that handles various different FHIR types correctly.
+ 
+ * See this bug for more information: https://github.com/standardhealth/shr-es6-export/issues/35
+ */ 
+export default class FindingResultFix extends FindingResult {
+
+  static fromFHIR(fhir, fhirType, shrId=uuid(), allEntries=[], mappedResources={}, referencesOut=[], asExtension=false) {
+    const inst = new FindingResultFix();
+    if (!asExtension && fhir != null) {
+      // reminder: Reason.value can be: (CodeableConcept|Quantity|string|Range|Ratio|time|dateTime|TimePeriod)
+
+      switch(fhirType) {
+        case 'string':
+        case 'time':
+        case 'dateTime':
+          inst.value = fhir;
+          break;
+
+        case 'CodeableConcept':
+          inst.value = FHIRHelper.createInstanceFromFHIR('shr.core.CodeableConcept', fhir, 'CodeableConcept', shrId, allEntries, mappedResources, referencesOut);
+          break;
+
+        case 'Quantity':
+          inst.value = FHIRHelper.createInstanceFromFHIR('shr.core.Quantity', fhir, 'Quantity', shrId, allEntries, mappedResources, referencesOut);
+          break;
+
+        case 'Range':
+          inst.value = FHIRHelper.createInstanceFromFHIR('shr.core.Range', fhir, 'Range', shrId, allEntries, mappedResources, referencesOut);
+          break;
+
+        case 'Ratio':
+          inst.value = FHIRHelper.createInstanceFromFHIR('shr.core.Ratio', fhir, 'Ratio', shrId, allEntries, mappedResources, referencesOut);
+          break;
+
+        // the one instance here where the FHIR type != the SHR type name....
+        case 'Period':
+          inst.value = FHIRHelper.createInstanceFromFHIR('shr.core.TimePeriod', fhir, 'Period', shrId, allEntries, mappedResources, referencesOut);
+          break;
+
+        default:
+          // do nothing
+      }
+    }
+    return inst;
+  }
+}

--- a/src/model/init.js
+++ b/src/model/init.js
@@ -8,6 +8,7 @@ import CodingFix from './fluxExtensions/CodingFix';
 import CodeableConceptFix from './fluxExtensions/CodeableConceptFix';
 import ReasonFix from './fluxExtensions/ReasonFix';
 import MedicationRequestedFix from './fluxExtensions/MedicationRequestedFix';
+import FindingResultFix from './fluxExtensions/FindingResultFix';
 
 /**
  * The init function initializes the ES helper functions with the necessary dependencies for creating
@@ -26,6 +27,7 @@ function init() {
   ClassRegistry.set('shr.core', 'CodeableConcept', CodeableConceptFix);
   ClassRegistry.set('shr.base', 'Reason', ReasonFix);
   ClassRegistry.set('shr.medication', 'MedicationRequested', MedicationRequestedFix);
+  ClassRegistry.set('shr.base', 'FindingResult', FindingResultFix);
 }
 
 init();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4680,9 +4680,10 @@ fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fhir-mapper@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/fhir-mapper/-/fhir-mapper-1.0.4.tgz#2e44f90312e5ff3eaaa777488065f0ff709b7a55"
+fhir-mapper@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fhir-mapper/-/fhir-mapper-1.0.6.tgz#1c82971ff236feb82b2f0fc9ef7e530dcd56727c"
+  integrity sha512-UttkCJIJ7/cX/8jg6/toWJvPgHG9qwJK5iXuosS1IEBKWCVikifp418FHVU8zkSZA2CON1drD6bWBtkDXKsdNg==
   dependencies:
     fhirpath "^0.10.3"
     lodash "^4.17.11"


### PR DESCRIPTION
Addresses [ASCODCP-1934](https://jira.mitre.org/browse/ASCODCP-1934).

This PR has 2 main impacts:
1) Reduces the number of errors seen in the console when loading patients via SMART on FHIR, by skipping processing any FHIR resources that don't have profiles on them. The profiles are how the `fromFHIR` logic knows what SHR class to instantiate, so if there's no profile on something there's nothing we can do with it.
     - Also adds a fix for one specific SHR class, `shr.base.FindingResult` to let it handle different FHIR types appropriately. (This is a known limitation in the ES6 exporter that also affected the `shr.base.Reason` class) 
2) Adds a data source configuration option `resourceTypes` to specify which resource types should be fetched from the FHIR server. If the config option is not specified it falls back to fetching every resource type the server supports, as defined by the server's conformance statement. I set the `/smartcompass` endpoint to fetch the following FHIR resource types, since based on some quick testing these are the ones the app currently uses: Patient, Condition, Encounter, MedicationOrder, Observation, Organization, Practitioner, Procedure. 

This should be tested on (at least) both the `/smartcompass` and `/synthea` endpoints, since both of those leverage the SMART on FHIR data source. One simple test case is:
 - Launch the Compass app via http://moonshot-dev.mitre.org:4001/?auth_error=&fhir_version_1=r2&fhir_version_2=r2&iss=&launch_ehr=1&launch_url=http%3A%2F%2Flocalhost%3A3000%2Flaunchcompass&patient=&prov_skip_auth=1&provider=&pt_skip_auth=1&public_key=&sb=&sde=&sim_ehr=0&token_lifetime=15&user_pt= -- make sure that FHIR Version is set to R2 (DSTU2) and the launch URL points to your local env /launchcompass
 - Select the default provider and then patient Marshawn McOde
 - Confirm that medications load in the UI
 - Update config.js to remove `MedicationOrder` from the resourceTypes for /smartcompass
 - Rerun the above steps, and confirm that medications no longer appear in the UI


_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [x] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
