### PR TITLE
Basic throttling of onScroll

### DIFF
--- a/src/lib/react-minimap/react-minimap.js
+++ b/src/lib/react-minimap/react-minimap.js
@@ -38,7 +38,7 @@ export class Minimap extends React.Component {
       this.init = this.init.bind(this);
       this.up = this.up.bind(this);
 
-      this.resize = _.throttle(this.synchronize, 100);
+      this.resize = _.throttle(this.synchronize, 200);
 
       this.state = {
           children: null,
@@ -333,7 +333,7 @@ export class Minimap extends React.Component {
       return (
           <div
               className={"minimap-container " + this.props.className}
-              onScroll={this.synchronize}
+              onScroll={this.resize}
               ref={(source) => {this.source = source;}}
           >
               <div className="minimap-children-wrapper">


### PR DESCRIPTION
Pretty straightforward change coming out of the IE investigation - increases the throttle on the minimap, and uses the throttled function as the onScroll handler. Results in remarkable performance improvements on IE, at the cost of the actual minimap grey-box looking a bit laggy. That's a tradeoff I'm comfortable with. 