### PR TITLE
Completion Portal only opens when cursor is collapsed

### DIFF
--- a/src/notes/CompletionPortalPlugin.jsx
+++ b/src/notes/CompletionPortalPlugin.jsx
@@ -1,9 +1,18 @@
 import CompletionComponentFactory from './CompletionComponentFactory';
 
 export default function CompletionPortalPlugin(opts) {
+    let collapsed = true;
 
     const onKeyDown = (...args) => {
         const completionComponent = opts.getCompletionComponent();
+        if (Array.of(...args)[1].isCmd || Array.of(...args)[1].isCtrl) { // ...args[1] is data
+            if (Array.of(...args)[1].key === 'a') {
+                collapsed = false;
+                return Array.of(...args)[2]; // return state
+            }
+        } else {
+            collapsed = true;
+        }
         if (completionComponent && completionComponent.onKeyDown) {
             return completionComponent.onKeyDown(...args);
         }
@@ -17,7 +26,7 @@ export default function CompletionPortalPlugin(opts) {
         if (previousNodeShortcut && previousNodeShortcut.completionComponentName) {
             // But only if the portal isn't already open
             const completionComponent = CompletionComponentFactory.createInstance(previousNodeShortcut.completionComponentName);
-            if (!opts.getCompletionComponent()) {
+            if (!opts.getCompletionComponent() && collapsed) {
                 opts.openPortal(previousNodeShortcut, completionComponent);
             }
         } else if (opts.getCompletionComponent()) {

--- a/src/notes/CompletionPortalPlugin.jsx
+++ b/src/notes/CompletionPortalPlugin.jsx
@@ -1,18 +1,9 @@
 import CompletionComponentFactory from './CompletionComponentFactory';
 
 export default function CompletionPortalPlugin(opts) {
-    let collapsed = true;
 
     const onKeyDown = (...args) => {
         const completionComponent = opts.getCompletionComponent();
-        if (Array.of(...args)[1].isCmd || Array.of(...args)[1].isCtrl) { // ...args[1] is data
-            if (Array.of(...args)[1].key === 'a') {
-                collapsed = false;
-                return Array.of(...args)[2]; // return state
-            }
-        } else {
-            collapsed = true;
-        }
         if (completionComponent && completionComponent.onKeyDown) {
             return completionComponent.onKeyDown(...args);
         }
@@ -26,7 +17,7 @@ export default function CompletionPortalPlugin(opts) {
         if (previousNodeShortcut && previousNodeShortcut.completionComponentName) {
             // But only if the portal isn't already open
             const completionComponent = CompletionComponentFactory.createInstance(previousNodeShortcut.completionComponentName);
-            if (!opts.getCompletionComponent() && collapsed) {
+            if (!opts.getCompletionComponent() && state.selection.isCollapsed) {
                 opts.openPortal(previousNodeShortcut, completionComponent);
             }
         } else if (opts.getCompletionComponent()) {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._

Added half of a single line to only open the portal if the mouse is collapsed.  For example, if you do @condition Gastrointestinal Stromal Tumor and then #diseaseStatus expand and then command + A, the calendar will no longer pop up.
## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
