### PR TITLE
Upgrade fhir-mapper to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "downshift": "^1.31.16",
     "elasticlunr": "https://github.com/mgramigna/elasticlunr.js",
     "es6-shim": "0.35.3",
-    "fhir-mapper": "^2.0.1",
+    "fhir-mapper": "^3.0.0",
     "fhirclient": "^0.1.12",
     "flat": "^4.1.0",
     "flux_notes_treatment_options_rest_client": "^1.1.2",

--- a/public/config.js
+++ b/public/config.js
@@ -39,10 +39,7 @@ CONFIG = {
         dataSource: 'GenericSmartOnFhirDstu2DataSource',
         shortcuts: [],
         dataSourceProps: {
-            mapper: 'SyntheaToV09',
-            mapperVariables: {
-                primaryCancerConditionCodes: ['444814009'] // you know what it is
-            },
+            mapper: 'CernerSandboxMapper',
             resourceTypes: ['Patient', 'Condition', 'Encounter', 'MedicationOrder', 'Observation', 'Procedure']
         },
     },

--- a/public/config.js
+++ b/public/config.js
@@ -39,7 +39,10 @@ CONFIG = {
         dataSource: 'GenericSmartOnFhirDstu2DataSource',
         shortcuts: [],
         dataSourceProps: {
-            mapper: 'cernerSandbox',
+            mapper: 'SyntheaToV09',
+            mapperVariables: {
+                primaryCancerConditionCodes: ['444814009'] // you know what it is
+            },
             resourceTypes: ['Patient', 'Condition', 'Encounter', 'MedicationOrder', 'Observation', 'Procedure']
         },
     },
