### PR TITLE
[CCP] Fixed bug where side effects config flag wouldn't affect side effects header

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -61,7 +61,7 @@ CONFIG = {
             // (aka, the server listed here can be used as a 'shim')
             // server: "http://localhost:3001/1_0_2"
         }
-    }, 
+    },
     {
         path: '/smart',
         display: 'Flux Notes™',

--- a/src/mcode-pilot/components/TreatmentOptionsOutcomesTable/TreatmentOptionsOutcomesHeaders.jsx
+++ b/src/mcode-pilot/components/TreatmentOptionsOutcomesTable/TreatmentOptionsOutcomesHeaders.jsx
@@ -33,6 +33,7 @@ export default class TreatmentOptionsOutcomesHeaders extends Component {
             changeSort,
             handleChangeEffect,
             selectedTreatment,
+            showSideEffects,
             sideEffects,
             sideEffectSelection,
             sortColumn,
@@ -43,13 +44,10 @@ export default class TreatmentOptionsOutcomesHeaders extends Component {
             <thead className="treatment-options-outcomes-table__header">
                 <tr>
                     <td colSpan="2" />
-                    <td colSpan={this.props.timescale.length} className="header-title">
-                        Overall survival rates
-                    </td>
-                    <td>
-                        Side Effects
-                    </td>
+                    <td colSpan={this.props.timescale.length} className="header-title">Overall survival rates</td>
+                    {showSideEffects && <td>Side Effects</td>}
                 </tr>
+
                 <tr>
                     <td className="compare-header">
                         {selectedTreatment ? 'comparing against' : 'compare'}
@@ -76,26 +74,28 @@ export default class TreatmentOptionsOutcomesHeaders extends Component {
                         );
                     })}
 
-                    <td id="ccp-table-select">
-                        <Select
-                            value={sideEffectSelection}
-                            onChange={handleChangeEffect}
-                            name="sideEffect"
-                            className="custom-select"
-                        >
-                            <MenuItem value="Most Common" className="side-effect-option">
-                                <em>Most Common</em>
-                            </MenuItem>
+                    {showSideEffects &&
+                        <td id="ccp-table-select">
+                            <Select
+                                value={sideEffectSelection}
+                                onChange={handleChangeEffect}
+                                name="sideEffect"
+                                className="custom-select"
+                            >
+                                <MenuItem value="Most Common" className="side-effect-option">
+                                    <em>Most Common</em>
+                                </MenuItem>
 
-                            {sideEffects.map(effect => {
-                                return (
-                                    <MenuItem value={effect} key={effect} className="side-effect-option">
-                                        {effect.toLowerCase()}
-                                    </MenuItem>
-                                );
-                            })}
-                        </Select>
-                    </td>
+                                {sideEffects.map(effect => {
+                                    return (
+                                        <MenuItem value={effect} key={effect} className="side-effect-option">
+                                            {effect.toLowerCase()}
+                                        </MenuItem>
+                                    );
+                                })}
+                            </Select>
+                        </td>
+                    }
                 </tr>
             </thead>
         );
@@ -105,6 +105,7 @@ export default class TreatmentOptionsOutcomesHeaders extends Component {
 TreatmentOptionsOutcomesHeaders.propTypes = {
     changeSort: PropTypes.func.isRequired,
     selectedTreatment: PropTypes.bool,
+    showSideEffects: PropTypes.bool.isRequired,
     sortColumn: PropTypes.string.isRequired,
     sortDirection: PropTypes.number.isRequired,
     timescale: PropTypes.array.isRequired

--- a/src/mcode-pilot/components/TreatmentOptionsOutcomesTable/TreatmentOptionsOutcomesTable.jsx
+++ b/src/mcode-pilot/components/TreatmentOptionsOutcomesTable/TreatmentOptionsOutcomesTable.jsx
@@ -133,7 +133,15 @@ export default class TreatmentOptionsOutcomesTable extends Component {
     }
 
     renderHeader = () => {
-        const { similarPatientTreatmentsData, changeSort, selectedTreatment, sortColumn, sortDirection, timescale } = this.props;
+        const {
+            changeSort,
+            selectedTreatment,
+            showSideEffects,
+            similarPatientTreatmentsData,
+            sortColumn,
+            sortDirection,
+            timescale
+        } = this.props;
         const { sideEffectSelection } = this.state;
         const sortName = sortDirection === 2 ? 'sort-up' : sortDirection === 1 ? 'sort-down' : 'sort';
         const sortP = sortColumn === 'totalPatients';
@@ -143,15 +151,16 @@ export default class TreatmentOptionsOutcomesTable extends Component {
         return (
             <TreatmentOptionsOutcomesHeaders
                 changeSort={changeSort}
+                handleChangeEffect={this.handleChangeEffect}
                 selectedTreatment={selectedTreatmentBool}
+                showSideEffects={showSideEffects}
+                sideEffects={sideEffects}
                 sideEffectSelection={sideEffectSelection}
+                sortColumn={sortColumn}
+                sortDirection={sortDirection}
                 sortName={sortName}
                 sortP={sortP}
-                sideEffects={sideEffects}
-                sortColumn={sortColumn}
                 timescale={timescale}
-                sortDirection={sortDirection}
-                handleChangeEffect={this.handleChangeEffect}
             />
         );
     }


### PR DESCRIPTION
This PR satisfies [JIRA 2234](https://jira.mitre.org/browse/ASCODCP-2234) and fixes a bug where the Compass side effects config flag wasn't affecting the table header for side effects. This bug was introduced during the CCP optimization updates which moved all the headers into a new component.

To test: change `showSideEffects` flag to false (`public/config.js > services > outcomes`)

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [ ] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [x] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [x] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
