### PR TITLE
Allow re-selection of values via completion portal

### DIFF
--- a/src/notes/CompletionPortalPlugin.jsx
+++ b/src/notes/CompletionPortalPlugin.jsx
@@ -11,7 +11,7 @@ export default function CompletionPortalPlugin(opts) {
         // Step one: If we're at the beginning of a line, see if the previous node is a shortcut
         const previousNode = (state.selection.focusOffset === 0) ? state.document.getPreviousSibling(state.selection.focusKey) : null;
         const previousNodeShortcut = previousNode ? previousNode.data.get('shortcut') : null;
-        // IF we're right next to a shortcut, that shortcut has a completion component and is incomplete, then let's open that completionComponent
+        // IF we're right next to a shortcut, that shortcut has a completion component, then let's open that completionComponent
         if (previousNodeShortcut && previousNodeShortcut.completionComponent) {
             // But only if the portal isn't already open
             if (!opts.getCompletionComponent()) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -420,11 +420,10 @@ class FluxNotesEditor extends React.Component {
         let transform;
         transform = this.state.state.transform();
 
-        shortcut.clearValueSelectionOptions();
         shortcut.setText(selection.context);
         if (shortcut.isContext()) {
             shortcut.setValueObject(selection.object);
-            this.contextManager.addShortcutToContext(shortcut);
+            if (!Lang.includes(this.contextManager.contexts, shortcut)) this.contextManager.addShortcutToContext(shortcut);
             this.contextManager.contextUpdated();
         }
 

--- a/src/shortcuts/CreatorChild.jsx
+++ b/src/shortcuts/CreatorChild.jsx
@@ -112,13 +112,14 @@ export default class CreatorChild extends Shortcut {
     }
 
     setText(text, updatePatient = true) {
+        const previousText = this.text; // Store previous text to allow for reselection of multi-choice subtypess
         this.text = this._getTriggerWithoutPrefix(text);
         let value = this.text;
         if (this.metadata.picker === 'date-id') {
             value = moment(text, 'MM-DD-YYYY').format('D MMM YYYY');
         }
         if (!Lang.isUndefined(this.parentContext)) {
-            this.parentContext.setAttributeValue(this.metadata.parentAttribute, value, false, updatePatient);
+            this.parentContext.setAttributeValue(this.metadata.parentAttribute, value, false, updatePatient, previousText);
         }
     }
 

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -186,10 +186,10 @@ export default class EntryShortcut extends Shortcut {
         return this._getAttributeValue(this.object, name);
     }
 
-    setAttributeValue(name, value, publishChanges = true, updatePatient = true) {
+    setAttributeValue(name, value, publishChanges = true, updatePatient = true, currentChildText = '') {
         const voa = this.valueObjectAttributes[name];
         if (Lang.isUndefined(voa)) throw new Error("Unknown attribute '" + name + "' for structured phrase '" + this.getDisplayText() + "'"); //this.text
-        this.isSet[name] = (value != null);
+        this.isSet[name] = (value !== null);
         const patientSetMethod = voa["patientSetMethod"];
         const setMethod = voa["setMethod"];
         if (value === null && voa.default) {
@@ -203,7 +203,13 @@ export default class EntryShortcut extends Shortcut {
                 this.values[name] = value;
             } else {
                 if (voa["type"] === "list" && !Lang.isArray(value)) {
-                    let list = this.getAttributeValue(name);
+                    const list = this.getAttributeValue(name);
+
+                    // If we are changing an existing child's value instead of adding a new one
+                    // remove that child before adding the new value
+                    if (Lang.includes(list, currentChildText)) {
+                        list.splice(list.indexOf(currentChildText), 1);
+                    }
                     list.push(value);
                     Lang.set(this.object, setMethod, list);
                 } else {
@@ -212,7 +218,13 @@ export default class EntryShortcut extends Shortcut {
             }
         } else {
             if (voa["type"] === "list" && !Lang.isArray(value)) {
-                let list = this.getAttributeValue(name);
+                const list = this.getAttributeValue(name);
+
+                // If we are changing an existing child's value instead of adding a new one
+                // remove that child before adding the new value
+                if (Lang.includes(list, currentChildText)) {
+                    list.splice(list.indexOf(currentChildText), 1);
+                }
                 list.push(value);
                 PatientRecord[patientSetMethod](this.object, list);
             } else {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

For [Jira 2075](https://jira.mitre.org/browse/ASCODCP-2075). Allows re-selection of labels when the cursor is after a shortcut that has been selected via the completion portal.

One thing to note: created [Jira 2124](https://jira.mitre.org/browse/ASCODCP-2124) to cover some additional refactoring that @Dtphelan1 and I discussed, specifically related to creator children and how the set and unset parent attribute values.

## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
