### PR TITLE
Quick fix to prevent null reference in react-minimap

### DIFF
--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -262,6 +262,12 @@ export class Minimap extends React.Component {
   synchronize(options) {
       const {width, height} = this.state;
 
+      if (!this.source) {
+        // unexpected condition here, likely caused by re-rendering due to an async data chance
+        // which resulted in the `source` ref getting unset and it has not yet been reset.
+        return;
+      }
+
       const rect = this.source.getBoundingClientRect();
 
       const dims = [ rect.width, rect.height ];


### PR DESCRIPTION
Addresses [ASCODCP-2023](https://jira.mitre.org/browse/ASCODCP-2023)

The core issue here is that the react-minimap component is throwing an error when it tries to reference an object that shouldn't be null. Previously (prior to the react-scripts upgrade) this error just printed to console, but now there is an error overlay that pops up and interrupts the user. One alternative or additional change if we want it would be to disable that overlay, but that may require ejecting if our react scripts customizations don't support that specific change. (See https://stackoverflow.com/questions/46589819/disable-error-overlay-in-development-mode )

The exception occurs when the `synchronize` function in `react-minimap.js` tries to call a function on `this.source`. `source` gets set as a "callback ref" ( https://reactjs.org/docs/refs-and-the-dom.html#callback-refs ) and so is guaranteed to be set when everything is rendered synchronously. Where the problem comes in is when the page gets re-rendered asynchronously, ie, when loading a patient via SMART on FHIR. In this case we're actually re-rendering multiple times: the first render is the loading spinner which doesn't include the minimap, the second is the structure of the UI (see screenshot at the bottom of the PR), and the third is the full content of the UI. Before that second render, `source` gets set as expected, but somewhere between that second and third render it gets un-set (same screenshot at the bottom of the PR for the stack trace). Then the synchronize function gets called (via the `setTimeout` in `componentWillMount`)  and errors out. Later before the third render `source` gets set again, and from there the app continues to function as expected. 

I'm sure there is some other way to reorganize or rearchitect either the FN UI or the minimap component to be more async-friendly, but that's going to require more research and time, which I'm not sure this issue really needs.
(You may notice on that react docs link there is a "Caveats with callback refs" -- I tried the change recommended there, but it didn't seem to change anything)

The quick fix implemented here is to just add a null check on `this.source` in `synchronize`. 

This should have no impact on any functionality, just preventing an error from being thrown.

Steps to reproduce:

 - use the SMART launcher at http://moonshot-dev.mitre.org:4001/?auth_error=&fhir_version_1=r2&fhir_version_2=r2&iss=&launch_ehr=1&launch_url=http%3A%2F%2Flocalhost%3A3000%2Flaunchcompass&patient=&prov_skip_auth=1&provider=&pt_skip_auth=1&public_key=&sb=&sde=&sim_ehr=0&token_lifetime=15&user_pt=
 - launch compass at http://localhost:3000/launchcompass
 - select default provider
 - select Minnie McOde


_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [ ] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code

Intermediate re-render:
![image](https://user-images.githubusercontent.com/13512036/59609009-90ee7280-90e4-11e9-85c6-ef14698c576c.png)
