### PR TITLE
Storing Longitudinal Data Table Favorites Locally via Preference Manager

### DIFF
--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -64,6 +64,7 @@ export default class LongitudinalTable extends Component {
         }
         return [tableValues, dates];
     }
+    // updates current favorites and local storage
     toggleFavorites = (section) => {
         const newFavorites = this.state.favorites;
         if (_.includes(this.state.favorites, section.name)) {
@@ -200,4 +201,5 @@ LongitudinalTable.propTypes = {
     conditionSectionName: propTypes.string,
     reorderRows: propTypes.func,
     subsectionLabel: propTypes.string,
+    preferenceManager: propTypes.object,
 };

--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -70,12 +70,12 @@ export default class LongitudinalTable extends Component {
         if (_.includes(this.state.favorites, section.name)) {
             newFavorites.splice(this.state.favorites.indexOf(section.name), 1);
             this.setState({ favorites: newFavorites });
-            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-favorites`, newFavorites);
+            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-longitudinal-viz-favorites`, newFavorites)
         }
         else {
             newFavorites.push(section.name);
             this.setState({ favorites: newFavorites });
-            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-favorites`, newFavorites);
+            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-longitudinal-viz-favorites`, newFavorites)
         }
     }
     renderStar(name, id) {

--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -5,7 +5,6 @@ import moment from 'moment';
 import './LongitudinalTable.css';
 import propTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
-import { Button } from 'material-ui';
 
 export default class LongitudinalTable extends Component {
 
@@ -26,39 +25,6 @@ export default class LongitudinalTable extends Component {
                 })
             });
         }
