### PR TITLE
Allow multiple insertions of #reason

### DIFF
--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -15,6 +15,7 @@ export default class CreatorChild extends Shortcut {
 
     initialize(contextManager, trigger, updatePatient = true) {
         super.initialize(contextManager, trigger, updatePatient);
+        super.determineParentContext(contextManager, this.metadata["knownParentContexts"], this.metadata["parentAttribute"]);
         let text = this.determineText(contextManager);
         if (!Lang.isUndefined(text)) {
             if (Lang.isArray(text) || text === 'date-id') {
@@ -24,15 +25,13 @@ export default class CreatorChild extends Shortcut {
             }
         }
 
-        super.determineParentContext(contextManager, this.metadata["knownParentContexts"], this.metadata["parentAttribute"]);
-
         if (!Lang.isUndefined(this.parentContext)) {
             this.parentContext.addChild(this);
         }
-        var found = false;
-        var picker = false;
+        let found = false;
+        let picker = false;
         if (this.metadata.stringTriggers) {
-            for (var i = 0; i < this.metadata.stringTriggers.length; i++) {
+            for (let i = 0; i < this.metadata.stringTriggers.length; i++) {
                 if (this.metadata.stringTriggers[i].name === trigger) {
                     found = true;
                     if (this.metadata.stringTriggers[i].picker) {
@@ -90,7 +89,12 @@ export default class CreatorChild extends Shortcut {
         } else if (Lang.isArray(this.metadata.picker)) {
             return this.metadata.picker;
         } else {
-            return this.getValueSet(this.metadata.picker).map((item) => {
+            // Check the attribute value of the parent to filter the options based on which ones exist in the editor already
+            const attributeValue = this.parentContext ? this.parentContext.getAttributeValue(this.metadata.parentAttribute) || [] : [];
+            return this.getValueSet(this.metadata.picker).filter(item => {
+                // If the current attribute value contains this item in the ValueSet, don't include it in the options to select from
+                return !Lang.includes(attributeValue, item.name);
+            }).map((item) => {
                 return {"key": item.id || item.code, "context": item.name, "object": item};
             });
         }
@@ -141,9 +145,10 @@ export default class CreatorChild extends Shortcut {
         if (this.parentContext) {
             const parentAttributeValue = this.parentContext.getAttributeValue(this.metadata.parentAttribute);
 
+            // If we have a multi-choice shortcut, it is incomplete only if the label inserted with no value selected
             if (Lang.isArray(parentAttributeValue)) {
-                // For creators that support multiple options, incomplete if there are none specified
-                return !Lang.isEmpty(parentAttributeValue);
+                // If text matches the label, no value selected yet. Render as incomplete
+                return this.getText() !== this.metadata.label.substring(1);
             }
 
             return !!parentAttributeValue; // If parent attribute is defined, shortcut is complete, else it is incomplete

--- a/src/shortcuts/Shortcut.jsx
+++ b/src/shortcuts/Shortcut.jsx
@@ -179,13 +179,11 @@ class Shortcut extends Context {
             return null;
         case "date":
             return ContextCalendar;
+        case "multi-choice":
         case "choice":
             return ContextListOptions;
         case "menu":
             return ContextGetHelp;
-        case "multi-choice":
-            console.error(`We don't currently support a completion component for ${this.metadata.subtype}-subtypes; trying to get a completionComponent for ${this.metadata.id}`);
-            return null;
         default:
             console.error(`We don't currently support a completion component for ${this.metadata.subtype}-subtypes; trying to get a completionComponent for ${this.metadata.id}`);
             return null;

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -335,7 +335,9 @@ class ShortcutManager {
                 isSet = context.getAttributeIsSet(parentAttribute);
                 isSettable = Lang.isUndefined(voa.isSettable) ? false : (voa.isSettable === "true");
                 if (isSettable) { // if is settable and not set, then we want to include the shortcut
-                    if (typeof context.getAttributeIsSetByLabel === 'function') {
+
+                    // We do not care if the attribute is set by the label for multi-choice shortcuts
+                    if (typeof context.getAttributeIsSetByLabel === 'function' && this.shortcuts[shortcutId].subtype !== 'multi-choice') {
                         if (context.getAttributeIsSetByLabel(parentAttribute)) return false; // If attribute was set by label then we should not include the shortcut
                     }
 

--- a/src/shortcuts/Shortcuts.json
+++ b/src/shortcuts/Shortcuts.json
@@ -153,7 +153,7 @@
     "subtype": "multi-choice",
     "id": "ProgressionReasonsCreator",
     "parentAttribute": "reasons",
-    "label": "#reasons",
+    "label": "#reason",
     "stringTriggers": {"category":"progression", "valueSet":"reason", "prefix": "#"},
     "picker": {"category": "progression", "valueSet": "reason", "prefix": "#"},
     "keywords": {"category":"progression", "valueSet":"reason", "prefix": ""},


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

For ASCODCP-1936. Originally scoped as writing a completion component for multi-selection, but shifted towards allowing #reason to be inserted multiple times using the same completion component as single-choice shortcuts.

Can now enter #reason to select a value. Can enter as many #reason shortcuts and select as you want until you have selected all choices in the value set.

**NOTE**: While doing this task I uncovered something on `master`/fnorg where the value set options for #reasons are always in the suggestion portal regardless of if they are in the editor or not. Created ASCODCP-2104 as a result.

Potential thing to keep in mind for the future: With this approach, I think clinician customization of the expanded text will need to support adding multiple incomplete #reason labels since we need to support 0 .. many. 

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
