### PR TITLE
Made default launch a genericDSTU2 launcher pointing to SmartPilot2MVP App

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -65,6 +65,37 @@ CONFIG = {
     {
         path: '/smart',
         display: 'Flux Notes™',
+        app: "SmartPilot2MvpApp",
+        isExact: true,
+        dataSource: 'GenericSmartOnFhirDstu2DataSource',
+        shortcuts: [],
+        dataSourceProps: {
+            mapper: 'CernerSandboxMapper',
+            resourceTypes: ['Patient', 'Condition', 'Encounter', 'MedicationOrder', 'Observation', 'Procedure']
+        },
+    },
+    {
+        path: '/launchmcode',
+        display: 'Flux',
+        app: "LaunchPage",
+        isExact: true,
+        launchContext: {
+            client: {
+                client_id: '6c12dff4-24e7-4475-a742-b08972c4ea27',
+                scope: 'patient/*.read user/*.* openid profile',
+                // note: the redirect_uri below may need to change in different environments.
+                // a relative URL (ex. /smart or ../smart) won't work in IE
+                redirect_uri: 'http://localhost:3000/smartmcode'
+            },
+            // uncomment the 'server' field below
+            // to override the iss parameter from the SMART launch process
+            // (aka, the server listed here can be used as a 'shim')
+            // server: "http://localhost:3001/1_0_2"
+        }
+    },
+    {
+        path: '/smartmcode',
+        display: 'Flux Notes™',
         app: "SmartFullApp",
         isExact: true,
         dataSource: 'McodeV09SmartOnFhirDataSource',
@@ -289,7 +320,7 @@ CONFIG = {
     {
         path: '/mvp',
         display: 'Flux Notes™',
-        app: "Pilot2MvpApp",
+        app: "SmartPilot2MvpApp",
         isExact: true,
         dataSource: 'HardCodedMcodeV09DataSource',
         patientId: '788dcbc3-ed18-470c-89ef-35ff91854c7f',

--- a/src/apps/AppManager.jsx
+++ b/src/apps/AppManager.jsx
@@ -5,6 +5,7 @@ import SmartFullApp from '../containers/SmartFullApp';
 import SlimApp from '../containers/SlimApp';
 import PointOfCareApp from '../containers/PointOfCareApp';
 import Pilot2MvpApp from '../containers/Pilot2MvpApp';
+import SmartPilot2MvpApp from '../containers/SmartPilot2MvpApp';
 import LandingPage from '../components/LandingPage';
 import LaunchPage from '../components/LaunchPage';
 import {ConfigManagerInstance} from '../config/ConfigManager';
@@ -19,6 +20,7 @@ const APPS = {
     'SmartCompassApp': SmartCompassApp,
     'PointOfCareApp': PointOfCareApp,
     'Pilot2MvpApp': Pilot2MvpApp,
+    'SmartPilot2MvpApp': SmartPilot2MvpApp,
 };
 
 export default class AppManager {

--- a/src/containers/SmartPilot2MvpApp.jsx
+++ b/src/containers/SmartPilot2MvpApp.jsx
@@ -1,0 +1,5 @@
+import { Pilot2MvpApp } from "./Pilot2MvpApp";
+import WithSmartData from './WithSmartData';
+
+const SmartPilot2MvpApp = WithSmartData(Pilot2MvpApp);
+export default SmartPilot2MvpApp;

--- a/src/containers/WithSmartData.jsx
+++ b/src/containers/WithSmartData.jsx
@@ -7,9 +7,6 @@ import 'fhirclient';
     App container to display theoretical SMART patient.
     Upon successful authorization of EHR user, app will handle reading of patient and loads it.
     If user authorization fails or if selected patient is not in the usermap, app will load a fail screen.
-
-    NOTE: the redirect_url property used in the launchContext for the /launch endpoint
-          will need to be changed in different environments
 */
 export default function WithSmartData(WrappedAppComponent) {
     return class extends WrappedAppComponent {


### PR DESCRIPTION
Created a new SmartApp called SmartPilot2MVP; moved the old /launch config to /launchmcode; made a new /launch config that successfully used the GenericDSTU2 DataSource to launch the new SmartApp; and it was all pretty seamless. To test, go to moonshot-dev:4001 and load up the  `localhost:3000/launch` page. This should successfully bring you to the SmartPilot2MVP page.  

They said it couldn't be done, that we couldn't create a PR again. And we're here to prove them all wrong. Feels good.
