### PR TITLE
add safeguard for when the nlp shortcut is deleted in the editor but …

### DIFF
--- a/src/notes/NLPHashtagPlugin.jsx
+++ b/src/notes/NLPHashtagPlugin.jsx
@@ -61,21 +61,24 @@ function NLPHashtagPlugin(opts) {
 
     // Get a text representation of the sentence following the NLPHashtag
     function getSentenceContainingNLPHashtag(editorState, NLPShortcut) {
-        // Get the block immediately following the NLPShortcut
-        const nodeAfterNLPShortcut = editorState.document.getNextSibling(NLPShortcut.key);
-        // Relevant selection is from the end of the shortcut to the end of my selection
-        const relevantSelection = {
-            anchorKey: nodeAfterNLPShortcut.key,
-            anchorOffset: 0,
-            focusKey: editorState.endKey,
-            focusOffset: editorState.endOffset,
-            isFocused: false,
-            isBackward: false,
-        };
-        const relevantFragment = editorState.document.getFragmentAtRange(new Selection(relevantSelection));
-        // Need this list of nodes in a JSON representation.
-        const textRepresentationOfNodes = convertToTextForNLPEngine(relevantFragment.nodes.map(node => node.toJSON()));
-        return textRepresentationOfNodes;
+        if (editorState.document.getNode(NLPShortcut.key)) {
+            // Get the block immediately following the NLPShortcut
+            const nodeAfterNLPShortcut = editorState.document.getNextSibling(NLPShortcut.key);
+            // Relevant selection is from the end of the shortcut to the end of my selection
+            const relevantSelection = {
+                anchorKey: nodeAfterNLPShortcut.key,
+                anchorOffset: 0,
+                focusKey: editorState.endKey,
+                focusOffset: editorState.endOffset,
+                isFocused: false,
+                isBackward: false,
+            };
+            const relevantFragment = editorState.document.getFragmentAtRange(new Selection(relevantSelection));
+            // Need this list of nodes in a JSON representation.
+            const textRepresentationOfNodes = convertToTextForNLPEngine(relevantFragment.nodes.map(node => node.toJSON()));
+            return textRepresentationOfNodes;
+        }
+        return '';
     }
 
     // Given a list of Slate nodes, convert them to text

--- a/src/shortcuts/NLPHashtag.jsx
+++ b/src/shortcuts/NLPHashtag.jsx
@@ -229,7 +229,7 @@ export default class NLPHashtag extends Shortcut {
     }
 
     getDisplayText() {
-        return this.initiatingTrigger;
+        return this.initiatingTrigger.replace('#', '');
     }
 
     serialize() {


### PR DESCRIPTION
_Pull requests into Flux require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable (**N/A**) and :white_check_mark:. Reviewers should complete every item on the bulleted list when reviewing._


## Submitter:
Covers [JIRA 2255](https://jira.mitre.org/browse/ASCODCP-2255). The issue stems from the initialization of `StructuredFieldPlugin`  was moved to the end of the constructor of `FluxNotesEditor.jsx`, now behind `NLPHashtagPlugin`.  This causes the nlp hashtag to be deleted in the editor before it is removed from contexts, thus causing the bug.  Add safeguard for when the nlp shortcut is deleted in the editor but not yet removed from contexts.


**Running the Application**

- [x] Manually tested in Chrome (primary browser for testing)
- [x] Manually tested in IE/Safari (verify app loads and basic feature testing)
- [x] Manually tested in Chrome in iPad mode (at minimum, viewing patient record)

**Task**

- [x] Branch implements task as expected
- [ ] Key application features are updated as needed for task and tested (see: [Key Application Features](https://github.com/FluxNotes/flux/wiki/Key-Application-Features))
- [ ] Task specific definition of done (as described in the Jira task) is met, if applicable.

**Documentation**

- [x] This pull request describes why these changes were made
- [x] Recognizes any potential shortcomings/bugs in the description 
- [ ] Pre release script is updated on the [Pre Release Testing Script wiki page](https://github.com/FluxNotes/flux/wiki/Pre-Release-Testing-Script) (add/remove single features to test, do not run through full script)
- [ ] Update the list of key features with new features on the [Key Application Features wiki page](https://github.com/FluxNotes/flux/wiki/Key-Application-Features)
- [ ] Document any new APIs/extension points
- [ ] Additional technical components and libraries are documented and added to [wiki](https://github.com/FluxNotes/flux/wiki/About-Flux-Notes) as needed

**Code Quality**

- [ ] Code style guide is followed (see: [Code Style Guide](https://github.com/FluxNotes/flux/wiki/JavaScript-and-HTML-Code-Style-Guide))
- [ ] Code is commented

**Tests**

- [x] Existing tests passed
- [ ] Added backend tests for new functionality added


## Reviewers:

- Check that code is maintainable and reusable. Code reuses existing code and infrastructure where appropriate.
- Check the PR and code accomplishes the task's purpose.
- Check that new tests appropriately test the new code, including edge cases. Other existing tests pass.
- Verify Pull Request checklist is correctly completed by submitter.
- Try to break the code
