### PR TITLE
Fixed indexing of medications in MedicationsColumnsSections.jsx

### DIFF
--- a/src/summary/VisualizerManager.jsx
+++ b/src/summary/VisualizerManager.jsx
@@ -242,6 +242,7 @@ export default class VisualizerManager {
     }
 
     getVisualizer(dataType, visualizerType) {
+        // TODO: Use a `find` or `pluck` here to get the element by reference, instead of getting an array and chosing the first thing
         let result = this.visualizers.filter((viz) => {
             return (viz.dataType === dataType && viz.visualizerType === visualizerType);
         });

--- a/src/summary/metadata/MedicationsColumnsSection.jsx
+++ b/src/summary/metadata/MedicationsColumnsSection.jsx
@@ -7,7 +7,7 @@ export default class MedicationsColumnsSection extends MedicationsSection {
             shortName: "Meds",
             clinicalEvents: ["pre-encounter"],
             defaultVisualizer: "tabular",
-            type: "Columns",
+            type: "Medications",
             data: [
                 {
                     name: "",

--- a/src/summary/metadata/MedicationsColumnsSection.jsx
+++ b/src/summary/metadata/MedicationsColumnsSection.jsx
@@ -11,6 +11,11 @@ export default class MedicationsColumnsSection extends MedicationsSection {
             data: [
                 {
                     name: "",
+                    // NOTE: Nearly positive that this doesn't get used. When we use this section to retreieve a visualizer from VisualizerManager,
+                    //       a transformation function, transformMedicationsToColumns, gets called to translate section.data -- i.e. this object here -- into
+                    //       a format that the can be visualized and indexed properly. The VisualizerManager also specifies that the renderedFormat is Columns,
+                    //       which is also the format that gets used to index the data. Long way of saying that I don't see this heading information being
+                    //       used anywhere in the app, since the transformMedicationsToColumns function uses it's own headings.
                     headings: ["Medication", "Dosage", "Timing", "Start", "End"],
                     itemsFunction: this.getItemListForMedications,
                 }


### PR DESCRIPTION
Another painfully straightforward PR. Looks like the type that we were using in the MedicationsColumnsSection wasn't able to handle data formatted the way that medications are. On the one hand, it's troubling that the format of the data was so different that the application crashed. On the other hand, I don't think it's a priority to address that schematic difference right now.I'll create a JIRA to address that at a later point.

Testing can be performed by changing all of the Medications on Ella to reference her Fracture instead of her Cancer. The DefaultMetadata, used by all non-cancer conditions (like Fracture), calls on the MedicationsColumnsSection, which by default uses the tabular format for rendering the Medications Visualizer. In addition to confirming the functionality of this usecase (which would have been broken before), please test against other patients as capable! 