### PR TITLE
Open notes with incomplete inserters

### DIFF
--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -208,8 +208,9 @@ export default class InsertValue extends Shortcut {
         if (Lang.isNull(text)) {
             text = this.initiatingTrigger;
         } else if (typeof text === "string" && text.startsWith(this.getPrefixCharacter())) {
+            // NOTE: This should only happen when the inserter shortcut is incomplete; we want that serialization to reflect the incompleteness
             if (text === this.initiatingTrigger) {
-                return `${text}`;
+                return text;
             }
             text = text.substring(1);
         }

--- a/src/shortcuts/InsertValue.jsx
+++ b/src/shortcuts/InsertValue.jsx
@@ -207,12 +207,11 @@ export default class InsertValue extends Shortcut {
         let text = displayText || this.text; // Use provided text to override shortcut text
         if (Lang.isNull(text)) {
             text = this.initiatingTrigger;
-        }
-        else if (typeof text === "string" && text.startsWith(this.getPrefixCharacter())) {
+        } else if (typeof text === "string" && text.startsWith(this.getPrefixCharacter())) {
+            if (text === this.initiatingTrigger) {
+                return `${text}`;
+            }
             text = text.substring(1);
-        }
-        if (text === this.initiatingTrigger) {
-            return `${text}`;
         }
         // If this.valueObject exists, put the entryId of the valueObject in the result text
         if (this.valueObject) {


### PR DESCRIPTION
The only issue I found with completing incomplete shortcuts was that they weren't serialized properly when closing a note; the result was that you couldn't start a note, create an incomplete shortcut, close it and reopen it. This fix in serialization addresses that. 

Note there are other bugs I discovered that have been tracked in the form of JIRA's, specifically 2096 and 2097

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [N/A] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [N/A] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [N/A] Document any new APIs/extension points
- [N/A] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