@@ -97,7 +100,7 @@ CONFIG = {
         dataSource: 'GenericSmartOnFhirDstu2DataSource',
         shortcuts: [],
         dataSourceProps: {
-            mapper: 'cernerSandbox'
+            mapper: 'CernerSandboxMapper'
         }
     },
     {

--- a/src/__test__/backend/dataaccess/McodeV09SmartOnFhirDataSource.test.js
+++ b/src/__test__/backend/dataaccess/McodeV09SmartOnFhirDataSource.test.js
@@ -114,7 +114,7 @@ describe('SMART on FHIR data source', function() {
           .get('/fhir/Patient?_id=1078857')
           .reply(200, patientSearchBundle);
 
-        const dataSource = new GenericSmartOnFhirDstu2DataSource({ mapper: "syntheaToV09" });
+        const dataSource = new GenericSmartOnFhirDstu2DataSource({ mapper: "SyntheaToV09" });
         dataSource.getPatient('1078857', (record, error) => {
             if (record) {
                 scope.done();

--- a/src/__test__/backend/dataaccess/McodeV09SmartOnFhirDataSource.test.js
+++ b/src/__test__/backend/dataaccess/McodeV09SmartOnFhirDataSource.test.js
@@ -99,7 +99,7 @@ describe('SMART on FHIR data source', function() {
         });
     });
 
-    it('should correctly map non-profiled FHIR resources to MCODE V05', function(done) {
+    it('should correctly map non-profiled FHIR resources to MCODE V09', function(done) {
         const patientSearchBundle = {
             resourceType: 'Bundle',
             type: 'searchset',

--- a/src/dataaccess/GenericSmartOnFhirDstu2DataSource.js
+++ b/src/dataaccess/GenericSmartOnFhirDstu2DataSource.js
@@ -5,10 +5,9 @@ import mappers from './mappers';
 class GenericSmartOnFhirDstu2DataSource extends McodeV09SmartOnFhirDataSource {
     constructor(props) {
         super(props);
-        if (props && typeof props.mapper === 'string') {
-            this.mapper = mappers[props.mapper];
-        } else {
-            this.mapper = props && props.mapper ? props.mapper: null;
+        if (props && props.mapper) {
+            const mapperClass = typeof props.mapper === 'string' ? mappers[props.mapper] : props.mapper;
+            this.mapper = new mapperClass(props.mapperVariables);
         }
     }
 

--- a/src/dataaccess/mappers/CernerSandboxMapper.js
+++ b/src/dataaccess/mappers/CernerSandboxMapper.js
@@ -1,8 +1,9 @@
 import {
-    buildMappers,
+    AggregateMapper,
     mappers,
     utils
 } from 'fhir-mapper';
+const SyntheaToV09 = mappers['SyntheaToV09'];
 
 const primaryCancerConditionCodes = [
     '254837009', // Malignant neoplasm of breast (disorder) (B)
@@ -57,6 +58,10 @@ const allRelevantProfiles = [
     'http://hl7.org/fhir/us/shr/StructureDefinition/onco-core-TumorMarkerTest'
 ];
 
+
+
+const defaultBaseMapper = new SyntheaToV09();
+
 const mapper = {
     filter: () => true,
     ignore: (resource) => {
@@ -67,7 +72,7 @@ const mapper = {
         // check if any of the profiles are mcode. returns null (falsy) if none found or the profile itself (truthy)
         return resource.meta.profile.find(p => allRelevantProfiles.includes(p));
     },
-    default: (resource, context) => mappers['syntheaToV09'].execute(resource, context),
+    default: (resource, context) => defaultBaseMapper.execute(resource, context),
     mappers: [
         {
             filter: "Condition.code.coding.where($this.code in %primaryCancerConditionCodes.first())",
@@ -108,6 +113,9 @@ const mapper = {
             }
         }],
 };
-export default buildMappers(mapper, {
-    primaryCancerConditionCodes
-});
+
+export default class Cerner extends AggregateMapper {
+    constructor(variables = {}) {
+        super(mapper, { primaryCancerConditionCodes, ...variables });
+    }
+};

--- a/src/dataaccess/mappers/CernerSandboxMapper.js
+++ b/src/dataaccess/mappers/CernerSandboxMapper.js
@@ -58,8 +58,6 @@ const allRelevantProfiles = [
     'http://hl7.org/fhir/us/shr/StructureDefinition/onco-core-TumorMarkerTest'
 ];
 
-
-
 const defaultBaseMapper = new SyntheaToV09();
 
 const mapper = {

--- a/src/dataaccess/mappers/CernerSandboxMapper.js
+++ b/src/dataaccess/mappers/CernerSandboxMapper.js
@@ -113,7 +113,7 @@ const mapper = {
 };
 
 export default class Cerner extends AggregateMapper {
-    constructor(variables = {}) {
-        super(mapper, { primaryCancerConditionCodes, ...variables });
+    constructor(mapperVariables = {}) {
+        super(mapper, { primaryCancerConditionCodes, ...mapperVariables });
     }
 };

--- a/src/dataaccess/mappers/index.js
+++ b/src/dataaccess/mappers/index.js
@@ -1,3 +1,3 @@
 import {mappers} from 'fhir-mapper';
-import cernerSandbox from './CernerSandboxMapper';
-export default {...mappers, cernerSandbox};
+import CernerSandboxMapper from './CernerSandboxMapper';
+export default {...mappers, CernerSandboxMapper};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,10 +4727,10 @@ fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fhir-mapper@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fhir-mapper/-/fhir-mapper-2.0.1.tgz#412d7888065ba4225187d369e6e4e6e4fd81f5a0"
-  integrity sha512-BPuK6OZT/EkbliucYHRLAfbpWOLesDvs5QHCvDZpQ/qYhSpCNi8euP8GnxlM8Zjwh+MdUFoDsTn10RzOY2Meww==
+fhir-mapper@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-mapper/-/fhir-mapper-3.0.0.tgz#c158576ca1ab9baf9b2c76d7fa2f115a21dfa007"
+  integrity sha512-TAHzOma359mG2/5os1Kg3dI72poQbL/GiJs1A0mW+GPozO3ejXAALqEa7xrhojGpBzDgsHhoIBE9Ehvzjl7Jww==
   dependencies:
     fhirpath "^0.10.3"
     lodash "^4.17.13"


### PR DESCRIPTION
This PR just bumps the `fhir-mapper` dependency to v3.0.0 along with supporting code changes.
The big difference between fhir-mapper 2 and 3 is that v3 exports classes which can be instantiated with custom parameters, whereas v2 exported pre-instantiated objects.

For an example of how the customization can be used, make the following change to `dataSourceProps` in the `/smartcompass` section of `config.js`

```diff
         dataSource: 'GenericSmartOnFhirDstu2DataSource',
         shortcuts: [],
         dataSourceProps: {
-            mapper: 'CernerSandboxMapper',
+            mapper: 'SyntheaToV09',
+            mapperVariables: {
+                primaryCancerConditionCodes: ['444814009'] // you know what it is
+            },
             resourceTypes: ['Patient', 'Condition', 'Encounter', 'MedicationOrder', 'Observation', 'Procedure']
         },
     },
```

Then load from the moonshot-dev launcher patient "Janet238 Waelchi213". With the change in place the actual cancer condition (Malignant neoplasm of breast) will no longer be mapped as a `onco.core.PrimaryCancerCondition` but instead the Viral sinusitis conditions will get mapped as a cancer condition. The difference should be easily apparent since the UI only renders the basic metadata for non-cancer conditions, but all sections for cancer conditions. 

_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:

**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [ ] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [ ] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- **n/a** Branch implements task as expected
- **n/a** Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- **n/a** Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [ ] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [ ] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [ ] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
