### PR TITLE
Set default font-size - fixing IE font-size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,10 @@ body {
   color: #232323;
 }
 
+html {
+    font-size: 16px;
+}
+
 ::-webkit-scrollbar {
     width: 10px;
     height: 12px;


### PR DESCRIPTION
Fixes our default font-size to 16px, overriding the browser-specified defaults. This makes sure fonts look the same across browsers. Please test on IE and any other browsers you may have for cross-compatibility. 👍 