-    }
-    updateInput(key, value) {
-        // update react state
-        this.setState({ [key]: value });
-
-        // update localStorage
-        localStorage.setItem(key, value);
-    }
-    hydrateStateWithLocalStorage() {
-        // for all items in state
-        if (localStorage.hasOwnProperty('favorites')) {
-            // get the key's value from localStorage
-            let value = localStorage.getItem('favorites');
-            if (value === '') {
-                this.setState({'favorites': []});
-                return;
-            }
-            // parse the localStorage string and setState
-            try {
-                value = JSON.parse(value);
-                const valueArray = value.split(',');
-                console.log('value2 :', valueArray);
-                this.setState({ 'favorites': valueArray });
-            } catch (e) {
-                // handle empty string
-                const valueArray = value.split(',');
-                console.log('value2 :', valueArray);
-                this.setState({ 'favorites': valueArray });
-            }
-        }
-    }
-    componentDidMount() {
-        this.hydrateStateWithLocalStorage();
     }
     /*
     Assigns an id to each row
@@ -102,13 +68,13 @@ export default class LongitudinalTable extends Component {
         const newFavorites = this.state.favorites;
         if (_.includes(this.state.favorites, section.name)) {
             newFavorites.splice(this.state.favorites.indexOf(section.name), 1);
-            // this.setState({ favorites: newFavorites });
-            this.updateInput('favorites', newFavorites);
+            this.setState({ favorites: newFavorites });
+            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-favorites`, newFavorites);
         }
         else {
             newFavorites.push(section.name);
-            // this.setState({ favorites: newFavorites });
-            this.updateInput('favorites', newFavorites);
+            this.setState({ favorites: newFavorites });
+            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-favorites`, newFavorites);
         }
     }
     renderStar(name, id) {

--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -70,12 +70,12 @@ export default class LongitudinalTable extends Component {
         if (_.includes(this.state.favorites, section.name)) {
             newFavorites.splice(this.state.favorites.indexOf(section.name), 1);
             this.setState({ favorites: newFavorites });
-            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-longitudinal-viz-favorites`, newFavorites)
+            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-longitudinal-viz-favorites`, newFavorites);
         }
         else {
             newFavorites.push(section.name);
             this.setState({ favorites: newFavorites });
-            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-longitudinal-viz-favorites`, newFavorites)
+            this.props.preferenceManager.setPreference(`${this.props.conditionSectionName}-longitudinal-viz-favorites`, newFavorites);
         }
     }
     renderStar(name, id) {

--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 import './LongitudinalTable.css';
 import propTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import { Button } from 'material-ui';
 
 export default class LongitudinalTable extends Component {
 
@@ -25,6 +26,39 @@ export default class LongitudinalTable extends Component {
                 })
             });
         }
+    }
+    updateInput(key, value) {
+        // update react state
+        this.setState({ [key]: value });
+
+        // update localStorage
+        localStorage.setItem(key, value);
+    }
+    hydrateStateWithLocalStorage() {
+        // for all items in state
+        if (localStorage.hasOwnProperty('favorites')) {
+            // get the key's value from localStorage
+            let value = localStorage.getItem('favorites');
+            if (value === '') {
+                this.setState({'favorites': []});
+                return;
+            }
+            // parse the localStorage string and setState
+            try {
+                value = JSON.parse(value);
+                const valueArray = value.split(',');
+                console.log('value2 :', valueArray);
+                this.setState({ 'favorites': valueArray });
+            } catch (e) {
+                // handle empty string
+                const valueArray = value.split(',');
+                console.log('value2 :', valueArray);
+                this.setState({ 'favorites': valueArray });
+            }
+        }
+    }
+    componentDidMount() {
+        this.hydrateStateWithLocalStorage();
     }
     /*
     Assigns an id to each row
@@ -68,11 +102,13 @@ export default class LongitudinalTable extends Component {
         const newFavorites = this.state.favorites;
         if (_.includes(this.state.favorites, section.name)) {
             newFavorites.splice(this.state.favorites.indexOf(section.name), 1);
-            this.setState({ favorites: newFavorites });
+            // this.setState({ favorites: newFavorites });
+            this.updateInput('favorites', newFavorites);
         }
         else {
             newFavorites.push(section.name);
-            this.setState({ favorites: newFavorites });
+            // this.setState({ favorites: newFavorites });
+            this.updateInput('favorites', newFavorites);
         }
     }
     renderStar(name, id) {

--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -5,7 +5,6 @@ import moment from 'moment';
 import './LongitudinalTable.css';
 import propTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
-import { Button } from 'material-ui';
 
 export default class LongitudinalTable extends Component {
 
@@ -26,39 +25,6 @@ export default class LongitudinalTable extends Component {
                 })
             });
         }
-    }
-    updateInput(key, value) {
-        // update react state
-        this.setState({ [key]: value });
-
-        // update localStorage
-        localStorage.setItem(key, value);
-    }
-    hydrateStateWithLocalStorage() {
-        // for all items in state
-        if (localStorage.hasOwnProperty('favorites')) {
-            // get the key's value from localStorage
-            let value = localStorage.getItem('favorites');
-            if (value === '') {
-                this.setState({'favorites': []});
-                return;
-            }
-            // parse the localStorage string and setState
-            try {
-                value = JSON.parse(value);
-                const valueArray = value.split(',');
-                console.log('value2 :', valueArray);
-                this.setState({ 'favorites': valueArray });
-            } catch (e) {
-                // handle empty string
-                const valueArray = value.split(',');
-                console.log('value2 :', valueArray);
-                this.setState({ 'favorites': valueArray });
-            }
-        }
-    }
-    componentDidMount() {
-        this.hydrateStateWithLocalStorage();
     }
     /*
     Assigns an id to each row

--- a/src/summary/LongitudinalTable.jsx
+++ b/src/summary/LongitudinalTable.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 import './LongitudinalTable.css';
 import propTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import { Button } from 'material-ui';
 
 export default class LongitudinalTable extends Component {
 
@@ -25,6 +26,39 @@ export default class LongitudinalTable extends Component {
                 })
             });
         }
+    }
+    updateInput(key, value) {
+        // update react state
+        this.setState({ [key]: value });
+
+        // update localStorage
+        localStorage.setItem(key, value);
+    }
+    hydrateStateWithLocalStorage() {
+        // for all items in state
+        if (localStorage.hasOwnProperty('favorites')) {
+            // get the key's value from localStorage
+            let value = localStorage.getItem('favorites');
+            if (value === '') {
+                this.setState({'favorites': []});
+                return;
+            }
+            // parse the localStorage string and setState
+            try {
+                value = JSON.parse(value);
+                const valueArray = value.split(',');
+                console.log('value2 :', valueArray);
+                this.setState({ 'favorites': valueArray });
+            } catch (e) {
+                // handle empty string
+                const valueArray = value.split(',');
+                console.log('value2 :', valueArray);
+                this.setState({ 'favorites': valueArray });
+            }
+        }
+    }
+    componentDidMount() {
+        this.hydrateStateWithLocalStorage();
     }
     /*
     Assigns an id to each row

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -34,22 +34,13 @@ export default class LongitudinalTableVisualizer extends Visualizer {
             }
         }
         this.sortData(data);
-        // order such that favorites are in the front of the array in sorted order
-        let pointer1 = 0;
-        let pointer2 = 1;
-        while (pointer1 < data.length && pointer2 < data.length) {
-            while (!data[pointer2].favorite) {
-                pointer2++;
-                if (pointer2 >= data.length) return data;
-            }
-            if (!data[pointer1].favorite) {
-                const temp = data[pointer1];
-                data[pointer1] = data[pointer2];
-                data[pointer2] = temp;
-                pointer2++;
-            }
-            pointer1++;
-        }
+        const favsArray = [];
+        const notFavsArray = [];
+        data.forEach((section) => {
+            if (section.favorite) favsArray.push(section);
+            else notFavsArray.push(section);
+        });
+        data = favsArray.concat(notFavsArray);
         return data;
     }
     sortData = (formattedData) => {
@@ -75,7 +66,7 @@ export default class LongitudinalTableVisualizer extends Visualizer {
         data.forEach((section) => { //to get the favorites in front of the not favorites
             if (section.favorite) {
                 separatedArray.unshift(section);
-                numFavs ++;
+                numFavs++;
             } else {
                 separatedArray.push(section);
             }

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -14,34 +14,42 @@ export default class LongitudinalTableVisualizer extends Visualizer {
         };
     }
     formatData = (section) => { //creates an array with one object for each section (wbc, platelets, etc.)
-        let data = [];
         const favorites = [];
+        const favsArray = [];
+        const notFavsArray = [];
         const name = `${this.props.conditionSection.name}-favorites`;
         if (this.props.preferenceManager.getPreference(name)) {
             favorites.push(...this.props.preferenceManager.getPreference(name));
         }
         for (let conditionIndex = 0; conditionIndex < section.length; conditionIndex++) {
             if (section[conditionIndex].data_cache) {
-                data.push(
-                    {
-                        name: section[conditionIndex].name,
-                        unit: section[conditionIndex].data_cache[0].unit,
-                        datesAndData: this.buildDataObject(conditionIndex, section),
-                        bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
-                        favorite: _.includes(favorites, section[conditionIndex].name),
-                    }
-                );
+                if (_.includes(favorites, section[conditionIndex].name)) {
+                    favsArray.push(
+                        {
+                            name: section[conditionIndex].name,
+                            unit: section[conditionIndex].data_cache[0].unit,
+                            datesAndData: this.buildDataObject(conditionIndex, section),
+                            bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
+                            favorite: true,
+                        }
+                    );
+                }
+                else {
+                    notFavsArray.push(
+                        {
+                            name: section[conditionIndex].name,
+                            unit: section[conditionIndex].data_cache[0].unit,
+                            datesAndData: this.buildDataObject(conditionIndex, section),
+                            bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
+                            favorite: false,
+                        }
+                    );
+                }
             }
         }
-        this.sortData(data);
-        const favsArray = [];
-        const notFavsArray = [];
-        data.forEach((section) => {
-            if (section.favorite) favsArray.push(section);
-            else notFavsArray.push(section);
-        });
-        data = favsArray.concat(notFavsArray);
-        return data;
+        this.sortData(favsArray);
+        this.sortData(notFavsArray);
+        return favsArray.concat(notFavsArray);
     }
     sortData = (formattedData) => {
         formattedData.sort((section1, section2) => {

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -14,42 +14,29 @@ export default class LongitudinalTableVisualizer extends Visualizer {
         };
     }
     formatData = (section) => { //creates an array with one object for each section (wbc, platelets, etc.)
-        const favorites = [];
-        const favsArray = [];
-        const notFavsArray = [];
+        const favoritedNames = [];
+        const favoritedSections = [];
+        const unfavoritedSections = [];
         const name = `${this.props.conditionSection.name}-favorites`;
         if (this.props.preferenceManager.getPreference(name)) {
-            favorites.push(...this.props.preferenceManager.getPreference(name));
+            favoritedNames.push(...this.props.preferenceManager.getPreference(name));
         }
         for (let conditionIndex = 0; conditionIndex < section.length; conditionIndex++) {
             if (section[conditionIndex].data_cache) {
-                if (_.includes(favorites, section[conditionIndex].name)) {
-                    favsArray.push(
-                        {
-                            name: section[conditionIndex].name,
-                            unit: section[conditionIndex].data_cache[0].unit,
-                            datesAndData: this.buildDataObject(conditionIndex, section),
-                            bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
-                            favorite: true,
-                        }
-                    );
-                }
-                else {
-                    notFavsArray.push(
-                        {
-                            name: section[conditionIndex].name,
-                            unit: section[conditionIndex].data_cache[0].unit,
-                            datesAndData: this.buildDataObject(conditionIndex, section),
-                            bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
-                            favorite: false,
-                        }
-                    );
-                }
+                let currentSection = {
+                    name: section[conditionIndex].name,
+                    unit: section[conditionIndex].data_cache[0].unit,
+                    datesAndData: this.buildDataObject(conditionIndex, section),
+                    bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
+                    favorite: _.includes(favoritedNames, section[conditionIndex].name),
+                };
+                if (currentSection.favorite) favoritedSections.push(currentSection)
+                else unfavoritedSections.push(currentSection);
             }
         }
-        this.sortData(favsArray);
-        this.sortData(notFavsArray);
-        return favsArray.concat(notFavsArray);
+        this.sortData(favoritedSections);
+        this.sortData(unfavoritedSections);
+        return favoritedSections.concat(unfavoritedSections);
     }
     sortData = (formattedData) => {
         formattedData.sort((section1, section2) => {
@@ -79,11 +66,11 @@ export default class LongitudinalTableVisualizer extends Visualizer {
                 separatedArray.push(section);
             }
         });
-        const favsArray = _.slice(separatedArray, 0,numFavs); //take just the favs and sort them alphabetically
+        const favsArray = _.slice(separatedArray, 0, numFavs); //take just the favs and sort them alphabetically
         this.sortData(favsArray);
-        const notFavsArray = _.slice(separatedArray,numFavs,separatedArray.length); //take just the not favs and sort them alphabetically
+        const notFavsArray = _.slice(separatedArray, numFavs, separatedArray.length); //take just the not favs and sort them alphabetically
         this.sortData(notFavsArray);
-        const finalArray = _.concat(favsArray,notFavsArray); //but the favs back together with the not favs in one array
+        const finalArray = _.concat(favsArray, notFavsArray); //but the favs back together with the not favs in one array
         this.setState({ data: finalArray });
     }
     componentWillReceiveProps(nextProps) {
@@ -103,7 +90,13 @@ export default class LongitudinalTableVisualizer extends Visualizer {
     render() {
         return (
             <div>
-                <LongitudinalTable reorderRows={this.reorderRows} dataInfo={this.state.data} tdpSearchSuggestions={this.props.tdpSearchSuggestions} conditionSectionName={this.props.conditionSection.name} subsectionLabel={this.props.conditionSection.subsectionLabel} preferenceManager={this.props.preferenceManager} />
+                <LongitudinalTable
+                    reorderRows={this.reorderRows}
+                    dataInfo={this.state.data}
+                    tdpSearchSuggestions={this.props.tdpSearchSuggestions}
+                    conditionSectionName={this.props.conditionSection.name}
+                    subsectionLabel={this.props.conditionSection.subsectionLabel}
+                    preferenceManager={this.props.preferenceManager} />
             </div>
         );
     }

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -14,7 +14,7 @@ export default class LongitudinalTableVisualizer extends Visualizer {
         };
     }
     formatData = (section) => { //creates an array with one object for each section (wbc, platelets, etc.)
-        const data = [];
+        let data = [];
         const favorites = [];
         const name = `${this.props.conditionSection.name}-favorites`;
         if (this.props.preferenceManager.getPreference(name)) {

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -17,7 +17,7 @@ export default class LongitudinalTableVisualizer extends Visualizer {
         const favoritedNames = [];
         const favoritedSections = [];
         const unfavoritedSections = [];
-        const name = `${this.props.conditionSection.name}-favorites`;
+        const name = `${this.props.conditionSection.name}-longitudinal-viz-favorites`;
         if (this.props.preferenceManager.getPreference(name)) {
             favoritedNames.push(...this.props.preferenceManager.getPreference(name));
         }

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -15,6 +15,11 @@ export default class LongitudinalTableVisualizer extends Visualizer {
     }
     formatData = (section) => { //creates an array with one object for each section (wbc, platelets, etc.)
         const data = [];
+        const favorites = [];
+        const name = `${this.props.conditionSection.name}-favorites`;
+        if (this.props.preferenceManager.getPreference(name)) {
+            favorites.push(...this.props.preferenceManager.getPreference(name));
+        }
         for (let conditionIndex = 0; conditionIndex < section.length; conditionIndex++) {
             if (section[conditionIndex].data_cache) {
                 data.push(
@@ -23,12 +28,28 @@ export default class LongitudinalTableVisualizer extends Visualizer {
                         unit: section[conditionIndex].data_cache[0].unit,
                         datesAndData: this.buildDataObject(conditionIndex, section),
                         bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
-                        favorite: false,
+                        // favorite should check whether list of favorites contain the name im looking at
+                        favorite: _.includes(favorites, section[conditionIndex].name),
                     }
                 );
             }
         }
         this.sortData(data);
+        let pointer1 = 0;
+        let pointer2 = 1;
+        while (pointer1 < data.length && pointer2 < data.length) {
+            while (!data[pointer2].favorite) {
+                pointer2++;
+                if (pointer2 >= data.length) return data;
+            }
+            if (!data[pointer1].favorite) {
+                const temp = data[pointer1];
+                data[pointer1] = data[pointer2];
+                data[pointer2] = temp;
+                pointer2++;
+            }
+            pointer1++;
+        }
         return data;
     }
     sortData = (formattedData) => {
@@ -101,4 +122,5 @@ LongitudinalTableVisualizer.propTypes = {
     sectionTransform: propTypes.func,
     tdpSearchSuggestions: propTypes.array,
     visualizerManager: propTypes.object,
+    preferenceManager: propTypes.object,
 };

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -28,13 +28,13 @@ export default class LongitudinalTableVisualizer extends Visualizer {
                         unit: section[conditionIndex].data_cache[0].unit,
                         datesAndData: this.buildDataObject(conditionIndex, section),
                         bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
-                        // favorite should check whether list of favorites contain the name im looking at
                         favorite: _.includes(favorites, section[conditionIndex].name),
                     }
                 );
             }
         }
         this.sortData(data);
+        // order such that favorites are in the front of the array in sorted order
         let pointer1 = 0;
         let pointer2 = 1;
         while (pointer1 < data.length && pointer2 < data.length) {

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -23,14 +23,14 @@ export default class LongitudinalTableVisualizer extends Visualizer {
         }
         for (let conditionIndex = 0; conditionIndex < section.length; conditionIndex++) {
             if (section[conditionIndex].data_cache) {
-                let currentSection = {
+                const currentSection = {
                     name: section[conditionIndex].name,
                     unit: section[conditionIndex].data_cache[0].unit,
                     datesAndData: this.buildDataObject(conditionIndex, section),
                     bands: section[conditionIndex].bands && section[conditionIndex].bands.length > 0 ? section[conditionIndex].bands : null,
                     favorite: _.includes(favoritedNames, section[conditionIndex].name),
                 };
-                if (currentSection.favorite) favoritedSections.push(currentSection)
+                if (currentSection.favorite) favoritedSections.push(currentSection);
                 else unfavoritedSections.push(currentSection);
             }
         }

--- a/src/summary/LongitudinalTableVisualizer.jsx
+++ b/src/summary/LongitudinalTableVisualizer.jsx
@@ -104,7 +104,7 @@ export default class LongitudinalTableVisualizer extends Visualizer {
     render() {
         return (
             <div>
-                <LongitudinalTable reorderRows={this.reorderRows} dataInfo={this.state.data} tdpSearchSuggestions={this.props.tdpSearchSuggestions} conditionSectionName={this.props.conditionSection.name} subsectionLabel={this.props.conditionSection.subsectionLabel} />
+                <LongitudinalTable reorderRows={this.reorderRows} dataInfo={this.state.data} tdpSearchSuggestions={this.props.tdpSearchSuggestions} conditionSectionName={this.props.conditionSection.name} subsectionLabel={this.props.conditionSection.subsectionLabel} preferenceManager={this.props.preferenceManager} />
             </div>
         );
     }

--- a/src/summary/TargetedDataSection.jsx
+++ b/src/summary/TargetedDataSection.jsx
@@ -452,6 +452,7 @@ export default class TargetedDataSection extends Component {
                 tdpSearchSuggestions={this.tdpSearchSuggestions}
                 highlightedSearchSuggestion={this.props.highlightedSearchSuggestion}
                 visualizerManager={this.props.visualizerManager}
+                preferenceManager={this.props.preferenceManager}
             />
         );
     }


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

Used preference manager such that longitudinal table can store favorites within local storage. Thus when you refresh the page after selecting lab/vital names as favorites, they will be favorited and show up as favorites on load, starred in sorted order.
## Submitter:

**Running the Application**

- [X] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [x] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
