### PR TITLE
Fixed the functionality of switching between completion portals

### DIFF
--- a/src/notes/CompletionPortalPlugin.jsx
+++ b/src/notes/CompletionPortalPlugin.jsx
@@ -15,11 +15,11 @@ export default function CompletionPortalPlugin(opts) {
         const previousNodeShortcut = previousNode ? previousNode.data.get('shortcut') : null;
 
         // IF we're right next to a shortcut, that shortcut has a completion component, then let's open that completionComponent
-        if (previousNodeShortcut && previousNodeShortcut.completionComponentName && previousNodeShortcut !== opts.getCompletionComponentShortcut()) {
+        if (previousNodeShortcut && previousNodeShortcut.completionComponentName) {
             // But only if the portal isn't already open
             const completionComponent = CompletionComponentFactory.createInstance(previousNodeShortcut.completionComponentName);
 
-            if (state.selection.isCollapsed) {
+            if (previousNodeShortcut !== opts.getCompletionComponentShortcut() && state.selection.isCollapsed) {
                 opts.openPortal(previousNodeShortcut, completionComponent);
             }
         } else if (opts.getCompletionComponent()) {

--- a/src/notes/CompletionPortalPlugin.jsx
+++ b/src/notes/CompletionPortalPlugin.jsx
@@ -9,15 +9,17 @@ export default function CompletionPortalPlugin(opts) {
         }
     };
 
-    const onChange = (state, editor) => {
+    const onChange = (state) => {
         // Step one: If we're at the beginning of a line, see if the previous node is a shortcut
         const previousNode = (state.selection.focusOffset === 0) ? state.document.getPreviousSibling(state.selection.focusKey) : null;
         const previousNodeShortcut = previousNode ? previousNode.data.get('shortcut') : null;
-        // IF we're right next to a shortcut, that shortcut has a completion component and is incomplete, then let's open that completionComponent
-        if (previousNodeShortcut && previousNodeShortcut.completionComponentName) {
+
+        // IF we're right next to a shortcut, that shortcut has a completion component, then let's open that completionComponent
+        if (previousNodeShortcut && previousNodeShortcut.completionComponentName && previousNodeShortcut !== opts.getCompletionComponentShortcut()) {
             // But only if the portal isn't already open
             const completionComponent = CompletionComponentFactory.createInstance(previousNodeShortcut.completionComponentName);
-            if (!opts.getCompletionComponent() && state.selection.isCollapsed) {
+
+            if (state.selection.isCollapsed) {
                 opts.openPortal(previousNodeShortcut, completionComponent);
             }
         } else if (opts.getCompletionComponent()) {

--- a/src/notes/FluxNotesEditor.jsx
+++ b/src/notes/FluxNotesEditor.jsx
@@ -71,28 +71,38 @@ const initialEditorState = {
 
 class FluxNotesEditor extends React.Component {
     openCompletionPortal = (completionComponentShortcut, completionComponent) => {
-        // Always make sure we use an array here; doesn't always return an array from getValueSelectionOptions
-        const portalOptions = !Lang.isEmpty(completionComponentShortcut.getValueSelectionOptions()) ? completionComponentShortcut.getValueSelectionOptions() : [];
-        this.setState({
-            completionComponentShortcut: completionComponentShortcut,
-            portalOptions: portalOptions,
-            completionComponent: completionComponent,
-            openedPortal: "CompletionPortal",
-        });
+        // Timeout is needed to possibly allow another completion portal to close first
+        // This is probably not the best approach but the alternative solution was to implement complicated logic to determine if a portal should close
+        setTimeout(() => {
+            // Always make sure we use an array here; doesn't always return an array from getValueSelectionOptions
+            const portalOptions = !Lang.isEmpty(completionComponentShortcut.getValueSelectionOptions()) ? completionComponentShortcut.getValueSelectionOptions() : [];
+            this.setState({
+                completionComponentShortcut,
+                portalOptions,
+                completionComponent,
+                openedPortal: "CompletionPortal",
+            });
+        }, 0);
     }
 
     closeCompletionPortal = () => {
-        // Clean up some variables stored at the Editor level
-        this.setState({
-            completionComponentShortcut: null,
-            portalOptions: [],
-            completionComponent: null,
-            openedPortal: null,
-        });
+        if (this.state.completionComponentShortcut) {
+            // Clean up some variables stored at the Editor level
+            this.setState({
+                completionComponentShortcut: null,
+                portalOptions: [],
+                completionComponent: null,
+                openedPortal: null,
+            });
+        }
     }
 
     getCompletionComponent = () => {
         return this.refs.completionComponent;
+    }
+
+    getCompletionComponentShortcut = () => {
+        return this.state.completionComponentShortcut;
     }
 
     constructor(props) {
@@ -121,7 +131,8 @@ class FluxNotesEditor extends React.Component {
         const completionPortalPluginOptions = {
             openPortal: this.openCompletionPortal,
             closePortal: this.closeCompletionPortal,
-            getCompletionComponent: this.getCompletionComponent
+            getCompletionComponent: this.getCompletionComponent,
+            getCompletionComponentShortcut: this.getCompletionComponentShortcut
         };
         this.completionPortalPlugin = CompletionPortalPlugin(completionPortalPluginOptions);
         this.plugins.push(this.completionPortalPlugin);


### PR DESCRIPTION
Addresses JIRA-2227.

- Added a `setTimeout` in `openCompletionPortal` to possibly wait for another completion portal to close before opening.
   -  Although this may not be the best approach, with the way we have implemented the opening and closing of portals, we would have to add in some complicated logic to determine when to open and close portals so this approach may be better for our time and effort.

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
-  Manually tested in IE/Safari (verify app loads and basic feature testing)
-  Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
-  Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [x] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
-  Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
-  Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
-  Document any new APIs/extension points
-  Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
-  Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
