### PR TITLE
Add "cursor: pointer" style to all non-editable shortcuts

### DIFF
--- a/src/notes/FluxNotesEditor.scss
+++ b/src/notes/FluxNotesEditor.scss
@@ -134,11 +134,23 @@
                         display: inline;
                         border-bottom: 1.5px dashed $missing-data-red;
                     }
+
+                    &, &-incomplete {
+                        &[contenteditable="false"]:hover {
+                            cursor: pointer;
+                        }
+                    }
                 }
                 &-creator {
                     border-bottom: 1px solid $shr-context-line;
                     &-incomplete {
                         border-bottom: 1.5px dashed $missing-data-red;
+                    }
+
+                    &, &-incomplete {
+                        &:hover {
+                            cursor: pointer;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Why not?