### PR TITLE
Exploration of replacing placeholders with incomplete shortcuts

### DIFF
--- a/src/context/ContextManager.jsx
+++ b/src/context/ContextManager.jsx
@@ -209,6 +209,11 @@ class ContextManager {
         }
     }
 
+    // getPlaceholders returns all contexts that can be filled out by the POC panel
+    getPlaceholders() {
+        return this.contexts.filter(c => (!c.isComplete && !Lang.isUndefined(c.metadata.formSpec)) || c.attributesSetByPoc);
+    }
+
     clearContexts() {
         this.contexts = [];
         this.activeContexts = [];

--- a/src/context/ShortcutViewModeContent.jsx
+++ b/src/context/ShortcutViewModeContent.jsx
@@ -72,7 +72,7 @@ export default class ShortcutViewModeContent extends Component {
         } else {
             // const activeContextIndex = this.state.currentContextIndex;
             // const activeContext = activeContexts[activeContextIndex];
-            const listOfContextOptions = activeContexts.map((context, i) => {
+            const listOfContextOptions = activeContexts.filter(c => !c.attributesSetByPoc).map((context, i) => {
                 // Since contexts move down in the list as more get added, we need an invariant to describe the items location in the list
                 // Contexts come in stack order, so newest contexts are on the top, oldest on the bottom
                 // The first context we entered will always be the last one in the list, so we want the unique i.d. for the last item to be 0;
@@ -130,7 +130,7 @@ export default class ShortcutViewModeContent extends Component {
     }
 }
 
-ShortcutViewModeContent.propTypes= {
+ShortcutViewModeContent.propTypes = {
     contextManager: PropTypes.object.isRequired,
     onClick: PropTypes.func.isRequired,
     shortcutManager: PropTypes.object.isRequired,

--- a/src/notes/FillPlaceholder.jsx
+++ b/src/notes/FillPlaceholder.jsx
@@ -106,6 +106,7 @@ export default class FillPlaceholder extends Component {
 
     onSetValue = (source, attributeSpec, entryIndex, newValue) => {
         const { placeholder } = this.props;
+        placeholder.attributesSetByPoc = true;
         //if (entryIndex === -1) entryIndex = placeholder.entryShortcuts.length - 1;
         const attributes = placeholder.getAttributeValue(attributeSpec.name, entryIndex);
         let error;
@@ -362,7 +363,7 @@ export default class FillPlaceholder extends Component {
                     <Checkbox style={{ width: 26, height: 26 }} checked={done} value="done" onChange={this.onDone} color="primary" />
                 </span> */}
                 <span className="shortcut-name" key="0">
-                    {placeholder.shortcutDisplayText}
+                    {placeholder.getDisplayText()}
                 </span>
             </Grid>
         );

--- a/src/notes/StructuredFieldPlugin.jsx
+++ b/src/notes/StructuredFieldPlugin.jsx
@@ -256,6 +256,8 @@ function StructuredFieldPlugin(opts) {
                     return <span contentEditable={shortcut.metadata.isEditable && shortcut.isComplete ? '' : false} className={sfClass} {...props.attributes}>{props.children}</span>;
                 } else {
                     const sfClass = `structured-field-creator${shortcut.isComplete ? "" : "-incomplete"}`;
+
+                    if (shortcut.attributesSetByPoc) return <span contentEditable={false} className={sfClass} {...props.attributes}>{shortcut.getAsString().replace(/#/g, '')}</span>;
                     return <span contentEditable={false} className={sfClass} {...props.attributes}>{props.children}{safariSpacing}</span>;
                 }
             },

--- a/src/panels/NotesPanel.jsx
+++ b/src/panels/NotesPanel.jsx
@@ -269,7 +269,7 @@ export default class NotesPanel extends Component {
                             </Row>
                             <Row start="xs" style={{ marginLeft: '2px', marginRight: '10px' }}>
                                 <PointOfCare
-                                    placeholders={this.props.structuredFieldMapManager.placeholders}
+                                    placeholders={this.props.contextManager.getPlaceholders()}
                                     isAppBlurred={this.props.isAppBlurred}
                                     ref={(poc) => { this.pointOfCare = poc; }} />
                             </Row>

--- a/src/shortcuts/CreatorBase.jsx
+++ b/src/shortcuts/CreatorBase.jsx
@@ -21,6 +21,7 @@ export default class CreatorBase extends EntryShortcut {
     }
 
     get isComplete() {
+        if (this._attributesSetByPoc) return this.hasParentContext() && this.hasData();
         return this.hasParentContext() && this.hasChildren();
     }
 

--- a/src/shortcuts/EntryShortcut.jsx
+++ b/src/shortcuts/EntryShortcut.jsx
@@ -23,6 +23,8 @@ export default class EntryShortcut extends Shortcut {
             if (!this.object) {
                 this.object = FluxObjectFactory.createInstance({}, metadata["valueObject"], patient);
             }
+
+            if (dataObj.attributesSetByPoc) this._attributesSetByPoc = true;
         }
         this.setValueObject(this.object);
     }
@@ -249,7 +251,11 @@ export default class EntryShortcut extends Shortcut {
 
     serialize() {
         if (Lang.isUndefined(this.object.entryInfo)) return this.initiatingTrigger;
-        return `${this.initiatingTrigger}[[{"entryId":${this.getEntryId()}}]]`;
+        const obj = {
+            entryId: this.getEntryId()
+        };
+        if (this._attributesSetByPoc) obj.attributesSetByPoc = this._attributesSetByPoc;
+        return `${this.initiatingTrigger}[[${JSON.stringify(obj)}]]`;
     }
 
     getText() {
@@ -345,6 +351,18 @@ export default class EntryShortcut extends Shortcut {
             },
             children: []
         };
+    }
+
+    get attributes() {
+        return this.metadata.formSpec.attributes;
+    }
+
+    set attributesSetByPoc(val) {
+        this._attributesSetByPoc = val;
+    }
+
+    get attributesSetByPoc() {
+        return this._attributesSetByPoc;
     }
 
     onBeforeDeleted() {

--- a/src/shortcuts/ShortcutManager.js
+++ b/src/shortcuts/ShortcutManager.js
@@ -313,7 +313,7 @@ class ShortcutManager {
         let contextValueObjectEntryTypes;
         let result = this.childShortcuts[currentContextId], parentAttribute;
         let value, parentVOAs, voa, isSettable, isSet, parentIdVOAs;
-        if (_.isUndefined(result)) return [];
+        if (_.isUndefined(result) || context.attributesSetByPoc) return [];
 
         result = result.filter((shortcutId) => {
 


### PR DESCRIPTION
This PR is made to document an approach I tried to replace our current version of placeholders with incomplete shortcuts and to save off the branch if we decide to use this approach in the future.

I started off by passing the incomplete shortcuts in the editor to the POC panel so that the user can select values for the shortcuts.  The problem I ran into immediately was that no child shortcuts were being inserted into the editor but the value object(e.g. `CancerDiseaseStatus`) was being updated from the selections in the POC panel.  After talking with Dylan, we decided to update the text of the shortcut after selections are made from the POC, similar to how our current placeholders look.
Result after selections:
![image](https://user-images.githubusercontent.com/6588796/66974203-65669f00-f068-11e9-9eb8-3524a195f41b.png)

Shortcomings:
If we decided to insert a child shortcut in the editor instead of selecting it from POC panel, the child shortcut would get inserted into the editor but the text of the shortcut would also update which would cause duplicate information being displayed in the editor.
Result after inserting #imaging:
![image](https://user-images.githubusercontent.com/6588796/66974384-e4f46e00-f068-11e9-921f-9387bbf67071.png)

Because these issues caused inconsistency with how shortcuts are displayed and problems that are not easily solvable, we decided to keep placeholders as is for now.  Before this exploration we thought that placeholders could easily be replaced by incomplete shortcuts but when actually trying to implement this change, there were a lot of issues and edge cases that we did not think would arise.

Approaches to try in the future:

- After making selections from POC, insert the child shortcuts into the editor.  This approach is not easily implemented since the POC and editor do not currently interact with each other.  Some difficulties that may also arise is figuring out whether a selection in the panel needs to update a current shortcut in the editor or inserting a new one.
-  The user needs to expand a shortcut before the user can switch over to the POC panel and fill out the incomplete child shortcuts.  Problem with this is that we require the user to expand a shortcut beforehand which may not be ideal.  We could also make shortcuts automatically expand if the user switches to the POC panel, but like the problem we encountered before the POC and editor do not currently interact with each other.





