### PR TITLE
Note assistant icon fixed on IE

### DIFF
--- a/src/notes/NoteAssistant.scss
+++ b/src/notes/NoteAssistant.scss
@@ -38,7 +38,7 @@ $note-assistant-width-3: 160px;
             min-height: 20px !important;
             max-height: 41px !important;
             width: 50% !important;
-            display: inline-block !important;
+            display: inline !important;
             background-color: $background !important;
             box-shadow: none;
             border: 1px solid $line-gray;


### PR DESCRIPTION
I'm removing the full PR review for what is obvious once you look at the diff. Load up the app on IE/other browsers and check that the note assistant buttons look good. 